### PR TITLE
(chore) CI workflow modifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: OpenMRS CI
 
 on:
   push:
@@ -17,19 +17,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
           node-version: "14.x"
-      - run: npx lerna bootstrap
-      - name: TurboRepo local cache server
+      - name: Install dependencies
+        run: npx lerna bootstrap
+      - name: Setup local cache server for Turborepo
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
-      - run: yarn run verify 
-      - run: yarn turbo run build --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="${{ github.repository_owner }}"
-      - name: Upload Artifacts
+      - name: Run tests
+        run: yarn run test
+      - name: Run lint and typechecking
+        run: yarn run verify 
+      - name: Run build
+        run: yarn turbo run build --color --api="http://127.0.0.1:9080" --token="${{ secrets.TURBO_SERVER_TOKEN }}" --team="${{ github.repository_owner }}"
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
           name: packages

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,6 +3,5 @@
 
 set -e  # die on error
 
-npx lerna run lint --since main
-npx lerna run typescript --since main
+yarn run verify
 yarn run test

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ci:publish": "lerna publish from-package --yes",
     "ci:prepublish": "lerna publish from-package --no-git-reset --yes --dist-tag next",
     "release": "lerna version --no-git-tag-version",
-    "verify": "turbo run lint && turbo run test && turbo run typescript",
+    "verify": "turbo run lint && turbo run typescript",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx,css,scss}\"",
     "test": "cross-env TZ=UTC jest --config jest.config.json --verbose false --passWithNoTests",
     "test-watch": "cross-env TZ=UTC jest --watch --config jest.config.json",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR makes the following changes to the CI workflow:

- Renames the workflow from `Node.js CI` to `OpenMRS CI`.
- Adds more descriptive names to steps in the `build` job.
- Amends the `verify` script in the lock file to remove the `test` job. Because `test` is run at the top level instead of per package, we cannot leverage the benefits of Turborepo. Running `turbo run test` doesn't do anything; you'd need to run `yarn run test` to run tests. I've added a test step using `yarn run test` to the CI that actually runs the tests.

Additionally, it amends the `pre-push` hook to leverage Turborepo.

## Screenshots

> Pre-push hook not working
<img width="1105" alt="Screenshot 2022-05-11 at 11 55 40" src="https://user-images.githubusercontent.com/8509731/167812045-f663420c-3c3f-48ad-b99f-5ce60aef37da.png">
