### PR TITLE
isssue O3-1194: Removed some useEffect for handling onClick outside. Now actions menu  can be opened 

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -115,10 +115,6 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
   }, [showSearchInput]);
 
   useEffect(() => {
-    showSearchInput ? setCanClickOutside(true) : setCanClickOutside(false);
-  }, [showSearchInput]);
-
-  useEffect(() => {
     if (isEmpty(searchTerm)) {
       setShowResultsPanel(false);
     }


### PR DESCRIPTION
… can open

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
