### PR TITLE
O3-1221: Fetch active visits only when the location param is provided

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -32,7 +32,7 @@ export function useActiveVisits() {
     sessionLocation;
   const url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}`;
   const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
-    sessionLocation ? url : '',
+    sessionLocation ? url : null,
     openmrsFetch,
   );
 

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -31,7 +31,10 @@ export function useActiveVisits() {
     '&location=' +
     sessionLocation;
   const url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}`;
-  const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(url, openmrsFetch);
+  const { data, error, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
+    sessionLocation ? url : '',
+    openmrsFetch,
+  );
 
   const mapVisitProperties = (visit: Visit): ActiveVisit => ({
     age: visit?.patient?.person?.age,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
When fetching active visits with the `location` parameter as undefined, the backend throws the 404 error.  This PR enable fetching the active visits only when the `location` parameter is defined. 

## Screenshots

![Screenshot 2022-05-19 at 5 13 00 PM](https://user-images.githubusercontent.com/33891016/169315727-15d51448-4248-47d2-8f5b-3e277892043e.png)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
