### PR TITLE
(feat): Minor tweaks to the active visits table

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -100,16 +100,12 @@ const ActiveVisitsTable: React.FC = () => {
                 align="start"
                 direction="bottom"
                 tooltipText={visit.priorityComment}>
-                <Tag
-                  className={visit.priority === 'Priority' ? styles.priorityTag : ''}
-                  type={getTagType(visit?.priority)}>
+                <Tag className={styles.tag} type={getTagType(visit?.priority)}>
                   {visit.priority}
                 </Tag>
               </TooltipDefinition>
             ) : (
-              <Tag
-                className={visit.priority === 'Priority' ? styles.priorityTag : ''}
-                type={getTagType(visit?.priority)}>
+              <Tag className={styles.tag} type={getTagType(visit?.priority)}>
                 {visit.priority}
               </Tag>
             )}
@@ -181,11 +177,9 @@ const ActiveVisitsTable: React.FC = () => {
                           </TableCell>
                         </TableExpandRow>
                         {row.isExpanded ? (
-                          <TableExpandedRow
-                            className={styles.expandedActiveVisitRow}
-                            colSpan={headers.length + 2}></TableExpandedRow>
+                          <TableExpandedRow className={styles.expandedActiveVisitRow} colSpan={headers.length + 2} />
                         ) : (
-                          <div />
+                          <TableExpandedRow className={styles.hiddenRow} colSpan={headers.length + 2} />
                         )}
                       </React.Fragment>
                     ))}

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
@@ -43,14 +43,8 @@
   border-bottom: none;
 }
 
-.priorityTag {
-  @include carbon--type-style("label-01");
-   color: #943d00;
-   background-color: #ffc9a3;
-}
-
 .tag {
-  @include carbon--type-style("label-01");
+  margin: 0.25rem 0;
 }
 
 .backgroundDataFetchingIndicator {
@@ -97,6 +91,10 @@
 
 .expandedActiveVisitRow th[colspan] td[colspan] > div:first-child {
   padding: 0 1rem;
+}
+
+.hiddenRow {
+  display: none;
 }
 
 .content {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

These include:

- Removing some unnecessary tag styling.
- Fixing a `validateDOMNesting` warning because of using a <div> as a child of <tbody>. `<tbody>` only permits table rows as children.

## Screenshots

![Screenshot 2022-03-09 at 11 34 05](https://user-images.githubusercontent.com/8509731/157405897-36df8b29-c61f-434e-a815-96d7cfee7f54.png)
