### PR TITLE
(refactor) Replace deprecated `useSessionUser` with `useSession`

### DIFF
--- a/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.component.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next';
 import Calendar16 from '@carbon/icons-react/es/calendar/16';
 import Location16 from '@carbon/icons-react/es/location/16';
 import { Dropdown } from 'carbon-components-react';
-import { formatDate, useSessionUser } from '@openmrs/esm-framework';
+import { formatDate, useSession } from '@openmrs/esm-framework';
 import PatientQueueIllustration from './patient-queue-illustration.component';
 import styles from './patient-queue-header.scss';
 
 const PatientQueueHeader: React.FC<{ title: string }> = ({ title }) => {
   const { t } = useTranslation();
-  const userSession = useSessionUser();
+  const userSession = useSession();
   const userLocation = userSession?.sessionLocation?.display;
   const careTypes = [
     {

--- a/packages/esm-patient-list-app/src/add-patient/add-patient.component.tsx
+++ b/packages/esm-patient-list-app/src/add-patient/add-patient.component.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { toOmrsIsoString, showToast, usePagination, useSessionUser } from '@openmrs/esm-framework';
+import { toOmrsIsoString, showToast, usePagination, useSession } from '@openmrs/esm-framework';
 import { Button, Checkbox, Pagination, Search, SkeletonText } from 'carbon-components-react';
 import styles from './add-patient.scss';
 import { addPatientToLocalOrRemotePatientList } from '../api/api';
@@ -22,7 +22,7 @@ type PatientListObj = Record<string, PatientListProp>;
 const AddPatient: React.FC<AddPatientProps> = ({ closeModal, patientUuid }) => {
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState('');
-  const userId = useSessionUser()?.user.uuid;
+  const userId = useSession()?.user.uuid;
   const { data, isValidating } = useAllPatientListsWhichDoNotIncludeGivenPatient(userId, patientUuid);
   const [patientListsObj, setPatientListsObj] = useState<PatientListObj | null>(null);
 

--- a/packages/esm-patient-list-app/src/offline-patient-table/offline-patient-table.component.tsx
+++ b/packages/esm-patient-list-app/src/offline-patient-table/offline-patient-table.component.tsx
@@ -20,7 +20,7 @@ import {
 import {
   useStore,
   getOfflinePatientDataStore,
-  useSessionUser,
+  useSession,
   age,
   useLayoutType,
   syncOfflinePatientData,
@@ -43,7 +43,7 @@ export interface OfflinePatientTableProps {
 const OfflinePatientTable: React.FC<OfflinePatientTableProps> = ({ isInteractive, showHeader }) => {
   const { t } = useTranslation();
   const store = useStore(getOfflinePatientDataStore());
-  const userId = useSessionUser()?.user.uuid;
+  const userId = useSession()?.user.uuid;
   const layout = useLayoutType();
   const { isValidating, data: patients, mutate } = useAllPatientsFromOfflinePatientList(userId);
   const toolbarItemSize = layout === 'desktop' ? 'sm' : undefined;

--- a/packages/esm-patient-list-app/src/patient-list-list/patient-list-list.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-list/patient-list-list.component.tsx
@@ -4,7 +4,7 @@ import { Button, DataTableHeader, Tab, Tabs } from 'carbon-components-react';
 import PatientListTable from './patient-list-table.component';
 import CreateNewList from '../ui-components/create-edit-patient-list/create-edit-list.component';
 import { useTranslation } from 'react-i18next';
-import { ExtensionSlot, useSessionUser } from '@openmrs/esm-framework';
+import { ExtensionSlot, useSession } from '@openmrs/esm-framework';
 import styles from './patient-list-list.scss';
 import { useAllPatientLists } from '../api/hooks';
 import { PatientList, PatientListFilter, PatientListType } from '../api/types';
@@ -78,7 +78,7 @@ const PatientListList: React.FC = () => {
   const [selectedTab, setSelectedTab] = useState(TabTypes.STARRED);
   const [searchString, setSearchString] = useState<string>('');
   const patientListFilter = usePatientListFilterForCurrentTab(selectedTab, searchString);
-  const userId = useSessionUser()?.user.uuid;
+  const userId = useSession()?.user.uuid;
   const customHeaders = useAppropriateTableHeadersForSelectedTab(selectedTab);
   const patientListQuery = useAllPatientLists(userId, patientListFilter);
 

--- a/packages/esm-patient-list-app/src/patient-list-list/patient-list-table.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-list/patient-list-table.component.tsx
@@ -17,7 +17,7 @@ import {
 } from 'carbon-components-react';
 import Star16 from '@carbon/icons-react/es/star/16';
 import StarFilled16 from '@carbon/icons-react/es/star--filled/16';
-import { useSessionUser, ConfigurableLink, useLayoutType } from '@openmrs/esm-framework';
+import { useSession, ConfigurableLink, useLayoutType } from '@openmrs/esm-framework';
 import styles from './patient-list-list.scss';
 import debounce from 'lodash-es/debounce';
 import { updateLocalOrRemotePatientList } from '../api/api';
@@ -54,7 +54,7 @@ const PatientListTable: React.FC<PatientListTableProps> = ({
   refetch,
   search,
 }) => {
-  const userId = useSessionUser()?.user.uuid;
+  const userId = useSession()?.user.uuid;
   const isDesktop = useLayoutType() === 'desktop';
 
   const handleSearch = useMemo(() => debounce((searchTerm) => search.onSearch(searchTerm), 300), []);

--- a/packages/esm-patient-list-app/src/ui-components/create-edit-patient-list/create-edit-list.component.tsx
+++ b/packages/esm-patient-list-app/src/ui-components/create-edit-patient-list/create-edit-list.component.tsx
@@ -3,7 +3,7 @@ import { Button, Dropdown, OnChangeData, TextArea, TextInput } from 'carbon-comp
 import Overlay from '../../overlay.component';
 import { useTranslation } from 'react-i18next';
 import styles from './create-edit-patient-list.scss';
-import { useLayoutType, showToast, useSessionUser } from '@openmrs/esm-framework';
+import { useLayoutType, showToast, useSession } from '@openmrs/esm-framework';
 import { createPatientList, editPatientList } from '../../api/api-remote';
 import { useCohortTypes } from '../../api/hooks';
 import { OpenmrsCohort, NewCohortData } from '../../api/types';
@@ -29,7 +29,7 @@ const CreateEditPatientList: React.FC<CreateEditPatientListProps> = ({
     location: '',
   });
   const isDesktop = useLayoutType() === 'desktop';
-  const user = useSessionUser();
+  const user = useSession();
   const { data: cohortTypes } = useCohortTypes();
 
   useEffect(() => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR replaces the deprecated useSessionUser function declaration with useSession. This PR does not introduce any functional changes.

Related: https://github.com/openmrs/openmrs-esm-patient-chart/pull/661