### PR TITLE
fix: Provide missing patient UUID to queued offline actions.

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -71,6 +71,7 @@ export default class FormManager {
     await queueSynchronizationItem(patientRegistration, syncItem, {
       id: values.patientUuid,
       displayName: 'Patient registration',
+      patientUuid: syncItem.fhirPatient.id,
       dependencies: [],
     });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
When queuing up sync items, we can provide a patient UUID. This should be done whenever possible so that other UI compoenents, e.g. the offline actions table, can display the action's associated patient.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
