### PR TITLE
O3-823: Editing patient details continually adds the patient address(es)

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -188,6 +188,25 @@ export default class FormManager {
     return [];
   }
 
+  static checkIfEdited = (obj1, obj2) => {
+    const objectKeys = Object.keys(obj1);
+
+    for (const objKey of objectKeys) {
+      const val1 = obj1[objKey];
+      const val2 = obj2[objKey];
+      const isAnObject = val1 != null && typeof val1 === 'object';
+      if (
+        (isAnObject && Object.keys(val1).length !== Object.keys(val2).length) ||
+        (isAnObject && !FormManager.checkIfEdited(val1, val2)) ||
+        (!isAnObject && val1 !== val2)
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
   static getPatientToCreate(
     values: FormValues,
     personAttributeSections: any,
@@ -195,6 +214,12 @@ export default class FormManager {
     initialAddressFieldValues: Record<string, any>,
     identifiers: Array<PatientIdentifier>,
   ): Patient {
+    let address = FormManager.getPatientAddressField(values, initialAddressFieldValues);
+
+    if (FormManager.checkIfEdited(initialAddressFieldValues, address)) {
+      address = {};
+    }
+
     return {
       uuid: patientUuidMap['patientUuid'],
       person: {
@@ -204,7 +229,7 @@ export default class FormManager {
         birthdate: values.birthdate,
         birthdateEstimated: values.birthdateEstimated,
         attributes: FormManager.getPatientAttributes(values, personAttributeSections),
-        addresses: [FormManager.getPatientAddressField(values, initialAddressFieldValues)],
+        addresses: [address],
         ...FormManager.getPatientDeathInfo(values),
       },
       identifiers,

--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -17,6 +17,7 @@ import {
   savePatientPhoto,
   saveRelationship,
 } from './patient-registration.resource';
+import isEqual from 'lodash-es/isEqual';
 
 export type SavePatientForm = (
   patientUuid: string | undefined,
@@ -188,25 +189,6 @@ export default class FormManager {
     return [];
   }
 
-  static checkIfEdited = (obj1, obj2) => {
-    const objectKeys = Object.keys(obj1);
-
-    for (const objKey of objectKeys) {
-      const val1 = obj1[objKey];
-      const val2 = obj2[objKey];
-      const isAnObject = val1 != null && typeof val1 === 'object';
-      if (
-        (isAnObject && Object.keys(val1).length !== Object.keys(val2).length) ||
-        (isAnObject && !FormManager.checkIfEdited(val1, val2)) ||
-        (!isAnObject && val1 !== val2)
-      ) {
-        return false;
-      }
-    }
-
-    return true;
-  };
-
   static getPatientToCreate(
     values: FormValues,
     personAttributeSections: any,
@@ -216,7 +198,7 @@ export default class FormManager {
   ): Patient {
     let address = FormManager.getPatientAddressField(values, initialAddressFieldValues);
 
-    if (FormManager.checkIfEdited(initialAddressFieldValues, address)) {
+    if (isEqual(initialAddressFieldValues, address)) {
       address = {};
     }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I have checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Quoting from the [O3-823](https://issues.openmrs.org/browse/O3-823) page:
"Every time a patient is edited using the *Edit patient details* action, a new address is appended to the patient's list of addresses in the backend."

This PR fixes the stated issue.

This is a follow-up PR to #63 


## Screenshots

*None.*


## Related Issue

[O3-823](https://issues.openmrs.org/browse/O3-823)


## Other

*None.*