### PR TITLE
(feat) Add ability to end an active visit from the active visits table

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -30,7 +30,7 @@ import {
 import Add16 from '@carbon/icons-react/es/add/16';
 import Group16 from '@carbon/icons-react/es/group/16';
 import InProgress16 from '@carbon/icons-react/es/in-progress/16';
-import { useLayoutType, ConfigurableLink, navigate } from '@openmrs/esm-framework';
+import { useLayoutType, ConfigurableLink, navigate, showModal } from '@openmrs/esm-framework';
 import {
   useVisitQueueEntries,
   useServices,
@@ -54,6 +54,13 @@ type FilterProps = {
 function ActionsMenu({ patientUuid }: { patientUuid: string }) {
   const { t } = useTranslation();
 
+  const openEndVisitModal = useCallback(() => {
+    const dispose = showModal('end-visit-dialog', {
+      closeModal: () => dispose(),
+      patientUuid,
+    });
+  }, [patientUuid]);
+
   return (
     <OverflowMenu light selectorPrimaryFocus={'#editPatientDetails'} size="sm" flipped>
       <OverflowMenuItem
@@ -76,6 +83,7 @@ function ActionsMenu({ patientUuid }: { patientUuid: string }) {
       <OverflowMenuItem
         className={styles.menuItem}
         id="#endVisit"
+        onClick={openEndVisitModal}
         hasDivider
         isDelete
         itemText={t('endVisit', 'End visit')}>

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -54,7 +54,7 @@ type FilterProps = {
 function ActionsMenu({ patientUuid }: { patientUuid: string }) {
   const { t } = useTranslation();
 
-  const openEndVisitModal = useCallback(() => {
+  const launchEndVisitModal = useCallback(() => {
     const dispose = showModal('end-visit-dialog', {
       closeModal: () => dispose(),
       patientUuid,
@@ -83,7 +83,7 @@ function ActionsMenu({ patientUuid }: { patientUuid: string }) {
       <OverflowMenuItem
         className={styles.menuItem}
         id="#endVisit"
-        onClick={openEndVisitModal}
+        onClick={launchEndVisitModal}
         hasDivider
         isDelete
         itemText={t('endVisit', 'End visit')}>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
https://user-images.githubusercontent.com/19533785/169823613-6cde21c7-2364-4fcb-9096-6c9677e29ba8.mp4

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
