### PR TITLE
O3-1292: The Close(X) button in visit header should go to previous page.

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -40,14 +40,18 @@ interface PaginationData {
 }
 interface NameLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
-  handleNameClick: (e: MouseEvent, to: string) => void;
-  name: string;
+  from: string;
 }
 
-const PatientNameLink: React.FC<NameLinkProps> = ({ handleNameClick, name, to }) => {
+const PatientNameLink: React.FC<NameLinkProps> = ({ from, to, children }) => {
+  const handleNameClick = (event: MouseEvent, to: string) => {
+    event.preventDefault();
+    navigate({ to });
+    localStorage.setItem('fromPage', from);
+  };
   return (
     <a onClick={(e) => handleNameClick(e, to)} href={interpolateUrl(to)}>
-      {name}
+      {children}
     </a>
   );
 };
@@ -64,12 +68,6 @@ const ActiveVisitsTable = () => {
 
   const currentPathName: string = window.location.pathname;
   const fromPage: string = getOriginFromPathName(currentPathName);
-
-  const handleNameClick = (event: MouseEvent, to: string) => {
-    event.preventDefault();
-    navigate({ to });
-    localStorage.setItem('fromPage', fromPage);
-  };
 
   const headerData = useMemo(
     () => [
@@ -190,10 +188,10 @@ const ActiveVisitsTable = () => {
                           <TableCell key={cell.id}>
                             {cell.info.header === 'name' ? (
                               <PatientNameLink
-                                name={cell.value}
-                                handleNameClick={handleNameClick}
-                                to={`\${openmrsSpaBase}/patient/${paginatedActiveVisits?.[index]?.patientUuid}/chart/`}
-                              />
+                                from={fromPage}
+                                to={`\${openmrsSpaBase}/patient/${paginatedActiveVisits?.[index]?.patientUuid}/chart/`}>
+                                {cell.value}
+                              </PatientNameLink>
                             ) : (
                               cell.value
                             )}

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -1,6 +1,7 @@
 import useSWR from 'swr';
 import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday';
+import { last } from 'lodash';
 import { openmrsFetch, Visit, useSession } from '@openmrs/esm-framework';
 
 dayjs.extend(isToday);
@@ -60,3 +61,8 @@ export function useActiveVisits() {
     isValidating,
   };
 }
+
+export const getOriginFromPathName = (pathname = '') => {
+  const from = pathname.split('/');
+  return last(from);
+};

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useCallback, MouseEvent, AnchorHTMLAttributes } from 'react';
+import React, { useEffect, useMemo, useState, useCallback, MouseEvent, AnchorHTMLAttributes, Children } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -56,13 +56,12 @@ type FilterProps = {
 interface NameLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
   handleNameClick: (e: MouseEvent, to: string) => void;
-  name: string;
 }
 
-const PatientNameLink: React.FC<NameLinkProps> = ({ handleNameClick, name, to }) => {
+const PatientNameLink: React.FC<NameLinkProps> = ({ handleNameClick, to, children }) => {
   return (
     <a onClick={(e) => handleNameClick(e, to)} href={interpolateUrl(to)}>
-      {name}
+      {children}
     </a>
   );
 };
@@ -201,9 +200,9 @@ function ActiveVisitsTable() {
         content: (
           <PatientNameLink
             to={`\${openmrsSpaBase}/patient/${entry.patientUuid}/chart`}
-            handleNameClick={handleNameClick}
-            name={entry.name}
-          />
+            handleNameClick={handleNameClick}>
+            {entry.name}
+          </PatientNameLink>
         ),
       },
       priority: {

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useCallback, MouseEvent, AnchorHTMLAttributes, Children } from 'react';
+import React, { useEffect, useMemo, useState, useCallback, MouseEvent, AnchorHTMLAttributes } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -55,10 +55,16 @@ type FilterProps = {
 
 interface NameLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
-  handleNameClick: (e: MouseEvent, to: string) => void;
+  from: string;
 }
 
-const PatientNameLink: React.FC<NameLinkProps> = ({ handleNameClick, to, children }) => {
+const PatientNameLink: React.FC<NameLinkProps> = ({ from, to, children }) => {
+  const handleNameClick = (event: MouseEvent, to: string) => {
+    event.preventDefault();
+    navigate({ to });
+    localStorage.setItem('fromPage', from);
+  };
+
   return (
     <a onClick={(e) => handleNameClick(e, to)} href={interpolateUrl(to)}>
       {children}
@@ -131,12 +137,6 @@ function ActiveVisitsTable() {
   const currentPathName: string = window.location.pathname;
   const fromPage: string = getOriginFromPathName(currentPathName);
 
-  const handleNameClick = (event: MouseEvent, to: string) => {
-    event.preventDefault();
-    navigate({ to });
-    localStorage.setItem('fromPage', fromPage);
-  };
-
   useEffect(() => {
     if (filter) {
       setFilteredRows(visitQueueEntries?.filter((entry) => entry.service === filter && /waiting/i.exec(entry.status)));
@@ -198,9 +198,7 @@ function ActiveVisitsTable() {
       ...entry,
       name: {
         content: (
-          <PatientNameLink
-            to={`\${openmrsSpaBase}/patient/${entry.patientUuid}/chart`}
-            handleNameClick={handleNameClick}>
+          <PatientNameLink to={`\${openmrsSpaBase}/patient/${entry.patientUuid}/chart`} from={fromPage}>
             {entry.name}
           </PatientNameLink>
         ),

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import useSWR from 'swr';
 import useSWRImmutable from 'swr/immutable';
 import { FetchResponse, openmrsFetch, useConfig, Visit } from '@openmrs/esm-framework';
+import { last } from 'lodash';
 
 export type QueuePriority = 'Emergency' | 'Not Urgent' | 'Priority' | 'Urgent';
 export type MappedQueuePriority = Omit<QueuePriority, 'Urgent'>;
@@ -155,3 +156,8 @@ export function useVisitQueueEntries(): UseVisitQueueEntries {
     isValidating,
   };
 }
+
+export const getOriginFromPathName = (pathname = '') => {
+  const from = pathname.split('/');
+  return last(from);
+};

--- a/packages/esm-outpatient-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-outpatient-app/src/visit-header/visit-header.component.tsx
@@ -18,6 +18,7 @@ import {
   useLayoutType,
   usePatient,
   useVisit,
+  navigate,
 } from '@openmrs/esm-framework';
 import capitalize from 'lodash-es/capitalize';
 import { launchPatientWorkspace } from './workspaces';
@@ -64,6 +65,13 @@ const VisitHeader: React.FC = () => {
 
   const noActiveVisit = !isLoading && visitNotLoaded;
 
+  const originPage = localStorage.getItem('fromPage');
+
+  const onClosePatientChart = () => {
+    originPage ? navigate({ to: `${window.spaBase}/${originPage}` }) : navigate({ to: `${window.spaBase}/home` });
+    setShowVisitHeader((prevState) => !prevState);
+    localStorage.removeItem('fromPage');
+  };
   const render = useCallback(() => {
     if (!showVisitHeader) {
       return null;
@@ -110,7 +118,7 @@ const VisitHeader: React.FC = () => {
               <HeaderGlobalAction
                 className={styles.headerGlobalBarCloseButton}
                 aria-label={t('close', 'Close')}
-                onClick={() => setShowVisitHeader((prevState) => !prevState)}>
+                onClick={onClosePatientChart}>
                 <CloseFilled20 />
               </HeaderGlobalAction>
             </HeaderGlobalBar>

--- a/packages/esm-outpatient-app/src/visit-header/visit-header.scss
+++ b/packages/esm-outpatient-app/src/visit-header/visit-header.scss
@@ -4,7 +4,7 @@
 
 .topNavHeader {
   top: var(--omrs-offline-banner-height);
-  @include brand-01(background-color);
+  @include brand-02(background-color);
 }
 
 .headerGlobalBarButton {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Implements the functionality to go back to the previous page when the close button of the patient chart page is clicked. If it was a link paste then it defaults to the `home` page.
PS: I changed the nav background color back to brand-02 as it is expected, it had been mistakenly changed in one of the previous commits.


## Video recording

https://user-images.githubusercontent.com/30952856/171272209-274fc6b7-d534-4afa-893f-1f97d48bea27.mov




## Related Issue
https://issues.openmrs.org/browse/O3-1292


