### PR TITLE
(fix) Fix appearance of search overlay separator text

### DIFF
--- a/packages/esm-outpatient-app/src/patient-search/basic-search.scss
+++ b/packages/esm-outpatient-app/src/patient-search/basic-search.scss
@@ -60,6 +60,7 @@
     border: 0;
     border-top: 1px solid $text-03;
     text-align: center;
+    overflow: visible;
     
     &::after {
       content: 'or';


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR fixes an issue in the basic search overlay component where some text gets cut off by a horizontal rule.


## Screenshots

> Before

![Screenshot 2022-03-14 at 11 56 59](https://user-images.githubusercontent.com/8509731/158138270-bb024374-ae3e-4e50-bcd2-2346034c472a.png)

> After

![Screenshot 2022-03-14 at 11 55 27](https://user-images.githubusercontent.com/8509731/158138285-f8da11cf-0d59-4d7a-a729-81f39966868a.png)

