### PR TITLE
(feat) Provide concept set UUIDs through config

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -98,14 +98,14 @@ function StatusIcon({ status }) {
 
 function ActiveVisitsTable() {
   const { t } = useTranslation();
-  const isDesktop = useLayoutType() === 'desktop';
-  const { visitQueueEntries, isLoading } = useVisitQueueEntries();
   const { services } = useServices();
+  const { visitQueueEntries, isLoading } = useVisitQueueEntries();
   const [contentSwitcherValue, setContentSwitcherValue] = useState<TableSize>(0);
   const [filteredRows, setFilteredRows] = useState<Array<MappedVisitQueueEntry>>([]);
   const [filter, setFilter] = useState('');
   const [tableSize, setTableSize] = useState<DataTableSize>('compact');
   const [showOverlay, setShowOverlay] = useState(false);
+  const isDesktop = useLayoutType() === 'desktop';
 
   useEffect(() => {
     if (contentSwitcherValue === 0) {

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import useSWR from 'swr';
 import useSWRImmutable from 'swr/immutable';
-import { FetchResponse, openmrsFetch, Visit } from '@openmrs/esm-framework';
+import { FetchResponse, openmrsFetch, useConfig, Visit } from '@openmrs/esm-framework';
 
 export type QueuePriority = 'Emergency' | 'Not Urgent' | 'Priority' | 'Urgent';
 export type MappedQueuePriority = Omit<QueuePriority, 'Urgent'>;
@@ -94,8 +94,11 @@ interface MappedEncounter extends Omit<Encounter, 'encounterType' | 'provider'> 
 }
 
 export function useServices() {
-  // TODO: Move to config file
-  const serviceConceptSetUuid = '330c0ec6-0ac7-4b86-9c70-29d76f0ae20a';
+  const config = useConfig();
+  const {
+    concepts: { serviceConceptSetUuid },
+  } = config;
+
   const apiUrl = `/ws/rest/v1/concept/${serviceConceptSetUuid}`;
   const { data } = useSWRImmutable<FetchResponse>(apiUrl, openmrsFetch);
 
@@ -123,7 +126,7 @@ export function useVisitQueueEntries(): UseVisitQueueEntries {
 
   const mapVisitQueueEntryProperties = (visitQueueEntry: VisitQueueEntry): MappedVisitQueueEntry => ({
     id: visitQueueEntry.queueEntry.uuid,
-    encounters: visitQueueEntry.visit.encounters.map(mapEncounterProperties),
+    encounters: visitQueueEntry.visit?.encounters?.map(mapEncounterProperties),
     name: visitQueueEntry.queueEntry.display,
     patientUuid: visitQueueEntry.queueEntry.patient.uuid,
     // Map `Urgent` to `Priority` because it's easier to distinguish between tags named
@@ -138,9 +141,9 @@ export function useVisitQueueEntries(): UseVisitQueueEntries {
     waitTime: visitQueueEntry.queueEntry.startedAt
       ? `${dayjs().diff(dayjs(visitQueueEntry.queueEntry.startedAt), 'minutes')}`
       : '--',
-    visitStartDateTime: visitQueueEntry.visit.visitStartDateTime,
-    visitType: visitQueueEntry.visit.visitType.display,
-    visitUuid: visitQueueEntry.visit.uuid,
+    visitStartDateTime: visitQueueEntry.visit?.visitStartDateTime,
+    visitType: visitQueueEntry.visit?.visitType?.display,
+    visitUuid: visitQueueEntry.visit?.uuid,
   });
 
   const mappedVisitQueueEntries = data?.data?.results?.map(mapVisitQueueEntryProperties);

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.test.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.test.tsx
@@ -1,25 +1,35 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { ConfigObject, openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import { swrRender, waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { mockServices, mockVisitQueueEntries } from '../../__mocks__/active-visits.mock';
 import ActiveVisitsTable from './active-visits-table.component';
 
-const mockOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockedOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockedUseConfig = useConfig as jest.Mock;
 
 jest.mock('./active-visits-table.resource.ts', () => {
   const originalModule = jest.requireActual('./active-visits-table.resource.ts');
 
   return {
     ...originalModule,
-    useServiceMetadata: jest.fn().mockReturnValue({ services: mockServices }),
+    useServices: jest.fn().mockReturnValue({ services: mockServices }),
   };
 });
 
 describe('ActiveVisitsTable: ', () => {
+  beforeEach(() =>
+    mockedUseConfig.mockReturnValue({
+      concepts: {
+        priorityConceptSetUuid: '96105db1-abbf-48d2-8a52-a1d561fd8c90',
+        serviceConceptSetUuid: '330c0ec6-0ac7-4b86-9c70-29d76f0ae20a',
+      },
+    } as ConfigObject),
+  );
+
   it('renders an empty state view if data is unavailable', async () => {
-    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
+    mockedOpenmrsFetch.mockReturnValueOnce({ data: { results: [] } });
 
     renderActiveVisitsTable();
 
@@ -31,7 +41,7 @@ describe('ActiveVisitsTable: ', () => {
   });
 
   it('renders a tabular overview of visit queue entry data when available', async () => {
-    mockOpenmrsFetch.mockReturnValueOnce({ data: { results: mockVisitQueueEntries } });
+    mockedOpenmrsFetch.mockReturnValueOnce({ data: { results: mockVisitQueueEntries } });
 
     renderActiveVisitsTable();
 

--- a/packages/esm-outpatient-app/src/config-schema.ts
+++ b/packages/esm-outpatient-app/src/config-schema.ts
@@ -1,2 +1,21 @@
-import { Type, validators } from '@openmrs/esm-framework';
-export const configSchema = {};
+import { Type } from '@openmrs/esm-framework';
+
+export const configSchema = {
+  concepts: {
+    priorityConceptSetUuid: {
+      _type: Type.ConceptUuid,
+      _default: '96105db1-abbf-48d2-8a52-a1d561fd8c90',
+    },
+    serviceConceptSetUuid: {
+      _type: Type.ConceptUuid,
+      _default: '330c0ec6-0ac7-4b86-9c70-29d76f0ae20a',
+    },
+  },
+};
+
+export interface ConfigObject {
+  concepts: {
+    priorityConceptSetUuid: string;
+    serviceConceptSetUuid: string;
+  };
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR makes the `service` and `priority` concept set UUIDs configurable. It also fixes a regression in the test suite owing to a reference to a function whose name changed.