### PR TITLE
Fix search input height

### DIFF
--- a/packages/esm-patient-list-app/src/patientListList/index.tsx
+++ b/packages/esm-patient-list-app/src/patientListList/index.tsx
@@ -125,6 +125,7 @@ const PatientListList: React.FC = () => {
         <Search
           style={{ backgroundColor: 'white', borderBottomColor: '#e0e0e0' }}
           labelText="search me"
+          size="xl"
           onFocus={() => {
             if (viewState.type === StateTypes.IDLE) {
               setViewState({ type: StateTypes.SEARCH, searchTerm: '' });

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.component.tsx
@@ -69,6 +69,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
         ref={searchBox}
         className={styles.autocompleteSearch}
         light
+        size="xl"
       />
       {suggestions.length > 0 && (
         <ul className={styles.suggestions}>

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -31,7 +31,7 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
       <HeaderGlobalAction
         onClick={togglePatientSearch}
         aria-label="Search Patient"
-        aria-labelledby="Searcch Patient"
+        aria-labelledby="Search Patient"
         name="SearchPatientIcon"
         className={styles.headerGlobalAction}>
         <Search20 />

--- a/packages/esm-patient-search-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search/patient-search.component.tsx
@@ -89,6 +89,7 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ hidePanel }) => {
         labelText=""
         ref={searchInput}
         autoFocus={true}
+        size="xl"
       />
 
       {!isEmpty(searchResults) && (


### PR DESCRIPTION
### Description

Provide carbon `Search` component with the prop size. By default, it should assume `size='xl'` seems like by default it assumes the smallest size as shown [here](https://www.carbondesignsystem.com/components/search/code) am setting it explicitly to `xl`

### Screenshoot

before 

<img width="1678" alt="Screenshot 2021-06-17 at 16 01 24" src="https://user-images.githubusercontent.com/28008754/122401604-6cecf280-cf85-11eb-8e22-c3bb517270b0.png">

after 

<img width="1371" alt="Screenshot 2021-06-17 at 16 00 29" src="https://user-images.githubusercontent.com/28008754/122401712-81c98600-cf85-11eb-8dd9-bd87d6dea4ee.png">

