### PR TITLE
fix: Remove the mockAutoGenerationOptionsResult from the production code

### DIFF
--- a/packages/esm-patient-registration-app/src/offline.resources.ts
+++ b/packages/esm-patient-registration-app/src/offline.resources.ts
@@ -4,7 +4,6 @@ import camelCase from 'lodash-es/camelCase';
 import escapeRegExp from 'lodash-es/escapeRegExp';
 import { FetchResponse, messageOmrsServiceWorker, openmrsFetch, SessionUser } from '@openmrs/esm-framework';
 import { PatientIdentifierType, FetchedPatientIdentifierType } from './patient-registration/patient-registration-types';
-import { mockAutoGenerationOptionsResult } from '../__mocks__/autogenerationoptions.mock';
 import { cacheForOfflineHeaders } from './constants';
 
 export interface Resources {
@@ -50,11 +49,11 @@ export async function fetchPatientIdentifierTypesWithSources(
   for (const identifierType of identifierTypes) {
     const [identifierSources, autoGenOptions] = await Promise.all([
       fetchIdentifierSources(identifierType.uuid, abortController),
-      fetchAutoGenerationOptions(identifierType.uuid, abortController),
+      fetchAutoGenerationOptions(abortController),
     ]);
 
     identifierType.identifierSources = identifierSources.data.results.map((source) => {
-      const option = find(autoGenOptions.results, { source: { uuid: source.uuid } });
+      const option = find(autoGenOptions.data.results, { source: { uuid: source.uuid } });
       source.autoGenerationOption = option;
       return source;
     });
@@ -130,12 +129,8 @@ async function fetchIdentifierSources(identifierType: string, abortController?: 
   );
 }
 
-function fetchAutoGenerationOptions(identifierType: string, abortController?: AbortController) {
-  // return openmrsFetch('/ws/rest/v1/idgen/autogenerationoption?v=full&identifierType=' + identifierType, {
-  //   signal: abortController.signal,
-  //   headers: cacheForOfflineHeaders,
-  // });‚
-  return Promise.resolve(mockAutoGenerationOptionsResult);
+async function fetchAutoGenerationOptions(abortController?: AbortController) {
+  return await cacheAndFetch(`/ws/rest/v1/idgen/autogenerationoption?v=full`, abortController);
 }
 
 async function cacheAndFetch(url: string, abortController?: AbortController) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Removes the use of `mockAutoGenerationOptionResult` and refactors things to use the actual API.

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
