### PR TITLE
(chore) Fix failing pre-release job in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,13 +308,21 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npx lerna bootstrap
+
+      - name: Build
+        run: yarn turbo run build --color
+
+      - name: Patch
+        run: yarn lerna version patch --no-git-tag-version --no-push --yes
       
-      - run: npx lerna run build --color
-      - run: npx lerna version patch --no-git-tag-version --no-push --yes
-      - run: npx lerna version "$(node -e "console.log(require('./lerna.json').version)")-pre.${{ github.run_number }}" --no-git-tag-version --yes
+      - name: Version
+        run: npx lerna version "$(node -e "console.log(require('./lerna.json').version)")-pre.${{ github.run_number }}" --no-git-tag-version --yes
+      
       - run: git config user.email "info@openmrs.org" && git config user.name "OpenMRS CI"
       - run: git add . && git commit -m "Prerelease version" --no-verify
-      - run: npm run ci:prepublish
+
+      - name: Pre-release
+        run: yarn run ci:prepublish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
@@ -344,7 +352,10 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npx lerna bootstrap
       
-      - run: npx lerna run build --color
-      - run: npm run ci:publish
+      - name: Build
+        run: yarn turbo run build --color
+      
+      - name: Publish
+        run: yarn run ci:publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Fixes the [currently failing](https://github.com/openmrs/openmrs-esm-patient-management/runs/6466981214?check_suite_focus=true) `pre-release` job of our CI workflow. I'd mistakenly appended the `color` flag to the end of `npx lerna run build`.
