### PR TITLE
(fix) Error: UUID for patient-attribute type not defined

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schemas/openmrs-esm-patient-registration-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schemas/openmrs-esm-patient-registration-schema.ts
@@ -86,12 +86,7 @@ export const esmPatientRegistrationSchema = {
   },
   codedPersonAttributes: {
     _type: Type.Array,
-    _default: [
-      {
-        uuid: '8b56eac7-5c76-4b9c-8c6f-1deab8d3fc47',
-        type: Type.ConceptUuid,
-      },
-    ],
+    _default: [],
     _elements: {
       _type: Type.Object,
       personAttributeUuid: {

--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -274,7 +274,6 @@ export default class FormManager {
 
   static getPatientAttributes(values: FormValues) {
     const attributes: Array<AttributeValue> = [];
-
     if (values.attributes) {
       for (const [key, value] of Object.entries(values.attributes)) {
         attributes.push({
@@ -282,6 +281,13 @@ export default class FormManager {
           value,
         });
       }
+    }
+    if (values.unidentifiedPatient) {
+      attributes.push({
+        // The UUID of the 'Unknown Patient' attribute-type will always be static across all implementations of OpenMRS
+        attributeType: '8b56eac7-5c76-4b9c-8c6f-1deab8d3fc47',
+        value: 'true',
+      });
     }
 
     return attributes;

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -101,10 +101,7 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
     try {
       await savePatientForm(
         !inEditMode,
-        {
-          ...values,
-          attributes: { ...values.attributes, '8b56eac7-5c76-4b9c-8c6f-1deab8d3fc47': `${values.unidentifiedPatient}` },
-        },
+        values,
         patientUuidMap,
         initialAddressFieldValues,
         capturePhotoProps,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
I have removed the incorrect and unnecessary attribute-type from the configuration file, to resolve the error stated in the title of the PR.

## Screenshots

https://user-images.githubusercontent.com/51502471/162441061-fb04d218-d4a3-4f3d-99cb-102aee7248cc.mov


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
