### PR TITLE
(feat) Enhancements to the active visits table

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Button,
   ContentSwitcher,
@@ -24,21 +25,20 @@ import {
 } from 'carbon-components-react';
 import Add16 from '@carbon/icons-react/es/add/16';
 import { useLayoutType, ConfigurableLink } from '@openmrs/esm-framework';
-import { useTranslation } from 'react-i18next';
-import { useActiveVisits } from '../patient-queue-metrics/queue-metrics.resource';
-import styles from './active-visits-list-table.scss';
 import PatientSearch from '../patient-search/patient-search.component';
+import { useActiveVisits } from './active-visits-table.resource';
+import styles from './active-visits-table.scss';
 
 enum tableSizes {
   DEFAULT = 0,
   LARGE = 1,
 }
 
-const ActiveVisitsListTable: React.FC = () => {
+const ActiveVisitsTable: React.FC = () => {
   const { t } = useTranslation();
-  const { activeVisits, isError, isLoading, isValidating } = useActiveVisits();
+  const { activeVisits, isLoading } = useActiveVisits();
   const [contentSwitcherValue, setContentSwitcherValue] = useState(0);
-  const [tableSize, setTableSize] = useState<DataTableSize>('sm');
+  const [tableSize, setTableSize] = useState<DataTableSize>('compact');
   const isDesktop = useLayoutType() === 'desktop';
   const [showOverlay, setShowOverlay] = useState(false);
 
@@ -90,22 +90,33 @@ const ActiveVisitsListTable: React.FC = () => {
   const tableRows = useMemo(() => {
     return activeVisits?.map((visit) => ({
       ...visit,
+      id: visit.uuid,
       priority: {
         content: (
-          <TooltipDefinition
-            align="start"
-            direction="bottom"
-            className={styles.priorityTooltip}
-            tooltipText={<div className={styles.priorityTooltip}>{visit?.notes}</div>}>
-            <Tag className={visit.priority === 'Priority' ? styles.priorityTag : ''} type={getTagType(visit?.priority)}>
-              {visit.priority}
-            </Tag>
-          </TooltipDefinition>
+          <>
+            {visit?.note ? (
+              <TooltipDefinition className={styles.tooltip} align="start" direction="bottom" tooltipText={visit.note}>
+                <Tag
+                  className={visit.priority === 'Priority' ? styles.priorityTag : ''}
+                  type={getTagType(visit?.priority)}>
+                  {visit.priority}
+                </Tag>
+              </TooltipDefinition>
+            ) : (
+              <Tag
+                className={visit.priority === 'Priority' ? styles.priorityTag : ''}
+                type={getTagType(visit?.priority)}>
+                {visit.priority}
+              </Tag>
+            )}
+          </>
         ),
       },
       name: {
         // TODO: Interpolate patient uuid into URL
-        content: <ConfigurableLink to={`\${openmrsSpaBase}/patient/${visit.id}/chart`}>{visit.name}</ConfigurableLink>,
+        content: (
+          <ConfigurableLink to={`\${openmrsSpaBase}/patient/${visit.uuid}/chart`}>{visit.name}</ConfigurableLink>
+        ),
       },
     }));
   }, [activeVisits]);
@@ -113,11 +124,12 @@ const ActiveVisitsListTable: React.FC = () => {
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" />;
   }
+
   if (activeVisits?.length) {
     return (
       <div className={styles.container} data-floating-menu-container>
-        <div className={styles.activeVisitsListContainer}>
-          <div className={styles.activeVisitsListHeaderContainer}>
+        <div className={styles.activeVisitsTableContainer}>
+          <div className={styles.activeVisitsTableHeaderContainer}>
             <label className={styles.heading}>{t('activeVisits', 'Active visits')}</label>
             <div className={styles.switcherContainer}>
               <label className={styles.contentSwitcherLabel}>{t('view', 'View:')} </label>
@@ -183,9 +195,10 @@ const ActiveVisitsListTable: React.FC = () => {
       </div>
     );
   }
+
   return (
-    <div className={styles.activeVisitsListContainer}>
-      <div className={styles.activeVisitsListHeaderContainer}>
+    <div className={styles.activeVisitsTableContainer}>
+      <div className={styles.activeVisitsTableHeaderContainer}>
         <label className={styles.heading}>{t('activeVisits', 'Active visits')}</label>
         <Button
           size="small"
@@ -207,7 +220,7 @@ const ActiveVisitsListTable: React.FC = () => {
   );
 };
 
-export default ActiveVisitsListTable;
+export default ActiveVisitsTable;
 
 function ActionsMenu() {
   const { t } = useTranslation();

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -94,8 +94,12 @@ const ActiveVisitsTable: React.FC = () => {
       priority: {
         content: (
           <>
-            {visit?.note ? (
-              <TooltipDefinition className={styles.tooltip} align="start" direction="bottom" tooltipText={visit.note}>
+            {visit?.priorityComment ? (
+              <TooltipDefinition
+                className={styles.tooltip}
+                align="start"
+                direction="bottom"
+                tooltipText={visit.priorityComment}>
                 <Tag
                   className={visit.priority === 'Priority' ? styles.priorityTag : ''}
                   type={getTagType(visit?.priority)}>

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
@@ -7,6 +7,7 @@ export interface ActiveVisit {
   name: string;
   patientUuid: string;
   priority: string;
+  priorityComment?: string;
   status: string;
   uuid: string;
   visitType: string;
@@ -37,6 +38,7 @@ export function useActiveVisits() {
     name: visit?.patient?.person?.display,
     patientUuid: visit?.patient?.uuid,
     priority: '',
+    priorityComment: '',
     status: '',
     uuid: visit.uuid,
     visitType: visit?.visitType?.display,
@@ -49,7 +51,7 @@ export function useActiveVisits() {
     {
       name: 'John Test Otieno',
       priority: 'Emergency',
-      note: 'Patient is convulsing and unconscious',
+      priorityComment: 'Patient is convulsing and unconscious',
       status: 'Attending triage',
       waitTime: '10',
       uuid: '1',

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
@@ -1,0 +1,102 @@
+import dayjs from 'dayjs';
+import useSWR from 'swr';
+import { Visit, openmrsFetch, SessionUser } from '@openmrs/esm-framework';
+
+export interface ActiveVisit {
+  location: string;
+  name: string;
+  patientUuid: string;
+  priority: string;
+  status: string;
+  uuid: string;
+  visitType: string;
+  visitUuid: string;
+  waitTime: string;
+}
+
+export function useActiveVisits() {
+  const { data: currentUserSession } = useCurrentSession();
+  const sessionLocation = currentUserSession?.data?.sessionLocation?.uuid;
+  const startDate = dayjs().format('YYYY-MM-DD');
+
+  const customRepresentation =
+    'custom:(uuid,patient:(uuid,person:(age,display,gender,uuid)),' +
+    'visitType:(uuid,name,display),location:(uuid,name,display),startDatetime,' +
+    'stopDatetime)&fromStartDate=' +
+    startDate +
+    '&location=' +
+    sessionLocation;
+
+  const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
+    `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}`,
+    openmrsFetch,
+  );
+
+  const mapVisitProperties = (visit: Visit): ActiveVisit => ({
+    location: visit?.location?.uuid,
+    name: visit?.patient?.person?.display,
+    patientUuid: visit?.patient?.uuid,
+    priority: '',
+    status: '',
+    uuid: visit.uuid,
+    visitType: visit?.visitType?.display,
+    visitUuid: visit.uuid,
+    waitTime: '',
+  });
+
+  // Mock data
+  const activeVisitLists = [
+    {
+      name: 'John Test Otieno',
+      priority: 'Emergency',
+      note: 'Patient is convulsing and unconscious',
+      status: 'Attending triage',
+      waitTime: '10',
+      uuid: '1',
+    },
+    {
+      name: 'Kennedy Test Kennedy',
+      priority: 'Not urgent',
+      status: 'Waiting for clinical consultation',
+      waitTime: '30',
+      uuid: '2',
+    },
+    {
+      name: 'Mose Test Test',
+      priority: 'Not urgent',
+      status: 'Waiting for triage',
+      waitTime: '25',
+      uuid: '3',
+    },
+    {
+      name: 'Joo Joo',
+      priority: 'Not urgent',
+      status: 'Waiting for pharmacy',
+      waitTime: '11',
+      uuid: '4',
+    },
+    {
+      name: 'Alex Berezinsky Test',
+      priority: 'Not urgent',
+      status: 'Waiting for triage',
+      waitTime: '--',
+      uuid: '5',
+    },
+  ];
+
+  return {
+    activeVisits: activeVisitLists,
+    isLoading: !data && !error,
+    isError: error,
+    isValidating,
+  };
+}
+
+export function useCurrentSession() {
+  const { data, error } = useSWR<{ data: SessionUser }, Error>(`/ws/rest/v1/session`, openmrsFetch);
+
+  return {
+    data: data ? data : null,
+    isError: error,
+  };
+}

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
@@ -7,12 +7,12 @@
   background-color: $ui-01;
 }
 
-.activeVisitsListContainer {
+.activeVisitsTableContainer {
   width: 100%;
   height: 100%;
 }
 
-.activeVisitsListHeaderContainer {
+.activeVisitsTableHeaderContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -37,6 +37,10 @@
 .switch {
    width: 7.875rem;
    height: 2rem;
+}
+
+.tooltip :global(.bx--tooltip__trigger.bx--tooltip__trigger--definition) {
+  border-bottom: none;
 }
 
 .priorityTag {
@@ -143,13 +147,3 @@
     border-bottom: 0.375rem solid var(--brand-03);
   }
 }
-
-.priorityTooltip {
-  @include carbon--type-style("body-short-02");
-  padding: 0.25rem; 
-}
-
-:global(.bx--tooltip--definition .bx--tooltip__trigger){
-  border-bottom: none;
-}
-

--- a/packages/esm-outpatient-app/src/home.component.tsx
+++ b/packages/esm-outpatient-app/src/home.component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ActiveVisitsListTable from './active-visits-list/active-visits-list-table.component';
+import ActiveVisitsTable from './active-visits/active-visits-table.component';
 import PatientQueueHeader from './patient-queue-header/patient-queue-header.component';
 import ClinicMetrics from './patient-queue-metrics/clinic-metrics.component';
 
@@ -10,7 +10,7 @@ const Home: React.FC<HomeProps> = () => {
     <div>
       <PatientQueueHeader />
       <ClinicMetrics />
-      <ActiveVisitsListTable />
+      <ActiveVisitsTable />
     </div>
   );
 };

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/queue-metrics.resource.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/queue-metrics.resource.tsx
@@ -1,6 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch, Visit, SessionUser } from '@openmrs/esm-framework';
-import dayjs from 'dayjs';
+import { openmrsFetch } from '@openmrs/esm-framework';
 
 export function useMetrics() {
   const metrics = { scheduled_appointments: 100, average_wait_time: 28, patients_waiting_for_service: 182 };
@@ -10,98 +9,5 @@ export function useMetrics() {
     metrics: metrics,
     isError: error,
     isLoading: !data && !error,
-  };
-}
-export interface ActiveVisit {
-  id: string;
-  priority: string;
-  status: string;
-  location: string;
-  name: string;
-  patientUuid: string;
-  waitTime: string;
-  visitType: string;
-  visitUuid: string;
-}
-
-export function useActiveVisits() {
-  const { data: currentUserSession } = useCurrentSession();
-  const sessionLocation = currentUserSession?.data?.sessionLocation?.uuid;
-  const startDate = dayjs().format('YYYY-MM-DD');
-
-  const customRepresentation =
-    'custom:(uuid,patient:(uuid,person:(age,display,gender,uuid)),' +
-    'visitType:(uuid,name,display),location:(uuid,name,display),startDatetime,' +
-    'stopDatetime)&fromStartDate=' +
-    startDate +
-    '&location=' +
-    sessionLocation;
-
-  const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
-    `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}`,
-    openmrsFetch,
-  );
-
-  const mapVisitProperties = (visit: Visit): ActiveVisit => ({
-    id: visit.uuid,
-    location: visit?.location?.uuid,
-    name: visit?.patient?.person?.display,
-    patientUuid: visit?.patient?.uuid,
-    visitType: visit?.visitType?.display,
-    visitUuid: visit.uuid,
-    priority: '',
-    waitTime: '',
-    status: '',
-  });
-
-  // mocked data for active visit list
-  const activeVisitLists = [
-    {
-      name: 'John Test Otieno',
-      priority: 'Emergency',
-      notes: 'Patient is convulsing and unconscious',
-      status: 'Triage',
-      waitTime: '20',
-      id: '1',
-    },
-    {
-      name: 'Kennedy Test Kennedy',
-      priority: 'Priority',
-      status: 'Consultation',
-      waitTime: '30',
-      id: '2',
-    },
-    {
-      name: 'Mose Test Test',
-      priority: 'Not urgent',
-      status: 'Pharmacy',
-      waitTime: '25',
-      id: '3',
-    },
-    {
-      name: 'Joo Joo',
-      priority: 'Not urgent',
-      status: 'Pharmacy',
-      waitTime: '11',
-      id: '4',
-    },
-  ];
-
-  const formattedActiveVisits = data?.data?.results.length ? data.data.results.map(mapVisitProperties) : [];
-
-  return {
-    activeVisits: activeVisitLists,
-    isLoading: !data && !error,
-    isError: error,
-    isValidating,
-  };
-}
-
-export function useCurrentSession() {
-  const { data, error } = useSWR<{ data: SessionUser }, Error>(`/ws/rest/v1/session`, openmrsFetch);
-
-  return {
-    data: data ? data : null,
-    isError: error,
   };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR makes the following improvements to the active visits table:

- Renames the `ActiveVisitsListTable` component to `ActiveVisitsTable`.
- Moves data fetching logic from the `QueueMetrics` resource to a new `ActiveVisitsTable` resource. There isn't sufficient overlap or code reuse to merit keeping those concerns in a shared resource.
- Changes the default table size from `sm` to `compact`.
- Alters the logic that determines when to show a tooltip when a user hovers over a priority tag. Presently, it shows a tooltip even when the tooltip text is unavailable. 


## Screenshots

> Compact table 

![Screenshot 2022-03-08 at 12 26 57](https://user-images.githubusercontent.com/8509731/157208057-2c67874d-ee95-48bc-aa02-2f7dbfa81fee.png)

> Large table

![Screenshot 2022-03-08 at 12 27 23](https://user-images.githubusercontent.com/8509731/157208092-89d7e8c0-9da5-4549-916f-751cc8d2983c.png)

> Tooltip shown on hover when a note is present

![Screenshot 2022-03-08 at 12 27 10](https://user-images.githubusercontent.com/8509731/157208122-eda08aef-a413-4ebe-b2b8-c5987546d6c2.png)

