### PR TITLE
(doc-fix) remove '/apps' from readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npx lerna bootstrap
 To develop on a specific package e.g [@openmrs/esm-patient-search-app](packages/esm-patient-search-app)
 
 ```sh
-npx openmrs develop --sources 'packages/apps/esm-patient-search-app'
+npx openmrs develop --sources 'packages/esm-patient-search-app'
 ```
 
 You can always use regex


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
there is no **apps** directory in project structure hence the command `npx openmrs develop --sources 'packages/apps/esm-patient-search-app'`  fails for many of us who copy paste commands from the readme

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
![apps abscent](https://user-images.githubusercontent.com/58003327/159725537-28bf9be2-d050-4048-b572-5669deea881c.jpg)


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
