### PR TITLE
(refactor) Replace deprecated useSessionUser with useSession

### DIFF
--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Calendar16 from '@carbon/icons-react/es/calendar/16';
 import Location16 from '@carbon/icons-react/es/location/16';
-import { formatDate, useSessionUser } from '@openmrs/esm-framework';
+import { formatDate, useSession } from '@openmrs/esm-framework';
 import styles from './appointments-header.scss';
 import AppointmentsIllustration from './appointments-illustration.component';
 
 const AppointmentsHeader: React.FC<{ title: string }> = ({ title }) => {
   const { t } = useTranslation();
-  const userSession = useSessionUser();
+  const userSession = useSession();
   const userLocation = userSession?.sessionLocation?.display;
 
   return (

--- a/packages/esm-appointments-app/src/appointments/patient-list-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/patient-list-list.component.tsx
@@ -4,7 +4,7 @@ import { Button, DataTableHeader, Tab, Tabs } from 'carbon-components-react';
 import PatientListTable from './patient-list-table.component';
 import CreateNewList from '../ui-components/create-edit-patient-list/create-edit-list.component';
 import { useTranslation } from 'react-i18next';
-import { ExtensionSlot, showModal, useSessionUser } from '@openmrs/esm-framework';
+import { ExtensionSlot, showModal, useSession } from '@openmrs/esm-framework';
 import styles from './patient-list-list.scss';
 import { useAllPatientLists } from '../api/hooks';
 import { PatientList, PatientListFilter, PatientListType } from '../api/types';
@@ -90,7 +90,7 @@ const PatientListList: React.FC = () => {
   const [selectedTab, setSelectedTab] = useState(TabTypes.STARRED);
   const [searchString, setSearchString] = useState<string>('');
   const patientListFilter = usePatientListFilterForCurrentTab(selectedTab, searchString);
-  const userId = useSessionUser()?.user.uuid;
+  const userId = useSession()?.user.uuid;
   const customHeaders = useAppropriateTableHeadersForSelectedTab(selectedTab);
   const patientListQuery = useAllPatientLists(userId, patientListFilter);
   const [showOverlay, setShowOverlay] = useState(false);

--- a/packages/esm-appointments-app/src/appointments/patient-list-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/patient-list-table.component.tsx
@@ -17,7 +17,7 @@ import {
 } from 'carbon-components-react';
 import Star16 from '@carbon/icons-react/es/star/16';
 import StarFilled16 from '@carbon/icons-react/es/star--filled/16';
-import { useSessionUser, ConfigurableLink, useLayoutType } from '@openmrs/esm-framework';
+import { useSession, ConfigurableLink, useLayoutType } from '@openmrs/esm-framework';
 import styles from './patient-list-list.scss';
 import debounce from 'lodash-es/debounce';
 import { updateLocalOrRemotePatientList } from '../api/api';
@@ -54,7 +54,7 @@ const PatientListTable: React.FC<PatientListTableProps> = ({
   refetch,
   search,
 }) => {
-  const userId = useSessionUser()?.user.uuid;
+  const userId = useSession()?.user.uuid;
   const isDesktop = useLayoutType() === 'desktop';
 
   const handleSearch = useMemo(() => debounce((searchTerm) => search.onSearch(searchTerm), 300), []);

--- a/packages/esm-appointments-app/src/ui-components/create-edit-patient-list/create-edit-list.component.tsx
+++ b/packages/esm-appointments-app/src/ui-components/create-edit-patient-list/create-edit-list.component.tsx
@@ -3,7 +3,7 @@ import { Button, Dropdown, OnChangeData, TextArea, TextInput } from 'carbon-comp
 import Overlay from '../../aa-tbd/overlay.component';
 import { useTranslation } from 'react-i18next';
 import styles from './create-edit-patient-list.scss';
-import { useLayoutType, showToast, useSessionUser } from '@openmrs/esm-framework';
+import { useLayoutType, showToast, useSession } from '@openmrs/esm-framework';
 import { createPatientList, editPatientList } from '../../api/api-remote';
 import { useCohortTypes } from '../../api/hooks';
 import { OpenmrsCohort, NewCohortData } from '../../api/types';
@@ -29,7 +29,7 @@ const CreateEditPatientList: React.FC<CreateEditPatientListProps> = ({
     location: '',
   });
   const isDesktop = useLayoutType() === 'desktop';
-  const user = useSessionUser();
+  const user = useSession();
   const { data: cohortTypes } = useCohortTypes();
 
   useEffect(() => {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Replace deprecated useSessionUser with useSession

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
