### PR TITLE
(feature) O3-1284: Patient search bar extension

### DIFF
--- a/packages/esm-patient-search-app/src/index.ts
+++ b/packages/esm-patient-search-app/src/index.ts
@@ -30,9 +30,16 @@ function setupOpenMRS() {
         load: getAsyncLifecycle(() => import('./patient-search-icon/patient-search-icon.component'), options),
       },
       {
+        // This extension renders the a Patient-Search Button, which when clicked, opens the search bar in an overlay.
         id: 'patient-search-button',
         slot: 'patient-search-button-slot',
         load: getAsyncLifecycle(() => import('./patient-search-button/patient-search-button.component'), options),
+      },
+      {
+        // P.S. This extension is not compatible with the tablet view.
+        id: 'patient-search-bar',
+        slot: 'patient-search-bar-slot',
+        load: getAsyncLifecycle(() => import('./patient-search-bar/patient-search-bar.component'), options),
       },
     ],
   };

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -11,6 +11,7 @@ interface PatientSearchBarProps {
   floatingSearchResults?: boolean;
   hidePanel?: () => void;
   orangeBorder?: boolean;
+  buttonProps?: Object;
 }
 
 const searchTimeout = 300;
@@ -21,6 +22,7 @@ const PatientSearchBar: React.FC<PatientSearchBarProps> = ({
   floatingSearchResults = true,
   orangeBorder,
   hidePanel,
+  buttonProps,
 }) => {
   const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState<string>();
@@ -38,7 +40,7 @@ const PatientSearchBar: React.FC<PatientSearchBarProps> = ({
           onChange={(event) => handleChange(event.target.value)}
           autoFocus={true}
         />
-        <Button type="submit" className={styles.searchButton} size={small ? 'sm' : 'md'}>
+        <Button type="submit" className={styles.searchButton} size={small ? 'sm' : 'md'} {...buttonProps}>
           {t('search', 'Search')}
         </Button>
       </div>

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -10,6 +10,7 @@ interface PatientSearchBarProps {
   selectPatientAction?: (patientUuid: string) => void;
   floatingSearchResults?: boolean;
   hidePanel?: () => void;
+  orangeBorder?: boolean;
 }
 
 const searchTimeout = 300;
@@ -17,7 +18,8 @@ const searchTimeout = 300;
 const PatientSearchBar: React.FC<PatientSearchBarProps> = ({
   small,
   selectPatientAction,
-  floatingSearchResults,
+  floatingSearchResults = true,
+  orangeBorder,
   hidePanel,
 }) => {
   const { t } = useTranslation();
@@ -26,7 +28,7 @@ const PatientSearchBar: React.FC<PatientSearchBarProps> = ({
 
   return (
     <div className={styles.patientSearchWrapper}>
-      <div className={styles.searchArea}>
+      <div className={`${styles.searchArea} ${orangeBorder && styles.orangeBorder}`}>
         <Search
           className={styles.patientSearchInput}
           size={small ? 'sm' : 'xl'}

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
@@ -33,6 +33,15 @@
   justify-content: center;
   flex-direction: row;
   align-items: center;
+  border: 1px solid $ui-04;
+}
+
+.patientSearchInput {
+  border: none;
+}
+
+.orangeBorder {
+  border: 1px solid $carbon--orange-40;
 }
 
 .searchButton,

--- a/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.component.tsx
@@ -27,7 +27,11 @@ const PatientSearchButton: React.FC<PatientSearchButtonProps> = ({
         <Overlay
           close={() => setShowSearchOverlay(false)}
           header={overlayHeader ? overlayHeader : t('searchResults', 'Search Results')}>
-          <PatientSearchBar hidePanel={() => setShowSearchOverlay(false)} selectPatientAction={selectPatientAction} />
+          <PatientSearchBar
+            hidePanel={() => setShowSearchOverlay(false)}
+            selectPatientAction={selectPatientAction}
+            floatingSearchResults={false}
+          />
         </Overlay>
       )}
 

--- a/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.component.tsx
@@ -9,7 +9,7 @@ interface PatientSearchButtonProps {
   buttonText?: string;
   overlayHeader?: string;
   selectPatientAction?: (patientUuid: string) => {};
-  buttonProps?: {};
+  buttonProps?: Object;
 }
 
 const PatientSearchButton: React.FC<PatientSearchButtonProps> = ({

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.scss
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.scss
@@ -14,7 +14,6 @@
 
 .patientSearchBar {
   width: 50vw;
-  border: 1px solid $carbon--orange-40;
 }
 
 .searchIconButton {

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -31,11 +31,11 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
       {showSearchInput &&
         (isDesktop ? (
           <div className={styles.patientSearchBar}>
-            <PatientSearchBar hidePanel={() => setShowSearchInput(false)} small floatingSearchResults />
+            <PatientSearchBar hidePanel={() => setShowSearchInput(false)} small orangeBorder />
           </div>
         ) : (
           <Overlay close={() => setShowSearchInput(false)} header={t('searchResults', 'Search Results')}>
-            <PatientSearchBar hidePanel={() => setShowSearchInput(false)} />
+            <PatientSearchBar hidePanel={() => setShowSearchInput(false)} floatingSearchResults={false} orangeBorder />
           </Overlay>
         ))}
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR adds the functionality to add the search bar as an extension, which can be placed anywhere in the application.
P.S. This search bar extension is made only for desktop view.

Extension-slot-name: **patient-search-bar-slot**
State which can be passed into the extension slot:
1. `small`, it is a boolean value to render a smaller and compact patient search bar.
2. `selectPatientAction`, you can pass your custom function to this prop, as in to decide what to do when a patient is selected.
3. `buttonProps`, this is an object, where you can pass the button props for search button as in to customize it.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
