### PR TITLE
(test) Fix warnings when running tests

### DIFF
--- a/packages/esm-outpatient-app/src/patient-search/search-results.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-search/search-results.component.tsx
@@ -92,8 +92,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({ patients }) => {
           onChange={({ selectedItem }) => setSelectedSortingCriteria(selectedItem.id as SortingCriteria)}
         />
       </div>
-      {sortedPatient.map((patient) => (
-        <div key={patient.id} className={styles.patientChart}>
+      {sortedPatient.map((patient, index) => (
+        <div key={index} className={styles.patientChart}>
           <div className={styles.container}>
             <PatientInfo patient={patient} />
           </div>

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Autosuggest } from './autosuggest.component';
-import { render, screen, fireEvent, waitForElement } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import '@testing-library/jest-dom/extend-expect';
 import '@testing-library/jest-dom';
@@ -37,6 +37,7 @@ describe('autosuggest', () => {
     render(
       <BrowserRouter>
         <Autosuggest
+          labelText=""
           name="person"
           placeholder="Find Person"
           onSuggestionSelected={handleSuggestionSelected}
@@ -58,7 +59,7 @@ describe('autosuggest', () => {
     setup();
     const searchbox = screen.getByRole('searchbox');
     fireEvent.change(searchbox, { target: { value: 'john' } });
-    const list = await waitForElement(() => screen.getByRole('list'));
+    const list = await waitFor(() => screen.getByRole('list'));
     expect(list).toBeInTheDocument();
     expect(list.children).toHaveLength(2);
   });
@@ -67,7 +68,7 @@ describe('autosuggest', () => {
     setup();
     const searchbox = screen.getByRole('searchbox');
     fireEvent.change(searchbox, { target: { value: 'john' } });
-    const list = await waitForElement(() => screen.getAllByRole('listitem'));
+    const list = await waitFor(() => screen.getAllByRole('listitem'));
     expect(list[0].textContent).toBe('John Doe');
     expect(list[1].textContent).toBe('John Smith');
   });
@@ -76,7 +77,7 @@ describe('autosuggest', () => {
     setup();
     const searchbox = screen.getByRole('searchbox');
     fireEvent.change(searchbox, { target: { value: 'john' } });
-    const listitems = await waitForElement(() => screen.getAllByRole('listitem'));
+    const listitems = await waitFor(() => screen.getAllByRole('listitem'));
     fireEvent.click(listitems[0]);
     expect(handleSuggestionSelected).toHaveBeenNthCalledWith(1, 'person', 'randomuuid1');
   });
@@ -85,7 +86,7 @@ describe('autosuggest', () => {
     setup();
     let searchbox = screen.getByRole('searchbox');
     fireEvent.change(searchbox, { target: { value: 'john' } });
-    const listitems = await waitForElement(() => screen.getAllByRole('listitem'));
+    const listitems = await waitFor(() => screen.getAllByRole('listitem'));
     fireEvent.click(listitems[0]);
     searchbox = screen.getByRole('searchbox');
     expect(searchbox.textContent).toBe('John Doe');
@@ -97,7 +98,7 @@ describe('autosuggest', () => {
     expect(list).toBeNull();
     const searchbox = screen.getByRole('searchbox');
     fireEvent.change(searchbox, { target: { value: 'john' } });
-    list = await waitForElement(() => screen.queryByRole('list'));
+    list = await waitFor(() => screen.getByRole('list'));
     expect(list).toBeInTheDocument();
     const listitems = screen.getAllByRole('listitem');
     fireEvent.click(listitems[0]);

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { render, wait, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as backendController from './patient-registration.resource';
 import * as mockOpenmrsFramework from '@openmrs/esm-framework/mock';
@@ -94,8 +93,7 @@ describe('patient registration sections', () => {
           <PatientRegistration isOffline={false} match={sampleMatchProp} savePatientForm={jest.fn()} />
         </ResourcesContext.Provider>,
       );
-      await wait();
-      expect(screen.getByLabelText(labelText)).not.toBeNull();
+      await waitFor(() => expect(screen.getByLabelText(labelText)).not.toBeNull());
     });
   };
 
@@ -180,6 +178,7 @@ describe('form submit', () => {
       patientUuid: mockPatient.id,
       error: null,
     });
+
     render(
       <ResourcesContext.Provider value={mockResourcesContextValue}>
         <PatientRegistration
@@ -189,7 +188,6 @@ describe('form submit', () => {
         />
       </ResourcesContext.Provider>,
     );
-    await wait();
 
     const givenNameInput = screen.getByLabelText('Given Name') as HTMLInputElement;
     const familyNameInput = screen.getByLabelText('Family Name') as HTMLInputElement;
@@ -212,7 +210,6 @@ describe('form submit', () => {
     userEvent.type(familyNameInput, 'Smith');
     userEvent.type(address1, 'Bom Jesus Street');
     userEvent.click(screen.getByText('Update Patient'));
-    await wait();
 
     expect(backendController.savePatient).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, wait, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { Formik, Form } from 'formik';
 import { validationSchema } from './patient-registration-validation';
 import { NameField } from '../field/name/name-field.component';
@@ -16,6 +16,7 @@ const mockFieldConfigs = {
     },
   },
 };
+
 describe('name input', () => {
   const formValues: FormValues = initialFormValues;
 
@@ -97,8 +98,6 @@ describe('name input', () => {
     fireEvent.blur(middleNameInput);
     fireEvent.change(familyNameInput, { target: { value: familyNameValue } });
     fireEvent.blur(familyNameInput);
-
-    await wait();
 
     return {
       givenNameError: screen.queryByText('Given name is required'),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR fixes a bunch of warnings that get raised when running tests in this repository. Specifically, these warnings relate to the usage of the deprecated `wait` function instead of `waitFor`.