### PR TITLE
O3-906: Fix superfluous registration form re-renders

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -66,7 +66,7 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
       setSections(configuredSections);
       setFieldConfigs(config.fieldConfigurations);
     }
-  }, [t, config]);
+  }, [config.sections, config.fieldConfigurations, config.sectionDefinitions]);
 
   useEffect(() => {
     for (const patientIdentifier of patientIdentifiers) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Presently, the patient registration form isn't working because too many re-renders are happening when the form gets launched. Tweaking the dependency array of the useEffect hook that sets the page sections and field configurations appears to solve this problem.