### PR TITLE
(feat) Adjust height of search overlay

### DIFF
--- a/packages/esm-outpatient-app/src/overlay.component.tsx
+++ b/packages/esm-outpatient-app/src/overlay.component.tsx
@@ -29,7 +29,7 @@ const Overlay: React.FC<OverlayProps> = ({ closePanel, children, header }) => {
           <div className={styles.headerContent}>{header}</div>
         </Header>
       )}
-      <div className={styles.overlayContent}>{children}</div>
+      <div>{children}</div>
     </div>
   );
 };

--- a/packages/esm-outpatient-app/src/overlay.scss
+++ b/packages/esm-outpatient-app/src/overlay.scss
@@ -3,18 +3,11 @@
 .desktopOverlay {
   position: absolute;
   top: $spacing-09;
-  height: calc(100vh - 6rem);
   width: 37rem;
   right: 0;
   bottom: 0;
   border-left: 1px solid $text-03;
   background-color: $ui-01;
-  height: 100vh;
-}
-
-.desktopOverlay::after {
-  height: 100%;
-  border-left: 1px solid $text-03;
 }
 
 .tabletOverlay {
@@ -61,7 +54,3 @@
   fill: $ui-05;
 }
 
-.overlayContent {
-  padding: 0 0 $spacing-05 0;
-  overflow-y: auto;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR adjusts the height of the search overlay panel so it fits the viewport and its content does not overflow unnecessarily.

## Screenshots

https://user-images.githubusercontent.com/8509731/158165491-29c890f6-f123-404a-94ff-601638ac385d.mp4