### PR TITLE
code cleanup on previous visits container

### DIFF
--- a/packages/esm-outpatient-app/src/past-visit/past-visit.component.tsx
+++ b/packages/esm-outpatient-app/src/past-visit/past-visit.component.tsx
@@ -20,15 +20,13 @@ const PastVisit: React.FC<PastVisitProps> = ({ patientUuid }) => {
 
   if (visits) {
     return (
-      <div className={styles.wrapper}>
-        <div className={styles.visitContainer}>
-          <div className={styles.container}>
-            <div className={styles.header}>
-              <h4 className={styles.visitType}>{visits?.visitType?.display}</h4>
-              <p className={styles.date}>{formatDatetime(parseDate(visits?.startDatetime))}</p>
-            </div>
-            <PastVisitSummary encounters={visits.encounters} patientUuid={patientUuid} />
+      <div className={styles.visitContainer}>
+        <div className={styles.container}>
+          <div className={styles.header}>
+            <h4 className={styles.visitType}>{visits?.visitType?.display}</h4>
+            <p className={styles.date}>{formatDatetime(parseDate(visits?.startDatetime))}</p>
           </div>
+          <PastVisitSummary encounters={visits.encounters} patientUuid={patientUuid} />
         </div>
       </div>
     );

--- a/packages/esm-outpatient-app/src/past-visit/past-visit.scss
+++ b/packages/esm-outpatient-app/src/past-visit/past-visit.scss
@@ -27,9 +27,7 @@
 
 .container {
   background-color: $ui-background;
-  border: 1px solid $grey-2;
   padding: $spacing-05;
-  margin: $spacing-05 0rem $spacing-05;
   width: 100% !important;
 }
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Removed border around previous visits container in active visits table in outpatient app

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
Before  :
<img width="671" alt="before" src="https://user-images.githubusercontent.com/19533785/170987985-88e6306c-5409-458d-89e8-5de6c24ef414.PNG">

After : 
<img width="654" alt="after" src="https://user-images.githubusercontent.com/19533785/170988021-fbfc01ab-7ab5-489d-9422-a353fb466f05.PNG">
*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
