### PR TITLE
(chore): Fix deprecated Prettier config option

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -5,5 +5,5 @@ module.exports = {
   bracketSpacing: true,
   parser: 'typescript',
   semi: true,
-  jsxBracketSameLine: true,
+  bracketSameLine: true,
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR replaces [deprecated](https://prettier.io/docs/en/options.html#deprecated-jsx-brackets) `jsxBracketSameLine` option with `bracketSameLine`.

## Screenshots

![Screenshot 2022-03-08 at 14 32 37](https://user-images.githubusercontent.com/8509731/157230987-4a303145-981d-4d24-a97d-72681a7eaed3.png)

