### PR TITLE
Error notification not displaying on registration form submit failure

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -147,11 +147,11 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
         setTarget(redirectUrl);
       }
     } catch (error) {
-      if (error.responseBody?.error?.globalErrors) {
+      if (error?.responseBody.error?.globalErrors) {
         error.responseBody.error.globalErrors.forEach((error) => {
           showToast({ description: error.message });
         });
-      } else if (error?.responseBody && error?.responseBody?.error?.message) {
+      } else if (error?.responseBody.error?.message) {
         showToast({ description: error.responseBody.error.message });
       } else {
         createErrorHandler()(error);

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -147,11 +147,11 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
         setTarget(redirectUrl);
       }
     } catch (error) {
-      if (error.responseBody && error.responseBody.error.globalErrors) {
+      if (error?.responseBody && error?.responseBody?.error?.globalErrors) {
         error.responseBody.error.globalErrors.forEach((error) => {
           showToast({ description: error.message });
         });
-      } else if (error.responseBody && error.responseBody.error.message) {
+      } else if (error?.responseBody && error?.responseBody?.error?.message) {
         showToast({ description: error.responseBody.error.message });
       } else {
         createErrorHandler()(error);

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -147,11 +147,11 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
         setTarget(redirectUrl);
       }
     } catch (error) {
-      if (error?.responseBody.error?.globalErrors) {
+      if (error.responseBody?.error?.globalErrors) {
         error.responseBody.error.globalErrors.forEach((error) => {
           showToast({ description: error.message });
         });
-      } else if (error?.responseBody.error?.message) {
+      } else if (error.responseBody?.error?.message) {
         showToast({ description: error.responseBody.error.message });
       } else {
         createErrorHandler()(error);

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -147,7 +147,7 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
         setTarget(redirectUrl);
       }
     } catch (error) {
-      if (error?.responseBody && error?.responseBody?.error?.globalErrors) {
+      if (error.responseBody?.error?.globalErrors) {
         error.responseBody.error.globalErrors.forEach((error) => {
           showToast({ description: error.message });
         });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

## Summary
This fixes the error toast display using optional chaining to access the error object properties

## Screenshots
<img width="1680" alt="Screenshot 2021-12-20 at 06 51 14" src="https://user-images.githubusercontent.com/48393059/146709549-d6906ea7-599f-4aa2-8997-169cfbc7bc6e.png">

