### PR TITLE
MF-687: Extend desktop search overlay to cover left navigation

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.scss
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.scss
@@ -1,21 +1,50 @@
-.patientLaunchContainer {
-    display: flex;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    min-height: 3rem;
-    z-index: 1000000;
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vendor/@carbon/layout/scss/generated/spacing";
+$inverse-02:#393939;
+
+.patientSearchIconWrapper {
+  display: flex;
+  width: 50vw;
+  justify-content: flex-end;
+  align-items: center;
 }
 
-:global(.omrs-breakpoint-gt-tablet) .patientLaunchContainer {
-    position: absolute;
-    width: 50vw;
-    right: 0;
-    height: 2.75rem;
-    left: unset;
+.patientSearchInput input:focus {
+  outline: none;
 }
 
-.headerGlobalAction {
-    background-color: transparent;
+// desktop mode styling
+:global(.omrs-breakpoint-gt-tablet) .searchArea {
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+  align-items: center;
+  width: 50vw;
+  border: $spacing-01 solid var(--omrs-color-brand-orange);
+  height: calc($spacing-08 - 0.25rem);
+  margin-right: $spacing-01;
+}
+
+// tablet mode styling
+:global(.omrs-breakpoint-lt-desktop) .searchArea {
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+  align-items: center;
+  width: 100vw;
+  border: $spacing-01 solid var(--omrs-color-brand-orange);
+  margin-right: $spacing-01;
+  position: fixed;
+  top: $spacing-09;
+  right: 0;
+  left: 0;
+}
+
+
+.closeButton {
+  background-color: $brand-02;
+}
+
+.searchButton {
+  background-color: $inverse-02;
 }

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -1,47 +1,163 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState, useEffect, useReducer, useMemo } from 'react';
 import Search20 from '@carbon/icons-react/es/search/20';
+import Close20 from '@carbon/icons-react/es/close/20';
 import { HeaderGlobalAction } from 'carbon-components-react/es/components/UIShell';
 import styles from './patient-search-icon.component.scss';
 import PatientSearch from '../patient-search/patient-search.component';
+import Search from 'carbon-components-react/es/components/Search';
+import { useTranslation } from 'react-i18next';
+import { Button } from 'carbon-components-react';
+import debounce from 'lodash-es/debounce';
+import { useLayoutType } from '@openmrs/esm-framework';
+import { performPatientSearch } from '../patient-search/patient-search.resource';
+import isEmpty from 'lodash-es/isEmpty';
+import { SearchedPatient } from '../types';
 
 interface PatientSearchLaunchProps {}
 
-const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
-  const [open, setOpen] = useState<boolean>(false);
+enum ActionTypes {
+  searching = 'searching',
+  resolved = 'resolved',
+  error = 'error',
+  idle = 'idle',
+}
+interface Searching {
+  type: ActionTypes.searching;
+  payload: Array<SearchedPatient>;
+}
 
-  const togglePatientSearch = useCallback(() => {
-    setOpen((prevState) => !prevState);
+interface Error {
+  type: ActionTypes.error;
+  payload: Error;
+}
+interface Resolved {
+  type: ActionTypes.resolved;
+  payload: Array<SearchedPatient>;
+}
+
+interface Idle {
+  type: ActionTypes.idle;
+  payload: Array<SearchedPatient>;
+}
+
+type Action = Searching | Error | Resolved | Idle;
+
+interface PatientSearch {
+  status: 'searching' | 'resolved' | 'error' | 'idle';
+  searchResults: Array<SearchedPatient>;
+}
+
+function reducer(state: PatientSearch, action: Action): PatientSearch {
+  switch (action.type) {
+    case ActionTypes.resolved:
+      return { status: 'resolved', searchResults: action.payload };
+    case ActionTypes.searching:
+      return { status: 'searching', searchResults: action.payload };
+    case ActionTypes.error:
+      return { ...state, status: 'error' };
+    case ActionTypes.idle:
+      return { status: 'idle', searchResults: action.payload };
+  }
+}
+
+const searchTimeout = 300;
+const customRepresentation =
+  'custom:(patientId,uuid,identifiers,display,' +
+  'patientIdentifier:(uuid,identifier),' +
+  'person:(gender,age,birthdate,birthdateEstimated,personName,display),' +
+  'attributes:(value,attributeType:(name)))';
+
+const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
+  const { t } = useTranslation();
+  const layout = useLayoutType();
+  const [open, setOpen] = useState<boolean>(false);
+  const [searchTerm, setSearchTerm] = useState<string>();
+  const initialState: PatientSearch = { status: 'idle', searchResults: [] };
+  const [{ searchResults, status }, dispatch] = useReducer(reducer, initialState);
+
+  const performSearch = () => {
+    const ac = new AbortController();
+    if (searchTerm) {
+      dispatch({ type: ActionTypes.searching, payload: [] });
+      performPatientSearch(searchTerm, customRepresentation).then(
+        ({ data }) => {
+          const results: Array<SearchedPatient> = data.results.map((res, i) => ({
+            ...res,
+            index: i + 1,
+          }));
+          dispatch({ type: ActionTypes.resolved, payload: results });
+        },
+        (error) => {
+          dispatch({ type: ActionTypes.error, payload: error });
+        },
+      );
+    }
+    return () => ac.abort();
+  };
+
+  const handleEnterKeyPressed = (event: KeyboardEvent) => event.key.toLowerCase() === 'enter' && performSearch();
+
+  const withButtonSize = useCallback(() => {
+    if (layout === 'desktop') {
+      return { size: 'small' };
+    }
+  }, [layout]);
+
+  const handleChange = useMemo(() => debounce((searchTerm) => setSearchTerm(searchTerm), searchTimeout), []);
+
+  const handleCloseSearchPanel = useCallback(() => {
+    setOpen(false);
   }, []);
 
-  const patientSearchRef = React.useRef(null);
-  const current = patientSearchRef?.current;
+  useEffect(() => {
+    if (!open) {
+      setSearchTerm('');
+    }
+  }, [open]);
 
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (current && !current.contains(event.target)) {
-        setOpen(false);
-      }
-    };
-    window.addEventListener('click', handleClickOutside);
-    return () => window.removeEventListener('click', handleClickOutside);
-  }, [current]);
+    if (isEmpty(searchTerm)) {
+      dispatch({ type: ActionTypes.idle, payload: [] });
+    }
+  }, [searchTerm]);
 
   return (
-    <div ref={patientSearchRef}>
-      <HeaderGlobalAction
-        onClick={togglePatientSearch}
-        aria-label="Search Patient"
-        aria-labelledby="Search Patient"
-        name="SearchPatientIcon"
-        className={styles.headerGlobalAction}>
-        <Search20 />
-      </HeaderGlobalAction>
-      {open && (
-        <div className={styles.patientLaunchContainer}>
-          <PatientSearch hidePanel={togglePatientSearch} />
+    <>
+      <div className={styles.patientSearchIconWrapper}>
+        {open && (
+          <div className={styles.searchArea}>
+            <Search
+              size={layout === 'desktop' ? 'sm' : 'xl'}
+              className={styles.patientSearchInput}
+              placeholder={t('searchForPatient', 'Search for a patient by name or identifier number')}
+              labelText=""
+              onKeyUp={handleEnterKeyPressed}
+              onChange={(event) => handleChange(event.target.value)}
+              autoFocus={true}
+            />
+            <Button
+              disabled={status === 'searching'}
+              onClick={performSearch}
+              style={{ background: '#393939' }}
+              {...withButtonSize()}
+              className={styles.searchButton}>
+              {t('search', 'Search')}
+            </Button>
+          </div>
+        )}
+
+        <div className={`${open && styles.closeButton}`}>
+          <HeaderGlobalAction
+            onClick={() => setOpen((prevState) => !prevState)}
+            aria-label="Search Patient"
+            aria-labelledby="Search Patient"
+            name="SearchPatientIcon">
+            {open ? <Close20 /> : <Search20 />}
+          </HeaderGlobalAction>
         </div>
-      )}
-    </div>
+      </div>
+      {open && <PatientSearch hidePanel={handleCloseSearchPanel} searchResults={searchResults} status={status} />}
+    </>
   );
 };
 

--- a/packages/esm-patient-search-app/src/patient-search-result/patient-search-result.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-result/patient-search-result.component.tsx
@@ -55,7 +55,6 @@ const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({ patients, h
 
 interface PatientSearchResultsProps {
   patients: Array<SearchedPatient>;
-  searchTerm: string;
   hidePanel?: any;
 }
 

--- a/packages/esm-patient-search-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search/patient-search.component.tsx
@@ -1,69 +1,31 @@
 import React, { useEffect } from 'react';
-import { useTranslation, Trans } from 'react-i18next';
-import debounce from 'lodash-es/debounce';
+import { useTranslation } from 'react-i18next';
 import isEmpty from 'lodash-es/isEmpty';
 import { usePagination } from '@openmrs/esm-framework';
 import PaginationNav from 'carbon-components-react/es/components/PaginationNav';
-import Search from 'carbon-components-react/es/components/Search';
 import { Tile } from 'carbon-components-react/es/components/Tile';
-import { performPatientSearch } from './patient-search.resource';
 import { SearchedPatient } from '../types/index';
 import EmptyDataIllustration from './empty-data-illustration.component';
 import PatientSearchResults from '../patient-search-result/patient-search-result.component';
 import styles from './patient-search.scss';
+import Loading from 'carbon-components-react/es/components/Loading';
 
-const searchTimeout = 300;
 const resultsPerPage = 5;
-const customRepresentation =
-  'custom:(patientId,uuid,identifiers,display,' +
-  'patientIdentifier:(uuid,identifier),' +
-  'person:(gender,age,birthdate,birthdateEstimated,personName,display),' +
-  'attributes:(value,attributeType:(name)))';
 
 interface PatientSearchProps {
   hidePanel?: () => void;
+  searchResults: Array<SearchedPatient>;
+  status: 'searching' | 'resolved' | 'error' | 'idle';
 }
 
-const PatientSearch: React.FC<PatientSearchProps> = ({ hidePanel }) => {
+const PatientSearch: React.FC<PatientSearchProps> = ({ hidePanel, searchResults, status }) => {
   const { t } = useTranslation();
-  const [searchTerm, setSearchTerm] = React.useState('');
-  const [emptyResult, setEmptyResult] = React.useState(false);
-  const [searchResults, setSearchResults] = React.useState<Array<SearchedPatient>>([]);
-  const searchInput = React.useRef<HTMLInputElement | null>(null);
   const { totalPages, currentPage, goToNext, goToPrevious, results, goTo } = usePagination(
     searchResults,
     resultsPerPage,
   );
 
-  useEffect(() => {
-    const ac = new AbortController();
-    if (searchTerm) {
-      performPatientSearch(searchTerm, customRepresentation).then(({ data }) => {
-        const results: Array<SearchedPatient> = data.results.map((res, i) => ({
-          ...res,
-          index: i + 1,
-        }));
-
-        setSearchResults(results);
-
-        if (isEmpty(data.results)) {
-          setEmptyResult(true);
-        } else {
-          setEmptyResult(false);
-        }
-      });
-    } else {
-      setEmptyResult(false);
-      setSearchResults([]);
-    }
-    return () => ac.abort();
-  }, [searchTerm]);
-
-  const handleChange = debounce((searchTerm) => {
-    setSearchTerm(searchTerm);
-  }, searchTimeout);
-
-  const handlePageChange = (page) => {
+  const handlePageChange = (page: number) => {
     if (page === 0 && currentPage === 0) {
       goToNext();
     } else if (page + 1 > currentPage) {
@@ -80,43 +42,37 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ hidePanel }) => {
   }, [searchResults]);
 
   return (
-    <div className={styles.patientSearch}>
-      <Search
-        className={styles.patientSearchInput}
-        onChange={($event) => handleChange($event.target.value)}
-        placeholder={t('searchForPatient', 'Search for a patient by name or identifier number')}
-        labelText=""
-        ref={searchInput}
-        autoFocus={true}
-      />
-
-      <div className={styles.searchResultsContainer}>
-        {!isEmpty(searchResults) && (
-          <div className={styles.searchResults}>
-            <p className={styles.resultsText}>{t('patientsFound', { count: searchResults.length })}</p>
-            <PatientSearchResults hidePanel={hidePanel} searchTerm={searchTerm} patients={results} />
-            <div className={styles.pagination}>
-              <PaginationNav itemsShown={resultsPerPage} totalItems={totalPages} onChange={handlePageChange} />
+    <div className={styles.searchResultsContainer}>
+      {status === 'resolved' && (
+        <>
+          {!isEmpty(searchResults) && (
+            <div className={styles.searchResults}>
+              <p className={styles.resultsText}>{t('patientsFound', { count: searchResults.length })}</p>
+              <PatientSearchResults hidePanel={hidePanel} patients={results} />
+              <div className={styles.pagination}>
+                <PaginationNav itemsShown={resultsPerPage} totalItems={totalPages} onChange={handlePageChange} />
+              </div>
             </div>
-          </div>
-        )}
-        {emptyResult && (
-          <div className={styles.searchResults}>
-            <p className={styles.resultsText}>{t('noResultsFound', 'No results found')}</p>
-            <Tile className={styles.emptySearchResultsTile}>
-              <EmptyDataIllustration />
-              <p className={styles.emptyResultText}>
-                {t('noPatientChartsFoundMessage', 'Sorry, no patient charts have been found')}
-              </p>
-              <p className={styles.actionText}>
-                <span>{t('trySearchWithPatientUniqueID', "Try searching with the patient's unique ID number")}</span>
-                <br />
-                <span>{t('orPatientName', "OR the patient's name(s)")}</span>
-              </p>
-            </Tile>
-          </div>
-        )}
-      </div>
+          )}
+          {isEmpty(searchResults) && (
+            <div className={styles.searchResults}>
+              <p className={styles.resultsText}>{t('noResultsFound', 'No results found')}</p>
+              <Tile className={styles.emptySearchResultsTile}>
+                <EmptyDataIllustration />
+                <p className={styles.emptyResultText}>
+                  {t('noPatientChartsFoundMessage', 'Sorry, no patient charts have been found')}
+                </p>
+                <p className={styles.actionText}>
+                  <span>{t('trySearchWithPatientUniqueID', "Try searching with the patient's unique ID number")}</span>
+                  <br />
+                  <span>{t('orPatientName', "OR the patient's name(s)")}</span>
+                </p>
+              </Tile>
+            </div>
+          )}
+        </>
+      )}
+      {status === 'searching' && <Loading description="Active loading indicator" withOverlay={true} />}
     </div>
   );
 };

--- a/packages/esm-patient-search-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search/patient-search.component.tsx
@@ -16,9 +16,10 @@ interface PatientSearchProps {
   hidePanel?: () => void;
   searchResults: Array<SearchedPatient>;
   status: 'searching' | 'resolved' | 'error' | 'idle';
+  error;
 }
 
-const PatientSearch: React.FC<PatientSearchProps> = ({ hidePanel, searchResults, status }) => {
+const PatientSearch: React.FC<PatientSearchProps> = ({ hidePanel, searchResults, status, error }) => {
   const { t } = useTranslation();
   const { totalPages, currentPage, goToNext, goToPrevious, results, goTo } = usePagination(
     searchResults,
@@ -73,6 +74,26 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ hidePanel, searchResults,
         </>
       )}
       {status === 'searching' && <Loading description="Active loading indicator" withOverlay={true} />}
+      {status === 'error' && (
+        <div className={styles.searchResults}>
+          <p className={styles.resultsText}>{t('errorText', 'An error occurred while performing search')}</p>
+          <Tile className={styles.emptySearchResultsTile}>
+            <EmptyDataIllustration />
+            <div>
+              <p className={styles.errorMessage}>
+                {t('error', 'Error')} {`${error?.status}: `}
+                {error?.statusText}
+              </p>
+              <p className={styles.errorCopy}>
+                {t(
+                  'errorCopy',
+                  'Sorry, there was a an error. You can try to reload this page, or contact the site administrator and quote the error code above.',
+                )}
+              </p>
+            </div>
+          </Tile>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/esm-patient-search-app/src/patient-search/patient-search.resource.tsx
+++ b/packages/esm-patient-search-app/src/patient-search/patient-search.resource.tsx
@@ -1,7 +1,8 @@
 import { openmrsFetch } from '@openmrs/esm-framework';
 
-export function performPatientSearch(query, objectVersion) {
+export function performPatientSearch(query: string, objectVersion: string, ac: AbortController) {
   return openmrsFetch(`/ws/rest/v1/patient?q=${query}&v=${objectVersion}`, {
     method: 'GET',
+    signal: ac.signal,
   });
 }

--- a/packages/esm-patient-search-app/src/patient-search/patient-search.scss
+++ b/packages/esm-patient-search-app/src/patient-search/patient-search.scss
@@ -90,3 +90,16 @@
   margin: $spacing-05;
   background-color: $ui-02;
 }
+
+.errorMessage {
+  @include carbon--type-style("productive-heading-02");
+  color: $text-01;
+  margin-top: 2.25rem;
+  margin-bottom: $spacing-03;
+}
+
+.errorCopy {
+  margin-bottom: $spacing-03;
+  @include carbon--type-style("body-long-01");
+  color: $text-02;
+}

--- a/packages/esm-patient-search-app/src/patient-search/patient-search.scss
+++ b/packages/esm-patient-search-app/src/patient-search/patient-search.scss
@@ -1,23 +1,31 @@
 @import "../root.scss";
-@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vendor/@carbon/layout/scss/generated/spacing";
+
+:global(.bx--side-nav){
+  z-index: 0;
+}
 
 .searchResultsContainer {
   display: flex;
   justify-content: center;
   position: fixed;
   width: 100vw;
-  top: 3rem;
   bottom: 0;
   left: 0;
   right: 0;
   background-color:$ui-02;
-  padding: 0rem 1rem;
+  padding: 0rem $spacing-05;
   overflow-y: auto;
+}
+
+:global(.omrs-breakpoint-lt-desktop) .searchResultsContainer{
+  top: 6.25rem
 }
 
 :global(.omrs-breakpoint-gt-tablet) .searchResultsContainer {
   padding: 0;
   background-color:var(--omrs-color-bg-low-contrast);
+  top: $spacing-09;
 }
 
 .searchResults {
@@ -39,29 +47,15 @@
   @include carbon--type-style("label-01");
   color: $text-02;
   border-bottom: 0.063rem solid $ui-03;
-  padding: 0.5rem 0rem;
+  padding: $spacing-03 0rem;
 
 }
 
 :global(.omrs-breakpoint-gt-tablet) .resultsText {
-  margin: 1rem;
+  margin: $spacing-05;
 }
 
-.patientSearchInput {
-  background: transparent;
-  border: none;
-  padding: 0;
-  width: 100%;
-  text-align: center;
-}
 
-.patientSearchInput:focus {
-  outline: 2px solid #ff832b;
-}
-
-.patientSearchInput::placeholder {
-  color: var(--omrs-color-ink-medium-contrast);
-}
 
 .helperText {
   color: var(--omrs-color-ink-medium-contrast);
@@ -71,7 +65,7 @@
 .emptyResultText {
   @include carbon--type-style("productive-heading-01");
   color: $text-02;
-  margin-top: 1rem;
+  margin-top: $spacing-05;
   margin-bottom: 0.313rem;
 }
 
@@ -83,36 +77,16 @@
 .pagination {
   display: flex;
   justify-content: space-evenly;
-  padding: 4.688rem 0 1.5rem;
-}
-
-.patientSearchInput {
-  width: 100%;
-  top: 0;
-}
-
-.patientSearchInput {
-  :global(.bx--search-input:focus) {
-    outline: 2px solid #ff832b;
-  }
-}
-
-.patientSearchInput input {
-  width: 100vw;
-}
-
-.patientSearch {
-  width: 100%;
-  display: flex;
+  padding: 4.688rem 0 $spacing-06;
 }
 
 .emptySearchResultsTile {
   text-align: center;
-  margin-top: 1rem;
-  padding: 3rem 0rem;
+  margin-top: $spacing-05;
+  padding: $spacing-09 0rem;
 }
 
 :global(.omrs-breakpoint-gt-tablet) .emptySearchResultsTile {
-  margin: 1rem;
+  margin: $spacing-05;
   background-color: $ui-02;
 }

--- a/packages/esm-patient-search-app/translations/en.json
+++ b/packages/esm-patient-search-app/translations/en.json
@@ -4,6 +4,7 @@
   "orPatientName": "OR the patient's name(s)",
   "patientsFound": "Found {count, plural, one{{count} patient} other{{count} patients}}",
   "patientsFound_plural": "",
+  "search": "Search",
   "searchForPatient": "Search for a patient by name or identifier number",
   "trySearchWithPatientUniqueID": "Try searching with the patient's unique ID number"
 }


### PR DESCRIPTION
### Description

1. Extended desktop search to cover the left navigation
2. Updated the search experience to match the designs as shown [here](https://app.zeplin.io/project/60d59321e8100b0324762e05/dashboard?tag=Patient%20search)

## Screenshoots

### Desktop Search Experience
![desktop](https://user-images.githubusercontent.com/28008754/129444461-595fab82-4b56-4f8a-91e7-ac313920c48c.gif)

### Tablet search experience
![tablet](https://user-images.githubusercontent.com/28008754/129444485-5e3dc57b-5c31-4cfb-a1f5-765bc1004e1f.gif)

