### PR TITLE
(feat): UI enhancements

### DIFF
--- a/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.component.tsx
@@ -10,7 +10,7 @@ const PatientQueueHeader: React.FC = () => {
       <div className={styles['header-left']}>
         <PatientQueueIllustration />
         <div>
-          <p className={styles['bodyShort02']}>{t('patients', 'Patients')}</p>
+          <p className={styles['bodyShort02']}>{t('outpatients', 'Outpatients')}</p>
           <p className={styles['productiveHeading04']}>{t('home', 'Home')}</p>
         </div>
       </div>

--- a/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.scss
+++ b/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.scss
@@ -5,6 +5,7 @@
 .patient-header-container {
   height: $spacing-12;
   background-color: $ui-02;
+  border: 1px solid $ui-03; 
 }
 
 .header-left {

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import MetricsCard from './metrics-card.component';
-
-import styles from './clinic-metrics.scss';
 import { useTranslation } from 'react-i18next';
-import { useMetrics } from './queue-metrics.resource';
 import { Dropdown, DataTableSkeleton } from 'carbon-components-react';
+import { useMetrics } from './queue-metrics.resource';
+import MetricsCard from './metrics-card.component';
 import MetricsHeader from './metrics-header.component';
+import styles from './clinic-metrics.scss';
 
 const ClinicMetrics: React.FC = () => {
   const { t } = useTranslation();
-  const { data: metrics, isError, isLoading } = useMetrics();
+  const { metrics, isError, isLoading } = useMetrics();
 
   const items = [
     {
@@ -25,6 +24,7 @@ const ClinicMetrics: React.FC = () => {
       text: 'Pharmacy',
     },
   ];
+
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" />;
   }
@@ -41,18 +41,16 @@ const ClinicMetrics: React.FC = () => {
         <MetricsCard
           label={t('patients', 'Patients')}
           value={metrics ? metrics.patients_waiting_for_service : 0}
-          headerLabel={t('waitingFor', 'Waiting for:')}
-          childComponent={
-            <Dropdown
-              style={{ marginTop: '1.5rem' }}
-              id="inline"
-              label={t('triage', 'Triage')}
-              type="inline"
-              items={items}
-              itemToString={(item) => (item ? item.text : '')}
-            />
-          }
-        />
+          headerLabel={t('waitingFor', 'Waiting for:')}>
+          <Dropdown
+            style={{ marginTop: '1.5rem' }}
+            id="inline"
+            label={t('triage', 'Triage')}
+            type="inline"
+            items={items}
+            itemToString={(item) => (item ? item.text : '')}
+          />
+        </MetricsCard>
         <MetricsCard
           label={t('minutes', 'Minutes')}
           value={metrics ? metrics.avarage_wait_time : 0}

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.scss
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.scss
@@ -3,9 +3,10 @@
 @import "~carbon-components/src/globals/scss/mixins";
 
 .clinicMetricsContainer {
-    background-color: $ui-02 ;
-    display: flex;
-    justify-content: space-between;
-    padding:0 $spacing-05 $spacing-10 $spacing-03;
-
+  background-color: $ui-02 ;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 $spacing-05 $spacing-10 $spacing-03; 
+  flex-flow: row wrap;
+  margin-top: -$spacing-03;
 }

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.component.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import { Tile, Button } from 'carbon-components-react';
-import styles from './metrics-card.scss';
 import { useTranslation } from 'react-i18next';
+import { Tile, Button } from 'carbon-components-react';
 import ArrowRight16 from '@carbon/icons-react/es/arrow--right/16';
+import styles from './metrics-card.scss';
 
 interface MetricsCardProps {
   label: string;
   value: number;
   headerLabel: string;
-  childComponent?: React.ReactNode;
+  children?: React.ReactNode;
 }
 
-const MetricsCard: React.FC<MetricsCardProps> = ({ label, value, headerLabel, childComponent }) => {
+const MetricsCard: React.FC<MetricsCardProps> = ({ label, value, headerLabel, children }) => {
   const { t } = useTranslation();
 
   return (
@@ -19,9 +19,8 @@ const MetricsCard: React.FC<MetricsCardProps> = ({ label, value, headerLabel, ch
       <div className={styles.tileHeader}>
         <div className={styles.headerLabelContainer}>
           <label className={styles.headerLabel}>{headerLabel}</label>
-          {childComponent}
+          {children}
         </div>
-
         <Button kind="ghost" renderIcon={ArrowRight16} iconDescription={t('patientList', 'Patient list')}>
           {t('patientList', 'Patient list')}
         </Button>

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.scss
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.scss
@@ -2,42 +2,38 @@
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
 
-
 .tileContainer {
-    border: 0.0625rem solid $ui-03;
-    flex: 1;
-    height: 7.875rem;
-    padding: 0 $spacing-05;
-    margin: 0 $spacing-03;
-
+  border: 0.0625rem solid $ui-03;
+  flex-grow: 1;
+  height: 7.875rem;
+  padding: 0 $spacing-05;
+  margin: $spacing-03 $spacing-03;
 }
+
 .tileHeader {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: $spacing-03;
-    
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: $spacing-03;  
 }
+
 .headerLabel {
-    @include carbon--type-style("productive-heading-01");
-    color: $text-02
-
+  @include carbon--type-style("productive-heading-01");
+  color: $text-02;
 }
+
 .totalsLabel {
-    @include carbon--type-style("label-01");
-    color: $text-02
-
+  @include carbon--type-style("label-01");
+  color: $text-02;
 }
-.totalsValue {
-    @include carbon--type-style("productive-heading-04");
-    color: $ui-05;
 
+.totalsValue {
+  @include carbon--type-style("productive-heading-04");
+  color: $ui-05;
 }
 
 .headerLabelContainer {
- display: flex;
- align-items: center;
- height: $spacing-07;
-    
-
+  display: flex;
+  align-items: center;
+  height: $spacing-07;
 }

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-header.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-header.component.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from 'carbon-components-react';
 import ArrowRight16 from '@carbon/icons-react/es/arrow--right/16';
 
-interface MetricsHeaderProps {}
-const MetricsHeader: React.FC<MetricsHeaderProps> = () => {
+const MetricsHeader: React.FC = () => {
   const { t } = useTranslation();
 
   return (

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-header.scss
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-header.scss
@@ -3,14 +3,15 @@
 @import "~carbon-components/src/globals/scss/mixins";
 
 .metricsContainer {
-    display: flex;
-    justify-content: space-between ;
-    background-color:$ui-02 ;
-    height: $spacing-10;
-    align-items: center;
-    padding:0 $spacing-05;
+  display: flex;
+  justify-content: space-between ;
+  background-color:$ui-02 ;
+  height: $spacing-10;
+  align-items: center;
+  padding:0 $spacing-05;
 }
+
 .metricsTitle {
-    @include carbon--type-style("productive-heading-03");
-    color: $ui-05;
+  @include carbon--type-style("productive-heading-03");
+  color: $ui-05;
 }

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/queue-metrics.resource.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/queue-metrics.resource.tsx
@@ -6,7 +6,7 @@ export function useMetrics() {
   const { data, error } = useSWR<{ data: { results: {} } }, Error>(`/ws/rest/v1/queue?`, openmrsFetch);
 
   return {
-    data: metrics ? metrics : null,
+    metrics: data ? metrics : null,
     isError: error,
     isLoading: !data && !error,
   };

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -4,6 +4,7 @@
   "home": "Home",
   "minutes": "Minutes",
   "moreMetrics": "See more metrics",
+  "outpatients": "Outpatients",
   "patientList": "Patient list",
   "patients": "Patients",
   "scheduledAppointments": "Scheduled appts. today",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

These include:

- Making the metrics card wrap over on smaller viewports.
- Adding a bottom border to the outpatients' header.
- Renaming the main heading from `Patients` to `Outpatients`.

## Screenshots

> BEFORE (desktop)
<img width="1140" alt="Screenshot 2022-02-08 at 22 01 47" src="https://user-images.githubusercontent.com/8509731/153057294-5f60a37b-e04a-4ab4-8705-3a3a2e3e45f4.png">

> Tablet 
<img width="624" alt="Screenshot 2022-02-08 at 22 01 35" src="https://user-images.githubusercontent.com/8509731/153057374-549b7aec-94ce-4555-adaa-92e857e3b1e8.png">

> AFTER (desktop)
<img width="1440" alt="Screenshot 2022-02-08 at 22 01 07" src="https://user-images.githubusercontent.com/8509731/153057515-82e879aa-6b90-4eeb-876e-2af800f3ef18.png">

> Tablet
<img width="959" alt="Screenshot 2022-02-08 at 21 50 18" src="https://user-images.githubusercontent.com/8509731/153056894-454ed229-cac3-45ca-a287-43f4f9638d2b.png">