### PR TITLE
Fix: Store local patient lists information on a per-user basis

### DIFF
--- a/packages/esm-patient-list-app/src/AddPatientToList/index.tsx
+++ b/packages/esm-patient-list-app/src/AddPatientToList/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { usePatientListData } from '../patientListData';
 import { useTranslation } from 'react-i18next';
 import { addPatientToList, getPatientListsForPatient } from '../patientListData/api';
-import { toOmrsIsoString } from '@openmrs/esm-framework';
+import { toOmrsIsoString, useSessionUser } from '@openmrs/esm-framework';
 import Search from 'carbon-components-react/lib/components/Search';
 import Button from 'carbon-components-react/lib/components/Button';
 import Checkbox from 'carbon-components-react/lib/components/Checkbox';
@@ -17,7 +17,8 @@ interface AddPatientProps {
 const AddPatient: React.FC<AddPatientProps> = ({ close, patientUuid }) => {
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState('');
-  const { loading, data } = usePatientListData();
+  const userId = useSessionUser()?.user.uuid;
+  const { loading, data } = usePatientListData(userId);
   const [selectedLists, setSelectedList] = useState({});
 
   useEffect(() => {

--- a/packages/esm-patient-list-app/src/patientListData/hooks.ts
+++ b/packages/esm-patient-list-app/src/patientListData/hooks.ts
@@ -20,14 +20,14 @@ const loadedData = {
 /**
  * Hook for fetching all available patient lists with optionally provided filters and loading state information.
  */
-export function usePatientListData(filter?: PatientListFilter) {
+export function usePatientListData(userId: string, filter?: PatientListFilter) {
   const [data, setData] = useState<FetchState<Array<PatientList>>>(initialData);
 
   useEffect(() => {
     const ac = new AbortController();
     setData(initialData);
 
-    getLocalAndOnlinePatientLists(filter)
+    getLocalAndOnlinePatientLists(userId, filter)
       .then((patientLists) =>
         setData({
           ...(loadedData as any),
@@ -36,17 +36,18 @@ export function usePatientListData(filter?: PatientListFilter) {
       )
       .catch((error) => error?.name !== 'AbortError' && setData({ ...loadedData, error }));
     return () => ac.abort();
-  }, [filter]);
+  }, [userId, filter]);
 
   return data;
 }
 
 /** Fetches and merges patient lists from the device and backend into a single patient list array. */
 async function getLocalAndOnlinePatientLists(
+  userId: string,
   filter?: PatientListFilter,
   ac = new AbortController(),
 ): Promise<Array<PatientList>> {
-  const localPromise = getAllDeviceLocalPatientLists(filter);
+  const localPromise = getAllDeviceLocalPatientLists(userId, filter);
   const onlinePromise = getAllPatientLists(filter, ac).then((cohorts) => cohorts.map(mapCohortToPatientList));
   return Promise.all([localPromise, onlinePromise]).then((lists) => [].concat.apply([], lists));
 }

--- a/packages/esm-patient-list-app/src/patientListList/PatientListResults.tsx
+++ b/packages/esm-patient-list-app/src/patientListList/PatientListResults.tsx
@@ -1,3 +1,4 @@
+import { useSessionUser } from '@openmrs/esm-framework';
 import React, { CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePatientListData } from '../patientListData';
@@ -20,7 +21,8 @@ const PatientListResults: React.FC<PatientListResultsProps> = ({
 }) => {
   const { t } = useTranslation();
   const [filter, setFilter] = React.useState<string>();
-  const { data, loading } = usePatientListData({ name: filter });
+  const userId = useSessionUser()?.user.uuid;
+  const { data, loading } = usePatientListData(userId, { name: filter });
 
   React.useEffect(() => {
     setFilter(nameFilter);

--- a/packages/esm-patient-list-app/src/patientListList/index.tsx
+++ b/packages/esm-patient-list-app/src/patientListList/index.tsx
@@ -9,7 +9,7 @@ import CreateNewList from './CreateNewList';
 import PatientListMembersOverlay from '../PatientList';
 import SearchOverlay from './SearchOverlay';
 import { useTranslation } from 'react-i18next';
-import { ExtensionSlot, isOfflineUuid } from '@openmrs/esm-framework';
+import { ExtensionSlot, isOfflineUuid, useSessionUser } from '@openmrs/esm-framework';
 import { updateDeviceLocalPatientList, usePatientListData } from '../patientListData';
 import { PatientList, PatientListFilter, PatientListType } from '../patientListData/types';
 import { SearchState, StateTypes, ViewState } from './types';
@@ -85,20 +85,24 @@ const PatientListList: React.FC = () => {
   const [viewState, setViewState] = React.useState<ViewState>({ type: StateTypes.IDLE });
   const searchRef = React.useRef<Search & { input: HTMLInputElement }>();
   const patientListFilter = usePatientListFilterForCurrentTab(selectedTab);
-  const { data: patientListData, loading, error } = usePatientListData(patientListFilter);
+  const userId = useSessionUser()?.user.uuid;
+  const { data: patientListData, loading, error } = usePatientListData(userId, patientListFilter);
 
   const customHeaders = React.useMemo(
     () => (selectedTab === TabTypes.SYSTEM || selectedTab === TabTypes.USER ? headersWithoutType : undefined),
     [selectedTab === TabTypes.SYSTEM || selectedTab === TabTypes.USER],
   );
 
-  const setListStarred = React.useCallback((patientListId: string, isStarred: boolean) => {
-    if (isOfflineUuid(patientListId)) {
-      updateDeviceLocalPatientList(patientListId, { isStarred });
-    } else {
-      //updatePatientListDetails(listUuid, { isStarred: star }).then(() => setChanged((c) => !c));
-    }
-  }, []);
+  const setListStarred = React.useCallback(
+    (patientListId: string, isStarred: boolean) => {
+      if (isOfflineUuid(patientListId)) {
+        updateDeviceLocalPatientList(userId, patientListId, { isStarred });
+      } else {
+        //updatePatientListDetails(listUuid, { isStarred: star }).then(() => setChanged((c) => !c));
+      }
+    },
+    [userId],
+  );
 
   if (error) {
     //TODO show toast with error


### PR DESCRIPTION
A leftover from the last PR: The local patient list metadata (e.g. starred lists) should be considered on a per-user basis on the current device. The last PR only stored the info globally.

This one adds a `userId` to the stored data.