### PR TITLE
setup patient queue page

### DIFF
--- a/packages/esm-patient-queue-app/src/constants.ts
+++ b/packages/esm-patient-queue-app/src/constants.ts
@@ -1,0 +1,3 @@
+export const spaRoot = window['getOpenmrsSpaBase'];
+export const basePath = '/outpatient';
+export const spaBasePath = `${window.spaBase}${basePath}`;

--- a/packages/esm-patient-queue-app/src/home.component.tsx
+++ b/packages/esm-patient-queue-app/src/home.component.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import PatientQueueHeader from './patient-queue-header/patient-queue-header.component';
+
+interface HomeProps {}
+
+const Home: React.FC<HomeProps> = () => {
+  return (
+    <div>
+      <PatientQueueHeader />
+    </div>
+  );
+};
+
+export default Home;

--- a/packages/esm-patient-queue-app/src/index.ts
+++ b/packages/esm-patient-queue-app/src/index.ts
@@ -22,16 +22,15 @@ function setupOpenMRS() {
   defineConfigSchema(moduleName, configSchema);
 
   return {
-    extensions: [
+    pages: [
       {
-        id: 'patient-queue-header',
-        slot: 'homepage-widgets-slot',
-        load: getAsyncLifecycle(() => import('./patient-queue-header/patient-queue-header.component'), options),
-        offline: true,
+        route: 'outpatient',
+        load: getAsyncLifecycle(() => import('./root.component'), options),
         online: true,
-        order: 0,
+        offline: true,
       },
     ],
+    extensions: [],
   };
 }
 

--- a/packages/esm-patient-queue-app/src/patient-queue-header/patient-queue-header.scss
+++ b/packages/esm-patient-queue-app/src/patient-queue-header/patient-queue-header.scss
@@ -5,7 +5,6 @@
 .patient-header-container {
   height: $spacing-12;
   background-color: $ui-02;
-  margin: $spacing-02 0;
 }
 
 .header-left {
@@ -22,5 +21,5 @@
 .productiveHeading04 {
   @include carbon--type-style("productive-heading-04");
   color: $ui-05;
-  padding: $spacing-01 0;
+  padding: $spacing-03 0 0 0;
 }

--- a/packages/esm-patient-queue-app/src/patient-queue-header/patient-queue-illustration.component.tsx
+++ b/packages/esm-patient-queue-app/src/patient-queue-header/patient-queue-illustration.component.tsx
@@ -4,7 +4,7 @@ const PatientQueueIllustration: React.FC = () => {
   return (
     <svg width="92" height="94" viewBox="0 0 92 94" xmlns="http://www.w3.org/2000/svg">
       <title>Patient queue illustration</title>
-      <g fill="none" fill-rule="evenodd">
+      <g fill="none" fillRule="evenodd">
         <path fill="#FFF" d="M0 0h92v94H0z" />
         <path
           d="M40 32c.84-.602 1.12-1.797 1-3 .12-5.005-3.96-9-9-9s-9.12 3.995-9 9c-.12 3.572 2.1 6.706 5 8-6.76 1.741-12 7.91-12 15v15h28V32h-4zM76 67V52c0-7.09-5.24-13.278-12-15 2.9-1.294 5.12-4.428 5-8 .12-5.005-3.96-9-9-9s-9.12 3.995-9 9c-.12 1.203.14 2.398 1 3h-4v35h28z"

--- a/packages/esm-patient-queue-app/src/root.component.tsx
+++ b/packages/esm-patient-queue-app/src/root.component.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { SWRConfig } from 'swr';
+import { BrowserRouter, Route } from 'react-router-dom';
+import Home from './home.component';
+import { spaBasePath } from './constants';
+
+const swrConfiguration = {
+  // Maximum number of retries when the backend returns an error
+  errorRetryCount: 3,
+};
+
+const Root: React.FC = () => {
+  return (
+    <main>
+      <SWRConfig value={swrConfiguration}>
+        <BrowserRouter basename={spaBasePath}>
+          {/** Side Menu goes here */}
+          <Route path="/" component={Home} />
+        </BrowserRouter>
+      </SWRConfig>
+    </main>
+  );
+};
+
+export default Root;


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- This PR setup the patient-queue page `/outpatient` 
- remove `patient-queue-header` from `home-widget-slot`


## Screenshots

![Screenshot 2022-01-26 at 15 58 49](https://user-images.githubusercontent.com/28008754/151167145-3b3331b6-00b8-42e7-994b-193233f85e50.png)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
