### PR TITLE
Fix visit start time

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -28,9 +28,9 @@ import {
   parseDate,
 } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
+import { EmptyDataIllustration } from './empty-data-illustration.component';
 import { ActiveVisit, useActiveVisits } from './active-visits.resource';
 import styles from './active-visits.scss';
-import { EmptyDataIllustration } from './empty-data-illustration.component';
 
 interface PaginationData {
   goTo: (page: number) => void;
@@ -42,11 +42,9 @@ const ActiveVisitsTable = () => {
   const { t } = useTranslation();
   const config = useConfig();
   const layout = useLayoutType();
-
   const { data: activeVisits, isError, isLoading, isValidating } = useActiveVisits();
-
   const desktopView = layout === 'desktop';
-  const pageSizes = config?.activeVisits?.pageSizes ?? [10, 20, 50];
+  const pageSizes = config?.activeVisits?.pageSizes ?? [10, 20, 30, 40, 50];
   const [currentPageSize, setPageSize] = useState(config?.activeVisits?.pageSize ?? 10);
   const [searchString, setSearchString] = useState('');
 

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -19,12 +19,15 @@ export function useActiveVisits() {
   const { data: currentUserSession } = useCurrentSession();
   const startDate = dayjs().format('YYYY-MM-DD');
   const sessionLocation = currentUserSession?.data?.sessionLocation?.uuid;
+
   const customRepresentation =
     'custom:(uuid,patient:(uuid,identifiers:(identifier,uuid),person:(age,display,gender,uuid)),' +
     'visitType:(uuid,name,display),location:(uuid,name,display),startDatetime,' +
-    'stopDatetime)&fromStartDate=';
-  const url =
-    `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}` + startDate + '&location=' + sessionLocation;
+    'stopDatetime)&fromStartDate=' +
+    startDate +
+    '&location=' +
+    sessionLocation;
+  const url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}`;
   const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(url, openmrsFetch);
 
   const mapVisitProperties = (visit: Visit): ActiveVisit => ({

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
-import { openmrsFetch, Visit, SessionUser } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
+import { openmrsFetch, Visit, SessionUser } from '@openmrs/esm-framework';
 
 export interface ActiveVisit {
   age: string;
@@ -17,21 +17,15 @@ export interface ActiveVisit {
 
 export function useActiveVisits() {
   const { data: currentUserSession } = useCurrentSession();
-  const sessionLocation = currentUserSession?.data?.sessionLocation?.uuid;
   const startDate = dayjs().format('YYYY-MM-DD');
-
+  const sessionLocation = currentUserSession?.data?.sessionLocation?.uuid;
   const customRepresentation =
     'custom:(uuid,patient:(uuid,identifiers:(identifier,uuid),person:(age,display,gender,uuid)),' +
     'visitType:(uuid,name,display),location:(uuid,name,display),startDatetime,' +
-    'stopDatetime)&fromStartDate=' +
-    startDate +
-    '&location=' +
-    sessionLocation;
-
-  const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
-    `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}`,
-    openmrsFetch,
-  );
+    'stopDatetime)&fromStartDate=';
+  const url =
+    `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}` + startDate + '&location=' + sessionLocation;
+  const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(url, openmrsFetch);
 
   const mapVisitProperties = (visit: Visit): ActiveVisit => ({
     age: visit?.patient?.person?.age,
@@ -41,7 +35,7 @@ export function useActiveVisits() {
     location: visit?.location?.uuid,
     name: visit?.patient?.person?.display,
     patientUuid: visit?.patient?.uuid,
-    visitStartTime: visit.startDate,
+    visitStartTime: visit?.startDatetime,
     visitType: visit?.visitType?.display,
     visitUuid: visit.uuid,
   });

--- a/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
+++ b/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
@@ -15,8 +15,7 @@ interface VisitDetailComponentProps {
 const VisitDetailComponent: React.FC<VisitDetailComponentProps> = ({ visitUuid, patientUuid }) => {
   const { t } = useTranslation();
   const [listView, setView] = useState(true);
-
-  const { data: visit, isError, isLoading, isValidating } = useVisit(visitUuid);
+  const { visit, isError, isLoading, isValidating } = useVisit(visitUuid);
 
   const encounters = useMemo(
     () =>
@@ -65,6 +64,8 @@ const VisitDetailComponent: React.FC<VisitDetailComponentProps> = ({ visitUuid, 
         {!listView && <VisitSummary encounters={visit.encounters} patientUuid={patientUuid} />}
       </div>
     );
+  } else {
+    return null;
   }
 };
 

--- a/packages/esm-active-visits-app/src/visits-summary/visit.resource.ts
+++ b/packages/esm-active-visits-app/src/visits-summary/visit.resource.ts
@@ -146,7 +146,7 @@ export function useVisit(visitUuid: string) {
   );
 
   return {
-    data: data ? data.data : null,
+    visit: data ? data.data : null,
     isError: error,
     isLoading: !data && !error,
     isValidating,

--- a/packages/esm-patient-queue-app/translations/en.json
+++ b/packages/esm-patient-queue-app/translations/en.json
@@ -6,6 +6,7 @@
   "moreMetrics": "See more metrics",
   "patientList": "Patient list",
   "patients": "Patients",
-  "scheduledAppointment": "Scheduled appts. today",
+  "scheduledAppointments": "Scheduled appts. today",
+  "triage": "Triage",
   "waitingFor": "Waiting for:"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary
The active visits widget currently uses the visit `startDate` to compute the time when a visit started. This property doesn't exist on the visit object. We should instead use the `startDatetime` property. 

This commit fixes the ActiveVisits component logic to use the `startDatetime`.

## Screenshots

> Before 

<img width="1125" alt="Screenshot 2022-01-31 at 21 43 46" src="https://user-images.githubusercontent.com/8509731/151854393-ec45fbf0-e676-4c82-a42e-f23d50c06bb1.png">

> After

<img width="1126" alt="Screenshot 2022-01-31 at 21 43 14" src="https://user-images.githubusercontent.com/8509731/151854416-ffbfe25f-68f2-4873-8d9e-84433380a7c2.png">

> Error when the visit is `null`

<img width="1129" alt="Screenshot 2022-01-31 at 21 42 57" src="https://user-images.githubusercontent.com/8509731/151854503-54e7b41b-9802-421e-92fa-9c108eafddcf.png">

> Fixed 

<img width="1127" alt="Screenshot 2022-01-31 at 21 44 19" src="https://user-images.githubusercontent.com/8509731/151854596-c91f0347-0b3b-4575-bd67-b61da5395ea2.png">

