### PR TITLE
(fix) Move data-floating-menu-container attribute to DataTable tag

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   DataTable,
   DataTableHeader,
-  DataTableSize,
   DataTableSkeleton,
   Dropdown,
   OverflowMenu,
@@ -237,7 +236,7 @@ function ActiveVisitsTable() {
 
   if (visitQueueEntries?.length) {
     return (
-      <div className={styles.container} data-floating-menu-container>
+      <div className={styles.container}>
         <div className={styles.headerContainer}>
           <span className={styles.heading}>{t('activeVisits', 'Active visits')}</span>
           <Button
@@ -250,6 +249,7 @@ function ActiveVisitsTable() {
           </Button>
         </div>
         <DataTable
+          data-floating-menu-container
           filterRows={handleFilter}
           headers={tableHeaders}
           overflowMenuOnHover={isDesktop ? true : false}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR moves the `data-floating-menu-container` attribute from the topmost parent container div to the DataTable tag. Carbon uses this attribute to determine where to render the OverflowMenu component. Presently, the OverflowMenu gets rendered outside the bounds of the DataTable content area. Following this change, the Overflow menu gets correctly rendered within the DataTable.

Unrelatedly, this PR also removes an unused Carbon component import.