### PR TITLE
(feat) Minor visual tweaks to the basic search component

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -335,9 +335,7 @@ function ActiveVisitsTable() {
                       <p className={styles.content}>{t('noPatientsToDisplay', 'No patients to display')}</p>
                       <p className={styles.helper}>{t('checkFilters', 'Check the filters above')}</p>
                     </div>
-                    <span className={styles.separator}>
-                      <hr />
-                    </span>
+                    <p className={styles.separator}>{t('or', 'or')}</p>
                     <Button kind="ghost" size="small" renderIcon={Add16} onClick={() => setShowOverlay(true)}>
                       {t('addPatientToList', 'Add patient to list')}
                     </Button>

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
@@ -143,28 +143,31 @@
 }
 
 .separator {
-  display: block;
-  margin: 3rem auto;
+  @include carbon--type-style('body-short-02');
+  color: $text-02;
+  width: 80%;
+  margin: 1.5rem auto;
+  overflow: hidden;
+  text-align: center;
 
-  hr {
-    @include carbon--type-style('body-short-02');
-    color: $text-02;
-    width: 80%;
-    line-height: 1;
-    border: 0;
-    border-top: 1px solid $text-03;
-    text-align: center;
-    overflow: visible;
-    margin-bottom: -1rem;
-    
-    &::after {
-      content: 'or';
-      display: inline-block;
-      position: relative;
-      top: -0.7em;
-      padding: 0 1rem;
-      background: $ui-01;
-    }
+  &::before, &::after {
+    background-color: $text-03;
+    content: "";
+    display: inline-block;
+    height: 1px;
+    position: relative;
+    vertical-align: middle;
+    width: 50%;
+  }
+
+  &::before {
+    right: 0.5rem;
+    margin-left: -50%;
+  }
+
+  &::after {
+    left: 0.5rem;
+    margin-right: -50%;
   }
 }
 

--- a/packages/esm-outpatient-app/src/overlay.component.tsx
+++ b/packages/esm-outpatient-app/src/overlay.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { ArrowLeft16, Close16 } from '@carbon/icons-react';
 import { Button, Header } from 'carbon-components-react';
-import styles from './overlay.scss';
 import { useLayoutType } from '@openmrs/esm-framework';
+import styles from './overlay.scss';
 
 interface OverlayProps {
   closePanel: () => void;
@@ -22,7 +22,7 @@ const Overlay: React.FC<OverlayProps> = ({ closePanel, children, header }) => {
           </Button>
         </div>
       ) : (
-        <Header className={styles.tabletOverlayHeader}>
+        <Header aria-label="Tablet overlay" className={styles.tabletOverlayHeader}>
           <Button onClick={closePanel} hasIconOnly>
             <ArrowLeft16 onClick={closePanel} />
           </Button>

--- a/packages/esm-outpatient-app/src/patient-search/basic-search.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-search/basic-search.component.tsx
@@ -74,7 +74,9 @@ const BasicSearch: React.FC<BasicSearchProps> = ({ toggleSearchType }) => {
               </div>
             </Tile>
           </div>
-          <div className={styles['text-divider']}>{t('or', 'Or')}</div>
+          <span className={styles.separator}>
+            <hr />
+          </span>
           <div className={styles.buttonContainer}>
             <Button
               kind="ghost"

--- a/packages/esm-outpatient-app/src/patient-search/basic-search.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-search/basic-search.component.tsx
@@ -74,9 +74,7 @@ const BasicSearch: React.FC<BasicSearchProps> = ({ toggleSearchType }) => {
               </div>
             </Tile>
           </div>
-          <span className={styles.separator}>
-            <hr />
-          </span>
+          <p className={styles.separator}>{t('or', 'or')}</p>
           <div className={styles.buttonContainer}>
             <Button
               kind="ghost"

--- a/packages/esm-outpatient-app/src/patient-search/basic-search.scss
+++ b/packages/esm-outpatient-app/src/patient-search/basic-search.scss
@@ -44,33 +44,37 @@
   }
 
   .secondaryText {
+    width: 12rem;
     margin-top: 0.25rem;
     @include carbon--type-style("body-long-01");
   }
 }
 
-.text-divider {
-  display: flex;
-  align-items: center;
-  margin: $spacing-10 25%;
-  @include carbon--type-style("productive-heading-02");
-  color: $text-02;
-}
 
-.text-divider::before,
-.text-divider::after {
-  content: "";
-  height: 1px;
-  background-color: $text-03;
-  flex-grow: 1;
-}
+.separator {
+  display: block;
+  margin: 3rem auto;
 
-.text-divider::before {
-  margin-right: $spacing-05;
-}
-
-.text-divider::after {
-  margin-left: $spacing-05;
+  hr {
+    @include carbon--type-style('body-short-02');
+    color: $text-02;
+    width: 12rem;
+    line-height: 1;
+    border: 0;
+    border-top: 1px solid $text-03;
+    text-align: center;
+    overflow: visible;
+    margin-bottom: -1rem;
+    
+    &::after {
+      content: 'or';
+      display: inline-block;
+      position: relative;
+      top: -0.7em;
+      padding: 0 1rem;
+      background: $ui-01;
+    }
+  }
 }
 
 .buttonContainer {

--- a/packages/esm-outpatient-app/src/patient-search/basic-search.scss
+++ b/packages/esm-outpatient-app/src/patient-search/basic-search.scss
@@ -20,7 +20,7 @@
   }
 
   :global(.omrs-breakpoint-lt-desktop) & {
-    width: 50%;
+    width: 60%;
     margin: auto;
   }
 }
@@ -50,30 +50,32 @@
   }
 }
 
-
 .separator {
-  display: block;
+  @include carbon--type-style('productive-heading-03');
+  color: $text-02;
+  width: 12rem;
   margin: 3rem auto;
+  overflow: hidden;
+  text-align: center;
 
-  hr {
-    @include carbon--type-style('body-short-02');
-    color: $text-02;
-    width: 12rem;
-    line-height: 1;
-    border: 0;
-    border-top: 1px solid $text-03;
-    text-align: center;
-    overflow: visible;
-    margin-bottom: -1rem;
-    
-    &::after {
-      content: 'or';
-      display: inline-block;
-      position: relative;
-      top: -0.7em;
-      padding: 0 1rem;
-      background: $ui-01;
-    }
+  &::before, &::after {
+    background-color: $text-03;
+    content: "";
+    display: inline-block;
+    height: 1px;
+    position: relative;
+    vertical-align: middle;
+    width: 50%;
+  }
+
+  &::before {
+    right: 1rem;
+    margin-left: -50%;
+  }
+
+  &::after {
+    left: 1rem;
+    margin-right: -50%;
   }
 }
 

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -34,6 +34,7 @@
   "ncdCare": "NCD Care",
   "noPatientsToDisplay": "No patients to display",
   "notes": "Notes",
+  "or": "or",
   "outpatients": "Outpatients",
   "patientList": "Patient list",
   "patients": "Patients",

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -34,7 +34,6 @@
   "ncdCare": "NCD Care",
   "noPatientsToDisplay": "No patients to display",
   "notes": "Notes",
-  "or": "Or",
   "outpatients": "Outpatients",
   "patientList": "Patient list",
   "patients": "Patients",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR fixes the appearance of the helper text in the basic search component. Specifically, it:

- Constrains the width of the secondary text to match the designs.
- Refactors the horizontal rule separator and constrains the parent container width to the same width as the secondary helper text above it.
- Also adds an `aria-label` to the overlay header (effectively silencing a warning in the browser console).

## Screenshots

> Tablet

Empty filters

<img width="1029" alt="Screenshot 2022-04-06 at 12 50 54" src="https://user-images.githubusercontent.com/8509731/161948577-350fe03b-701a-4834-a473-bd52da94040e.png">

Basic search

<img width="1031" alt="Screenshot 2022-04-06 at 12 52 21" src="https://user-images.githubusercontent.com/8509731/161948822-94c76c80-6501-49e7-a384-a7d2a6658a28.png">

> Desktop

<img width="1584" alt="Screenshot 2022-04-06 at 12 53 29" src="https://user-images.githubusercontent.com/8509731/161949048-ff9457dd-8cc8-4e0b-822c-50ab3c42c9fd.png">
