### PR TITLE
Add react-dom as a peerDependency

### DIFF
--- a/packages/esm-active-visits-app/package.json
+++ b/packages/esm-active-visits-app/package.json
@@ -46,6 +46,7 @@
     "carbon-icons": "7.x",
     "dayjs": "1.x",
     "react": "16.x",
+    "react-dom": "16.x",
     "react-i18next": "11.x",
     "react-router-dom": "5.x",
     "rxjs": "6.x"


### PR DESCRIPTION
## Summary

This appears to resolve a problem where active visits seems to be using
a version of react-dom that is bundled in the carbon-components-react
package. The problem causes React Dev Tools to see the second react-dom
as a new renderer, which can cause it to erroneously detect the page
as using the production build of React when using a local development
server.

My suspicion is that, in fact, there is nothing special about esm-active-visits-app; that when we merge this, the same problem will appear with the next frontend module in the import map. However, when I made this change and ran a dev server for a different module (patient search), I saw no effect on the problem. So we will see.

It may be that the right thing to do in any case is to add the [common shared dependencies](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/shell/esm-app-shell/dependencies.json) to the [shared modules part of the default webpack config](https://github.com/openmrs/openmrs-esm-core/blob/6f1b6b6284b6d7af5656cb5cb9c066ce67ce366c/packages/tooling/openmrs/default-webpack-config.js#L121).

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Screenshots

https://user-images.githubusercontent.com/1031876/142293206-aa7185fd-ccaf-424d-81e3-b33d8e7a6ae3.mp4
