### PR TITLE
(fix) Fixed active visits tests - updated services dropdown

### DIFF
--- a/packages/esm-outpatient-app/__mocks__/active-visits.mock.ts
+++ b/packages/esm-outpatient-app/__mocks__/active-visits.mock.ts
@@ -1,4 +1,7 @@
-export const mockServices = ['Clinical consultation', 'Triage'];
+export const mockServices = [
+  { uuid: '176052c7-5fd4-4b33-89cc-7bae6848c65a', display: 'Clinical consultation' },
+  { uuid: 'd80ff12a-06a7-11ed-b939-0242ac120002', display: 'Triage' },
+];
 
 export const mockVisitQueueEntries = [
   {

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -338,7 +338,7 @@ function ActiveVisitsTable() {
                       label=""
                       titleText={t('showPatientsWaitingFor', 'Show patients waiting for') + ':'}
                       type="inline"
-                      items={services}
+                      items={[{ display: 'All' }, ...services]}
                       itemToString={(item) => (item ? item.display : '')}
                       onChange={handleServiceChange}
                       size="sm"

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.test.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.test.tsx
@@ -82,6 +82,7 @@ describe('ActiveVisitsTable: ', () => {
     // filter table to only show patients waiting for `Triage`
     const serviceFilter = screen.getByRole('button', { name: /show patients waiting for/i });
     userEvent.click(serviceFilter);
+    expect(screen.getByRole('listbox', { name: /show patients waiting for/i }));
     userEvent.click(screen.getByRole('option', { name: /Triage/i }));
 
     expect(screen.queryByText(/waiting for clinical consultation/i)).not.toBeInTheDocument();


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Refactored structure of data in services dropdown in active visits table to object with uuid and display. Updated active-visits-test and mock data to accomodate an object.

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
