### PR TITLE
(feat): Enhancements to the active visits widget datatable

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -42,7 +42,7 @@ const ActiveVisitsTable = () => {
   const { t } = useTranslation();
   const config = useConfig();
   const layout = useLayoutType();
-  const { data: activeVisits, isError, isLoading, isValidating } = useActiveVisits();
+  const { activeVisits, isError, isLoading, isValidating } = useActiveVisits();
   const desktopView = layout === 'desktop';
   const pageSizes = config?.activeVisits?.pageSizes ?? [10, 20, 30, 40, 50];
   const [currentPageSize, setPageSize] = useState(config?.activeVisits?.pageSize ?? 10);
@@ -126,14 +126,20 @@ const ActiveVisitsTable = () => {
     return (
       <div className={styles.activeVisitsContainer}>
         <div className={styles.activeVisitsDetailHeaderContainer}>
-          <h4 className={styles.productiveHeading02}>{t('activeVisits', 'Active Visits')}</h4>
+          <div className={!desktopView ? styles.tabletHeading : styles.desktopHeading}>
+            <h4>{t('activeVisits', 'Active Visits')}</h4>
+          </div>
           <div className={styles.backgroundDataFetchingIndicator}>
             <span>{isValidating ? <InlineLoading /> : null}</span>
           </div>
         </div>
-        <DataTable rows={paginatedActiveVisits} headers={headerData} isSortable>
+        <DataTable
+          rows={paginatedActiveVisits}
+          headers={headerData}
+          size={desktopView ? 'compact' : 'normal'}
+          useZebraStyles>
           {({ rows, headers, getHeaderProps, getTableProps, getBatchActionProps, getRowProps }) => (
-            <TableContainer title="" className={styles.tableContainer}>
+            <TableContainer className={styles.tableContainer}>
               <TableToolbar>
                 <TableToolbarContent>
                   <Search
@@ -144,7 +150,7 @@ const ActiveVisitsTable = () => {
                   />
                 </TableToolbarContent>
               </TableToolbar>
-              <Table className={styles.activeVisitsTable} {...getTableProps()} size={desktopView ? 'short' : 'normal'}>
+              <Table className={styles.activeVisitsTable} {...getTableProps()}>
                 <TableHead>
                   <TableRow>
                     <TableExpandHeader />
@@ -170,7 +176,7 @@ const ActiveVisitsTable = () => {
                           </TableCell>
                         ))}
                       </TableExpandRow>
-                      {row.isExpanded && (
+                      {row.isExpanded ? (
                         <TableRow className={styles.expandedActiveVisitRow}>
                           <th colSpan={headers.length + 2}>
                             <ExtensionSlot
@@ -183,6 +189,8 @@ const ActiveVisitsTable = () => {
                             />
                           </th>
                         </TableRow>
+                      ) : (
+                        <div />
                       )}
                     </React.Fragment>
                   ))}

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -46,7 +46,7 @@ export function useActiveVisits() {
   const formattedActiveVisits = data?.data?.results.length ? data.data.results.map(mapVisitProperties) : [];
 
   return {
-    data: formattedActiveVisits,
+    activeVisits: formattedActiveVisits,
     isLoading: !data && !error,
     isError: error,
     isValidating,

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.scss
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.scss
@@ -23,14 +23,6 @@
   justify-content: center;
 }
 
-.productiveHeading02::after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid #007d79;
-}
-
 .tableContainer section{
   position: relative;
 }
@@ -47,14 +39,6 @@
   padding: 0 1rem;
   display: flex;
   align-items: center;
-}
-
-.activeVisitsTable tr[data-parent-row]:nth-child(odd) td {
-  background-color: #ffffff;
-}
-
-.activeVisitsTable  tbody  tr[data-parent-row]:nth-child(even)  td {
-  background-color: #f4f4f4;
 }
 
 .visitSummaryContainer {
@@ -109,17 +93,9 @@
     content: "";
     display: block;
     width: 2rem;
-    padding-top: 0.188rem;
+    padding-top: 3px;
     border-bottom: 0.375rem solid $brand-teal-01;
   }
-}
-
-.heading:after {
-  content: "";
-  display: block;
-  width: 2rem;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
 }
 
 .tile {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Minor improvements to the active visits widget that include:

- Adding the useZebraStyles prop to the DataTable component. With this, we're able to rely on Carbon to provide zebra styling for table rows. This is preferable to the custom zebra styling implementation we had going.
- Move the dynamic table size prop to the DataTable component definition.

## Screenshots

> Tablet mode

<img width="936" alt="Screenshot 2022-02-16 at 00 29 12" src="https://user-images.githubusercontent.com/8509731/154152947-998eea51-9202-4469-8750-38e1164132e2.png">

> Desktop mode

<img width="1235" alt="Screenshot 2022-02-16 at 00 29 23" src="https://user-images.githubusercontent.com/8509731/154152996-0cce7bea-ae9a-49d3-83a3-cd9f74b556f4.png">

