### PR TITLE
(feat) Add edit patient details functionality to overflow menu

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -30,7 +30,7 @@ import {
 import Add16 from '@carbon/icons-react/es/add/16';
 import Group16 from '@carbon/icons-react/es/group/16';
 import InProgress16 from '@carbon/icons-react/es/in-progress/16';
-import { useLayoutType, ConfigurableLink } from '@openmrs/esm-framework';
+import { useLayoutType, ConfigurableLink, navigate } from '@openmrs/esm-framework';
 import {
   useVisitQueueEntries,
   useServices,
@@ -51,7 +51,7 @@ type FilterProps = {
   getCellId: (row, key) => string;
 };
 
-function ActionsMenu() {
+function ActionsMenu({ patientUuid }: { patientUuid: string }) {
   const { t } = useTranslation();
 
   return (
@@ -59,7 +59,12 @@ function ActionsMenu() {
       <OverflowMenuItem
         className={styles.menuItem}
         id="#editPatientDetails"
-        itemText={t('editPatientDetails', 'Edit patient details')}>
+        itemText={t('editPatientDetails', 'Edit patient details')}
+        onClick={() =>
+          navigate({
+            to: `\${openmrsSpaBase}/patient/${patientUuid}/edit`,
+          })
+        }>
         {t('editPatientDetails', 'Edit patient details')}
       </OverflowMenuItem>
       <OverflowMenuItem
@@ -301,7 +306,7 @@ function ActiveVisitsTable() {
                             <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
                           ))}
                           <TableCell className="bx--table-column-menu">
-                            <ActionsMenu />
+                            <ActionsMenu patientUuid={tableRows?.[index]?.patientUuid} />
                           </TableCell>
                         </TableExpandRow>
                         {row.isExpanded ? (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR adds functionality to the `Edit patient details` button so that when the user clicks on it, they get navigated to the patient registration form in edit mode.

## Video

https://user-images.githubusercontent.com/8509731/164475111-87df7900-ee2a-442e-8319-5fd5b8a6af8c.mp4
