### PR TITLE
Display active visit for the current date

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -43,7 +43,9 @@ export function useActiveVisits() {
     visitUuid: visit.uuid,
   });
 
-  const formattedActiveVisits = data?.data?.results.length ? data.data.results.map(mapVisitProperties) : [];
+  const formattedActiveVisits = data?.data?.results.length
+    ? data.data.results.map(mapVisitProperties).filter(({ visitStartTime }) => dayjs(visitStartTime).isToday())
+    : [];
 
   return {
     activeVisits: formattedActiveVisits,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Due to clinical testing clinical are interested in viewing current visits filtered to the current date, this PR updates active visits to show only visit with the current date. 


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
