### PR TITLE
03-767 Fix global nav icons partially being hidden

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.scss
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.scss
@@ -4,7 +4,6 @@ $inverse-02:#393939;
 
 .patientSearchIconWrapper {
   display: flex;
-  width: 50vw;
   justify-content: flex-end;
   align-items: center;
 }
@@ -23,6 +22,7 @@ $inverse-02:#393939;
   border: $spacing-01 solid var(--omrs-color-brand-orange);
   height: calc($spacing-08 - 0.25rem);
   margin-right: $spacing-01;
+  width: 50vw;
 }
 
 // tablet mode styling


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Fix hiding of the `app-switcher` from the global nav bar when the screen size is tablet mode


## Screenshots
## bug
![bug-search](https://user-images.githubusercontent.com/28008754/157184223-08b02f21-acd8-4a0d-ab4a-28d637972252.gif)


## fix
![fix-search](https://user-images.githubusercontent.com/28008754/157184198-531ab1fb-459f-428d-bf76-ed7cac9c52dc.gif)


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
