### PR TITLE
Removed Patient list from clinic-metrics' Average wait time card using props. 

### DIFF
--- a/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -28,11 +28,13 @@ const ClinicMetrics: React.FC = () => {
           label={t('patients', 'Patients')}
           value={metrics ? metrics.scheduled_appointments : 0}
           headerLabel={t('scheduledAppointments', 'Scheduled appts. today')}
+          showList={true}
         />
         <MetricsCard
           label={t('patients', 'Patients')}
           value={serviceCount}
-          headerLabel={t('waitingFor', 'Waiting for:')}>
+          headerLabel={t('waitingFor', 'Waiting for:')}
+          showList={true}>
           <Dropdown
             style={{ marginTop: '1.5rem' }}
             id="inline"
@@ -47,6 +49,7 @@ const ClinicMetrics: React.FC = () => {
           label={t('minutes', 'Minutes')}
           value={metrics ? metrics.average_wait_time : 0}
           headerLabel={t('averageWaitTime', 'Average wait time today')}
+          showList={false}
         />
       </div>
     </>

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.component.tsx
@@ -9,9 +9,10 @@ interface MetricsCardProps {
   value: number;
   headerLabel: string;
   children?: React.ReactNode;
+  showList: boolean;
 }
 
-const MetricsCard: React.FC<MetricsCardProps> = ({ label, value, headerLabel, children }) => {
+const MetricsCard: React.FC<MetricsCardProps> = ({ label, value, headerLabel, children, showList }) => {
   const { t } = useTranslation();
 
   return (
@@ -21,9 +22,11 @@ const MetricsCard: React.FC<MetricsCardProps> = ({ label, value, headerLabel, ch
           <label className={styles.headerLabel}>{headerLabel}</label>
           {children}
         </div>
-        <Button kind="ghost" renderIcon={ArrowRight16} iconDescription={t('patientList', 'Patient list')}>
-          {t('patientList', 'Patient list')}
-        </Button>
+        {showList ? (
+          <Button kind="ghost" renderIcon={ArrowRight16} iconDescription={t('patientList', 'Patient list')}>
+            {t('patientList', 'Patient list')}
+          </Button>
+        ) : null}
       </div>
       <div>
         <label className={styles.totalsLabel}>{label}</label>


### PR DESCRIPTION
…rd <metrics-card-avg-wait-time> with duplicated code

## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Removed Patient list from clinic-metrics Average wait time today.
-->

## Screenshots

<!--
Optional.
![image](https://user-images.githubusercontent.com/11721739/175765605-6cfb030b-ea31-4a29-8a4c-60b0a41c2fac.png)
![image](https://user-images.githubusercontent.com/11721739/175765631-ba77ec97-138d-4d88-bdc4-f1267d3e625b.png)

-->


## Related Issue

<!--
https://issues.openmrs.org/browse/O3-995
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
