### PR TITLE
O3-1268:Default patient identifier types should not be required

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.component.tsx
@@ -40,6 +40,7 @@ export const IdField: React.FC = () => {
                 identifierTypeUuid: identifierType.uuid,
                 source: identifierType.identifierSources?.[0],
                 preferred: identifierType.isPrimary,
+                required: identifierType.required,
               } as PatientIdentifierValue),
           ),
       );

--- a/packages/esm-patient-registration-app/src/patient-registration/field/id/identifier-selection-overlay.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/id/identifier-selection-overlay.tsx
@@ -198,6 +198,7 @@ const PatientIdentifierOverlay: React.FC<PatientIdentifierOverlayProps> = ({
           source: identifierType.source,
           identifierTypeUuid: identifierType.uuid,
           preferred: identifierType.isPrimary,
+          required: identifierType.required,
         });
       }
     });

--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.test.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.test.ts
@@ -35,6 +35,7 @@ const formValues: FormValues = {
       identifier: 'foo',
       identifierTypeUuid: 'identifierType',
       preferred: true,
+      required: false,
       source: {
         uuid: 'some-uuid',
         name: 'unique',

--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -154,7 +154,12 @@ export default class FormManager {
     abortController: AbortController,
   ): Promise<Array<PatientIdentifier>> {
     let identifierTypeRequests = patientIdentifiers
-      .filter((identifier) => identifier.action !== 'DELETE' && identifier.action !== 'NONE')
+      .filter(
+        (identifier) =>
+          identifier.action !== 'DELETE' &&
+          identifier.action !== 'NONE' &&
+          (identifier.required ? true : !!identifier.identifier),
+      )
       .map(async (patientIdentifier) => {
         const { identifierTypeUuid, identifier, uuid, action, source, preferred, autoGeneration } = patientIdentifier;
         if (identifier || (source && autoGeneration)) {

--- a/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/input/input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/input/input.component.tsx
@@ -40,7 +40,7 @@ export const Input: React.FC<InputProps> = ({ checkWarning, ...props }) => {
       <TextInput
         {...props}
         {...field}
-        invalid={!!(meta.touched && meta.error)}
+        invalid={props.name.includes('identifiers') ? false : !!(meta.touched && meta.error)}
         invalidText={invalidText}
         warn={!!warnText}
         warnText={warnText}

--- a/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/input/input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/input/input.component.tsx
@@ -40,7 +40,7 @@ export const Input: React.FC<InputProps> = ({ checkWarning, ...props }) => {
       <TextInput
         {...props}
         {...field}
-        invalid={props.name.includes('identifiers') ? false : !!(meta.touched && meta.error)}
+        invalid={!!(meta.touched && meta.error)}
         invalidText={invalidText}
         warn={!!warnText}
         warnText={warnText}

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
@@ -83,6 +83,7 @@ export const IdentifierInput: React.FC<IdentifierInputProps> = ({ patientIdentif
       ...patientIdentifier,
       action: 'UPDATE',
       source: identifierType?.identifierSources?.[0],
+      required: false,
     } as PatientIdentifierValue);
   }, [patientIdentifier]);
 

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
@@ -184,6 +184,7 @@ export function useInitialPatientIdentifiers(patientUuid: string): {
         action: 'NONE',
         source: null,
         preferred: patientIdentifier.identifierType.isPrimary,
+        required: false,
       })),
       isLoading: !data && !error,
     }),

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-types.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-types.tsx
@@ -34,6 +34,7 @@ export interface PatientIdentifierValue {
   source: IdentifierSource;
   autoGeneration?: boolean;
   preferred: boolean;
+  required: boolean;
   /**
    * @kind ADD -> add a new identifier to a patient
    * @kind UPDATE -> update an existing patient identifier

--- a/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.tsx
@@ -26,7 +26,11 @@ export const validationSchema = Yup.object({
   }),
   identifiers: Yup.array().of(
     Yup.object().shape({
-      identifier: Yup.string().required('identifierRequired'),
+      required: Yup.bool(),
+      identifier: Yup.string().when('required', {
+        is: true,
+        then: Yup.string().required('identifierRequired'),
+      }),
     }),
   ),
   yearsEstimated: Yup.number().min(0, 'negativeYears'),


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

When new default identifiers are configured to be shown on the registration screen, whether or not they are required should still be driven by the backend. So, for example, if I configure things so that an optional identifier appears by default on the registration screen, it should still not be required to submit the registration.

## Screenshots



https://user-images.githubusercontent.com/33891016/166717966-b7f6354d-dae2-40ff-8576-4080dbf83d35.mp4



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
