### PR TITLE
O3-1050: Patient Search should display a Clear button instead of X inside text field

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -125,6 +125,7 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
               className={styles.patientSearchInput}
               placeholder={t('searchForPatient', 'Search for a patient by name or identifier number')}
               labelText=""
+              closeButtonLabelText={t('clearSearch', 'Clear')}
               onKeyUp={handleEnterKeyPressed}
               onChange={(event) => handleChange(event.target.value)}
               autoFocus={true}

--- a/packages/esm-patient-search-app/translations/en.json
+++ b/packages/esm-patient-search-app/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "clearSearch": "Clear",
   "error": "Error",
   "errorCopy": "Sorry, there was a an error. You can try to reload this page, or contact the site administrator and quote the error code above.",
   "errorText": "An error occurred while performing search",

--- a/packages/esm-patient-search-app/translations/es.json
+++ b/packages/esm-patient-search-app/translations/es.json
@@ -1,3 +1,4 @@
 {
-  "searchForPatient": "Buscar un paciente"
+  "searchForPatient": "Buscar un paciente",
+  "clearSearch": "Dégager"
 }


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Instead of having a second X inside of the search bar to clear the text, the design has a ghost button saying Clear to separate it from the X above it to close the search bar entirely. See the design here: https://zpl.io/2jq39Xx
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-1050
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
