### PR TITLE
(fix) Fix alignment and positioning of side rail tooltips

### DIFF
--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -22,7 +22,6 @@
   "fields": "of the following fields",
   "firstName": "First name",
   "hivCare": "HIV care",
-  "home": "Home",
   "lastName": "Last name",
   "lastVisit": "Last Visit",
   "lastVisitDate": "Date",

--- a/packages/esm-patient-list-app/src/patient-list-action-button.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-action-button.component.tsx
@@ -27,8 +27,8 @@ const PatientListActionButton: React.FC = () => {
       renderIcon={ListBulleted20}
       hasIconOnly
       iconDescription={t('patientList', 'Patient list')}
-      tooltipAlignment="end"
-      tooltipPosition="bottom"
+      tooltipAlignment="start"
+      tooltipPosition="left"
     />
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR fixes the alignment and positioning of tooltips in the side rail. Presently, tooltips for some buttons in the side rail get cut off by the right margin of the page.

## Videos

> Current

https://user-images.githubusercontent.com/8509731/162152035-c095e3ac-2cfd-40b5-b246-aea6513b551c.mp4

> Fixed

https://user-images.githubusercontent.com/8509731/162151344-9e5ecfec-2dff-4470-8e60-f29431be3f06.mp4

Relates to: https://github.com/openmrs/openmrs-esm-patient-chart/pull/643