### PR TITLE
(chore) Downgrade @types/react version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3348,9 +3348,9 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "18.0.4"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.4.tgz#88e9eddd8788fdf60dcf260b1cff2fb7487e4373"
-  integrity sha512-Zm4ryWh9xQbMX6ge7Ej/nS6VBoT+9wzvwd/hZ+9EONGjBkejyyvEKndZt/DZHHj1lSU/YeTPyJAn22S3GnYchQ==
+  version "17.0.43"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
+  integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR fixes a typescript compilation regression caused by a recent [bump](https://github.com/openmrs/openmrs-esm-patient-management/commit/2c207e1c112260d958be5eb4d89b4326e6b4c64d) to the `@types/react` package by downgrading the package to an older version. 

This regression led to failing builds in both our local and [continuous integration](https://github.com/openmrs/openmrs-esm-patient-management/actions) environments.