### PR TITLE
MF-765:Change Actions list items to sentence case

### DIFF
--- a/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.component.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.component.tsx
@@ -12,7 +12,7 @@ export default function EditPatientDetailsButton({ patientUuid }) {
         className={`bx--overflow-menu-options__btn ${styles.link}`}
         title={t('editPatientDetails', 'Edit Patient Details')}>
         <span className="bx--overflow-menu-options__option-content">
-          {t('editPatientDetails', 'Edit Patient Details')}
+          {t('editPatientDetails', 'Edit patient details')}
         </span>
       </ConfigurableLink>
     </li>

--- a/packages/esm-patient-registration-app/translations/en.json
+++ b/packages/esm-patient-registration-app/translations/en.json
@@ -18,7 +18,7 @@
   "discardModalBody": "The changes you made to this patient's details have not been saved. Discard changes?",
   "discardModalHeader": "Confirm Discard Changes",
   "edit": "Edit",
-  "editPatientDetails": "Edit Patient Details",
+  "editPatientDetails": "Edit patient details",
   "emailLabelText": "Email",
   "enterIdentifierPlaceholderText": "Enter Identifier",
   "estimatedYearsLabelText": "Estimated Years",


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Change Actions list items to sentence case according to this [design.](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5993b012a3b15791a9f28)
Specifically changing Edit Patient Details to Edit patient details.

## Screenshots

![image](https://user-images.githubusercontent.com/67265839/134171622-ea9bec62-227b-428a-a44e-1e189d873160.png)


## Related Issue

Issue [MF-765](https://issues.openmrs.org/browse/MF-765)