### PR TITLE
(feat): Active visits table improvements

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits-list/active-visits-list-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits-list/active-visits-list-table.component.tsx
@@ -125,10 +125,15 @@ const ActiveVisitsListTable: React.FC = () => {
               {t('addPatientList', 'Add patient to list')}
             </Button>
           </div>
-          <DataTable rows={tableRows} headers={headerData} isSortable overflowMenuOnHover={isDesktop ? true : false}>
+          <DataTable
+            rows={tableRows}
+            headers={headerData}
+            size={tableSize}
+            overflowMenuOnHover={isDesktop ? true : false}
+            useZebraStyles>
             {({ rows, headers, getHeaderProps, getTableProps, getRowProps }) => (
               <TableContainer className={styles.tableContainer}>
-                <Table {...getTableProps()} className={styles.activeVisitsTable} size={tableSize}>
+                <Table {...getTableProps()} className={styles.activeVisitsTable}>
                   <TableHead>
                     <TableRow>
                       <TableExpandHeader />
@@ -139,8 +144,8 @@ const ActiveVisitsListTable: React.FC = () => {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {rows.map((row, index) => (
-                      <React.Fragment key={index}>
+                    {rows.map((row, i) => (
+                      <React.Fragment key={row.id}>
                         <TableExpandRow {...getRowProps({ row })}>
                           {row.cells.map((cell) => (
                             <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
@@ -153,7 +158,9 @@ const ActiveVisitsListTable: React.FC = () => {
                           <TableExpandedRow
                             className={styles.expandedActiveVisitRow}
                             colSpan={headers.length + 2}></TableExpandedRow>
-                        ) : null}
+                        ) : (
+                          <div />
+                        )}
                       </React.Fragment>
                     ))}
                   </TableBody>

--- a/packages/esm-outpatient-app/src/active-visits-list/active-visits-list-table.scss
+++ b/packages/esm-outpatient-app/src/active-visits-list/active-visits-list-table.scss
@@ -1,4 +1,3 @@
-
 @import "~@openmrs/esm-styleguide/src/vars";
 @import "~carbon-components/src/globals/scss/vars";
 @import "~carbon-components/src/globals/scss/mixins";
@@ -78,14 +77,6 @@
   align-items: center;
 }
 
-.activeVisitsTable tr[data-parent-row]:nth-child(odd) td {
-  background-color: $ui-02;
-}
-
-.activeVisitsTable tbody tr[data-parent-row]:nth-child(even) td {
-  background-color: $ui-01;
-}
-
 .activeVisitsTable tr:last-of-type {
   td {
     border-bottom: none;
@@ -148,8 +139,8 @@
     content: "";
     display: block;
     width: 2rem;
-    padding-top: 0.188rem;
-    border-bottom: 0.375rem solid $brand-teal-01;
+    padding-top: 3px;
+    border-bottom: 0.375rem solid var(--brand-03);
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Minor improvements to the active visits table that include:

- Adding the `useZebraStyles` prop to the DataTable component. With this, we're able to rely on Carbon to provide zebra styling for table rows. This is preferable to the custom zebra styling implementation we had going.
- Move the dynamic table `size` prop to the DataTable component definition.
- Leverage configurable branding colour tokens.

These changes do not change the functionality of this widget in any way.