### PR TITLE
(feat) Add empty state for filters on active visits table

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -348,6 +348,22 @@ function ActiveVisitsTable() {
                   })}
                 </TableBody>
               </Table>
+              {rows.length === 0 ? (
+                <div className={styles.tileContainer}>
+                  <Tile className={styles.tile}>
+                    <div className={styles.tileContent}>
+                      <p className={styles.content}>{t('noPatientsToDisplay', 'No patients to display')}</p>
+                      <p className={styles.helper}>{t('checkFilters', 'Check the filters above')}</p>
+                    </div>
+                    <span className={styles.separator}>
+                      <hr />
+                    </span>
+                    <Button kind="ghost" size="small" renderIcon={Add16} onClick={() => setShowOverlay(true)}>
+                      {t('addPatientToList', 'Add patient to list')}
+                    </Button>
+                  </Tile>
+                </div>
+              ) : null}
             </TableContainer>
           )}
         </DataTable>

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
@@ -123,7 +123,7 @@ export function useVisitQueueEntries(): UseVisitQueueEntries {
 
   const mapVisitQueueEntryProperties = (visitQueueEntry: VisitQueueEntry): MappedVisitQueueEntry => ({
     id: visitQueueEntry.queueEntry.uuid,
-    encounters: visitQueueEntry.visit.encounters.map(mapEncounterProperties),
+    encounters: visitQueueEntry.visit.encounters?.map(mapEncounterProperties),
     name: visitQueueEntry.queueEntry.display,
     patientUuid: visitQueueEntry.queueEntry.patient.uuid,
     // Map `Urgent` to `Priority` because it's easier to distinguish between tags named
@@ -138,9 +138,9 @@ export function useVisitQueueEntries(): UseVisitQueueEntries {
     waitTime: visitQueueEntry.queueEntry.startedAt
       ? `${dayjs().diff(dayjs(visitQueueEntry.queueEntry.startedAt), 'minutes')}`
       : '--',
-    visitStartDateTime: visitQueueEntry.visit.visitStartDateTime,
-    visitType: visitQueueEntry.visit.visitType.display,
-    visitUuid: visitQueueEntry.visit.uuid,
+    visitStartDateTime: visitQueueEntry.visit?.visitStartDateTime,
+    visitType: visitQueueEntry.visit?.visitType?.display,
+    visitUuid: visitQueueEntry.visit?.uuid,
   });
 
   const mappedVisitQueueEntries = data?.data?.results?.map(mapVisitQueueEntryProperties);

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
@@ -152,9 +152,40 @@
 }
 
 .content {
-  @include carbon--type-style("productive-heading-01");
+  @include carbon--type-style("productive-heading-02");
   color: $text-02;
   margin-bottom: 0.5rem;
+}
+
+.helper {
+  @include carbon--type-style('body-short-01');
+  color: $text-02;
+}
+
+.separator {
+  display: block;
+  margin: 3rem auto;
+
+  hr {
+    @include carbon--type-style('body-short-02');
+    color: $text-02;
+    width: 80%;
+    line-height: 1;
+    border: 0;
+    border-top: 1px solid $text-03;
+    text-align: center;
+    overflow: visible;
+    margin-bottom: -1rem;
+    
+    &::after {
+      content: 'or';
+      display: inline-block;
+      position: relative;
+      top: -0.7em;
+      padding: 0 1rem;
+      background: $ui-01;
+    }
+  }
 }
 
 .tileContainer {
@@ -166,6 +197,12 @@
 .tile {
   margin: auto;
   width: fit-content;
+}
+
+.tileContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .menuItem {

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.test.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.test.tsx
@@ -13,7 +13,7 @@ jest.mock('./active-visits-table.resource.ts', () => {
 
   return {
     ...originalModule,
-    useServiceMetadata: jest.fn().mockReturnValue({ services: mockServices }),
+    useServices: jest.fn().mockReturnValue({ services: mockServices }),
   };
 });
 
@@ -92,6 +92,15 @@ describe('ActiveVisitsTable: ', () => {
 
     expect(screen.getByText(/eric test ric/i)).toBeInTheDocument();
     expect(screen.queryByText(/john smith/i)).not.toBeInTheDocument();
+
+    userEvent.clear(searchbox);
+    userEvent.type(searchbox, 'gibberish');
+
+    expect(screen.queryByText(/eric test ric/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/john smith/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/no patients to display/i)).toBeInTheDocument();
+    expect(screen.getByText(/check the filters above/i)).toBeInTheDocument();
+    expect(screen.getByRole('separator')).toBeInTheDocument();
   });
 });
 

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -9,6 +9,7 @@
   "backToSimpleSearch": "Back to simple search",
   "cancel": "Cancel",
   "careType": "Type of Care",
+  "checkFilters": "Check the filters above",
   "clinicMetrics": "Clinic metrics",
   "currentVisit": "Current visit",
   "dateOfBirth": "Date of birth",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR adds an empty state to the outpatients' active visits table that is displayed when the search filter does not find any matching results.

[Zeplin screen](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/61bb8778389e746149d19220)

## Screenshots

> The empty state is shown when the search filter is engaged

<img width="1254" alt="Screenshot 2022-03-28 at 23 42 35" src="https://user-images.githubusercontent.com/8509731/160489726-540f1190-f670-4a7b-8979-5d0f41aff470.png">