### PR TITLE
O3-890: Person Attributes not POST'ed when patient registration form …

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schemas/openmrs-esm-patient-registration-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schemas/openmrs-esm-patient-registration-schema.ts
@@ -87,4 +87,31 @@ export const esmPatientRegistrationSchema = {
       _default: '736e8771-e501-4615-bfa7-570c03f4bef5',
     },
   },
+  personAttributeSections: {
+    _type: Type.Array,
+    _default: [{ personAttributes: [{ name: 'phone', uuid: '14d4f066-15f5-102d-96e4-000c29c2a5d7' }] }],
+    _elements: {
+      _type: Type.Object,
+      personAttributes: {
+        _type: Type.Array,
+        _elements: {
+          _type: Type.Object,
+          uuid: {
+            _type: Type.UUID,
+            _description: 'Person attributetype uuid used to save the attribute',
+          },
+          name: {
+            _type: Type.String,
+            _default: '',
+          },
+          _default: {
+            phone: {
+              name: 'phone',
+              uuid: '14d4f066-15f5-102d-96e4-000c29c2a5d7',
+            },
+          },
+        },
+      },
+    },
+  },
 };

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
@@ -7,6 +7,7 @@ import {
   getFormValuesFromFhirPatient,
   getPatientIdentifiersFromFhirPatient,
   getPatientUuidMapFromFhirPatient,
+  getPhonePersonAttributeValueFromFhirPatient,
 } from './patient-registration-utils';
 
 const blankFormValues: FormValues = {
@@ -50,6 +51,7 @@ export function useInitialFormValues(
           ...initialFormValues,
           ...getFormValuesFromFhirPatient(patient),
           ...getAddressFieldValuesFromFhirPatient(patient),
+          ...getPhonePersonAttributeValueFromFhirPatient(patient),
           identifiers: [...getPatientIdentifiersFromFhirPatient(patient)],
         });
       } else if (!isLoadingPatient && patientUuid) {

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-utils.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-utils.ts
@@ -160,3 +160,11 @@ export function getPatientIdentifiersFromFhirPatient(patient: fhir.Patient): Arr
     };
   });
 }
+
+export function getPhonePersonAttributeValueFromFhirPatient(patient: fhir.Patient) {
+  const result = {};
+  if (patient.telecom) {
+    result['phone'] = patient.telecom[0].value;
+  }
+  return result;
+}


### PR DESCRIPTION
## Requirements

- [ ] This PR addresses [O3-890](https://issues.openmrs.org/browse/O3-890)
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Currently, when a patient is registered, the phone number person attribute is not persisted.
- Currently, when patient details are loaded for editing, the phone field is blank - the attribute value is not bound to the phone field.
- This PR addresses these issues.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
