### PR TITLE
03 938 : Should be able to edit patient details from the patient search page

### DIFF
--- a/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.component.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.component.tsx
@@ -1,20 +1,40 @@
 import React from 'react';
-import { ConfigurableLink } from '@openmrs/esm-framework';
+import { navigate } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import styles from './edit-patient-details-button.scss';
 
-export default function EditPatientDetailsButton({ patientUuid }) {
+interface EditPatientDetailsButtonProps {
+  closePatientSearchResultsPanel?: () => void;
+  patientUuid: string;
+}
+
+const EditPatientDetailsButton: React.FC<EditPatientDetailsButtonProps> = ({
+  patientUuid,
+  closePatientSearchResultsPanel,
+}) => {
   const { t } = useTranslation();
+  const handleClick = React.useCallback(() => {
+    navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/edit` });
+    closePatientSearchResultsPanel();
+  }, [closePatientSearchResultsPanel, patientUuid]);
+
   return (
     <li className="bx--overflow-menu-options__option">
-      <ConfigurableLink
-        to={`\${openmrsSpaBase}/patient/${patientUuid}/edit`}
-        className={`bx--overflow-menu-options__btn ${styles.link}`}
-        title={t('editPatientDetails', 'Edit Patient Details')}>
+      <button
+        className="bx--overflow-menu-options__btn"
+        role="menuitem"
+        title={t('editPatientDetails', 'Edit Patient Details')}
+        data-floating-menu-primary-focus
+        onClick={handleClick}
+        style={{
+          maxWidth: '100vw',
+        }}>
         <span className="bx--overflow-menu-options__option-content">
           {t('editPatientDetails', 'Edit patient details')}
         </span>
-      </ConfigurableLink>
+      </button>
     </li>
   );
-}
+};
+
+export default EditPatientDetailsButton;

--- a/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.component.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.component.tsx
@@ -15,7 +15,7 @@ const EditPatientDetailsButton: React.FC<EditPatientDetailsButtonProps> = ({
   const { t } = useTranslation();
   const handleClick = React.useCallback(() => {
     navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/edit` });
-    closePatientSearchResultsPanel();
+    closePatientSearchResultsPanel && closePatientSearchResultsPanel();
   }, [closePatientSearchResultsPanel, patientUuid]);
 
   return (

--- a/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.component.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.component.tsx
@@ -4,19 +4,16 @@ import { useTranslation } from 'react-i18next';
 import styles from './edit-patient-details-button.scss';
 
 interface EditPatientDetailsButtonProps {
-  closePatientSearchResultsPanel?: () => void;
+  onTransition?: () => void;
   patientUuid: string;
 }
 
-const EditPatientDetailsButton: React.FC<EditPatientDetailsButtonProps> = ({
-  patientUuid,
-  closePatientSearchResultsPanel,
-}) => {
+const EditPatientDetailsButton: React.FC<EditPatientDetailsButtonProps> = ({ patientUuid, onTransition }) => {
   const { t } = useTranslation();
   const handleClick = React.useCallback(() => {
     navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/edit` });
-    closePatientSearchResultsPanel && closePatientSearchResultsPanel();
-  }, [closePatientSearchResultsPanel, patientUuid]);
+    onTransition && onTransition();
+  }, [onTransition, patientUuid]);
 
   return (
     <li className="bx--overflow-menu-options__option">
@@ -25,10 +22,7 @@ const EditPatientDetailsButton: React.FC<EditPatientDetailsButtonProps> = ({
         role="menuitem"
         title={t('editPatientDetails', 'Edit Patient Details')}
         data-floating-menu-primary-focus
-        onClick={handleClick}
-        style={{
-          maxWidth: '100vw',
-        }}>
+        onClick={handleClick}>
         <span className="bx--overflow-menu-options__option-content">
           {t('editPatientDetails', 'Edit patient details')}
         </span>

--- a/packages/esm-patient-search-app/src/patient-search-result/patient-search-result.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-result/patient-search-result.component.tsx
@@ -60,7 +60,7 @@ const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({ patients, h
                 patient,
                 patientUuid: patient.id,
                 onClick: onClickSearchResult,
-                closePatientSearchResultsPanel: hidePanel,
+                onTransition: hidePanel,
               }}
             />
           </div>

--- a/packages/esm-patient-search-app/src/patient-search-result/patient-search-result.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-result/patient-search-result.component.tsx
@@ -60,6 +60,7 @@ const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({ patients, h
                 patient,
                 patientUuid: patient.id,
                 onClick: onClickSearchResult,
+                closePatientSearchResultsPanel: hidePanel,
               }}
             />
           </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

At the moment, when you try to navigate to patient-registration in edit mode, from the patient-search, patient search result panel doesn't close. This PR adds that ability.


## Screenshots

![03-938](https://user-images.githubusercontent.com/28008754/143400106-831adbd6-8dc6-4a28-a8e8-36e069931e14.gif)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
