### PR TITLE
(feat): Fetch and render visit queue entries from the backend

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
@@ -152,3 +152,12 @@
     border-bottom: 0.375rem solid var(--brand-03);
   }
 }
+
+.statusContainer {
+  display: flex;
+  align-items: center;
+
+  svg {
+    margin-right: 0.5rem;
+  }
+}

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.test.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { openmrsFetch } from '@openmrs/esm-framework';
+import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
+import ActiveVisitsTable from './active-visits-table.component';
+import userEvent from '@testing-library/user-event';
+
+const mockOpenmrsFetch = openmrsFetch as jest.Mock;
+
+const mockVisitQueueEntries = [
+  {
+    uuid: 'fa1e98f1-f002-4174-9e55-34d60951e710',
+    visit: {
+      uuid: 'c90386ff-ae85-45cc-8a01-25852099c5ae',
+      display: 'Facility Visit @ Outpatient Clinic - 04/03/2022 07:22',
+    },
+    queueEntry: {
+      uuid: '712289ab-32c0-430f-87b6-d9c1e4e4686e',
+      display: 'Eric Test Ric',
+      priorityComment: 'Needs Triage',
+      sortWeight: 0,
+      startedAt: '2022-03-04T09:50:54.000+0000',
+      endedAt: null,
+      queue: {
+        uuid: '6a97bd65-3a9a-4fab-ae8f-be59dd4ddd87',
+        display: 'TRIAGE QUEUE',
+        name: 'TRIAGE QUEUE',
+        description: 'Queue for patients waiting for triage',
+        service: {
+          display: 'Triage',
+        },
+      },
+      status: {
+        uuid: 'aaec62b1-4b03-4166-ada7-230cb4b4aaaa',
+        display: 'Waiting',
+        links: [
+          {
+            rel: 'self',
+            uri: 'http://openmrs:8080/openmrs/ws/rest/v1/concept/aaec62b1-4b03-4166-ada7-230cb4b4aaaa',
+          },
+        ],
+      },
+      patient: {
+        uuid: 'cc75ad73-c24b-499c-8db9-a7ef4fc0b36d',
+        display: '10000F1 - Eric Test Ric',
+      },
+      priority: {
+        uuid: 'f9684018-a4d3-4d6f-9dd5-b4b1e89af3e7',
+        display: 'Not Urgent',
+      },
+      locationWaitingFor: null,
+      providerWaitingFor: null,
+    },
+  },
+  {
+    uuid: '2f85d611-5bb9-4bca-b6f8-661517df86c9',
+    visit: {
+      uuid: '6b3e233d-2b44-40ca-b0c8-c5a57a8c51b6',
+      display: 'Home Visit @ Outpatient Clinic - 09/03/2022 21:08',
+    },
+    queueEntry: {
+      uuid: '5f017eb0-b035-4acd-b284-da45f5067502',
+      display: 'John Smith',
+      priorityComment: 'Needs immediate assistance',
+      sortWeight: 0,
+      startedAt: '2022-03-09T13:50:54.000+0000',
+      endedAt: null,
+      queue: {
+        uuid: 'c187d78b-5c54-49bf-a0f8-b7fb6034d36d',
+        display: 'Consultation queue',
+        name: 'Consultation queue',
+        description: 'A queue for patients for a clincal consultation i.e. Doctor, Clinician',
+        service: {
+          display: 'Clinical Consultation',
+        },
+      },
+      status: {
+        uuid: 'aaec62b1-4b03-4166-ada7-230cb4b4aaaa',
+        display: 'Waiting',
+      },
+      patient: {
+        uuid: '53568469-f652-470d-95e8-13131914286b',
+        display: '10000JT - John Smith',
+      },
+      priority: {
+        uuid: 'b6a84ad0-c5e6-4a37-896e-5b7a0bccfd6c',
+        display: 'Emergency',
+      },
+      locationWaitingFor: null,
+      providerWaitingFor: null,
+    },
+  },
+];
+
+describe('ActiveVisitsTable: ', () => {
+  it('renders an empty state view if visit data is unavailable', async () => {
+    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
+
+    renderActiveVisitsTable();
+
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByText(/active visits/i)).toBeInTheDocument();
+    expect(screen.getByText(/no patients to display/i)).toBeInTheDocument();
+  });
+
+  it('renders a tabular overview of visit queue entry data when available', async () => {
+    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: mockVisitQueueEntries } });
+
+    renderActiveVisitsTable();
+
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByText(/active visits/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no patients to display/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+
+    const defaultViewButton = screen.getByRole('tab', { name: /default/i });
+    const largeViewButton = screen.getByRole('tab', { name: /large/i });
+
+    expect(defaultViewButton).toBeInTheDocument();
+    expect(largeViewButton).toBeInTheDocument();
+    expect(defaultViewButton).toHaveAttribute('aria-selected', 'true');
+
+    userEvent.click(largeViewButton);
+    expect(largeViewButton).toHaveAttribute('aria-selected', 'true');
+
+    expect(screen.getByRole('link', { name: /eric test ric/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /john smith/i })).toBeInTheDocument();
+    expect(screen.getByRole('tooltip', { name: /needs triage/i })).toBeInTheDocument();
+    expect(screen.getByRole('tooltip', { name: /needs immediate assistance/i })).toBeInTheDocument();
+
+    const expectedColumnHeaders = [/name/, /priority/, /status/, /wait time \(mins\)/];
+    expectedColumnHeaders.forEach((header) => {
+      expect(screen.getByRole('columnheader', { name: new RegExp(header, 'i') })).toBeInTheDocument();
+    });
+
+    const expectedTableRows = [
+      /Eric Test Ric Not Urgent Needs Triage Waiting/,
+      /John Smith Emergency Needs immediate assistance Waiting/,
+    ];
+    expectedTableRows.forEach((row) => {
+      expect(screen.getByRole('row', { name: new RegExp(row, 'i') })).toBeInTheDocument();
+    });
+  });
+});
+
+function renderActiveVisitsTable() {
+  swrRender(<ActiveVisitsTable />);
+}

--- a/tools/setupTests.ts
+++ b/tools/setupTests.ts
@@ -1,1 +1,13 @@
 import '@testing-library/jest-dom/extend-expect';
+
+declare global {
+  interface Window {
+    openmrsBase: string;
+    spaBase: string;
+  }
+}
+
+window.openmrsBase = '/openmrs';
+window.spaBase = '/spa';
+window.getOpenmrsSpaBase = () => '/openmrs/spa/';
+window.HTMLElement.prototype.scrollIntoView = jest.fn();

--- a/tools/test-helpers.tsx
+++ b/tools/test-helpers.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { SWRConfig } from 'swr';
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+
+const swrWrapper = ({ children }) => {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 0,
+        provider: () => new Map(),
+      }}>
+      {children}
+    </SWRConfig>
+  );
+};
+
+export const swrRender = (ui, options?) => render(ui, { wrapper: swrWrapper, ...options });
+
+export function waitForLoadingToFinish() {
+  return waitForElementToBeRemoved(() => [...screen.queryAllByRole(/progressbar/i)], {
+    timeout: 4000,
+  });
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR makes the following improvements to the Active Visits table:

- Adds data fetching logic to the `ActiveVisitsTable` resource.
- Makes the necessary modifications to the UI to get it working with data from the backend.
- Adds tests.

## Screenshots

![Screenshot 2022-03-09 at 21 17 32](https://user-images.githubusercontent.com/8509731/157506455-59da8f22-db59-4a86-b7dc-5c6c116ddbcd.png)
