### PR TITLE
O3-1228:Coded drop-down fields should default to "no selected value"

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.component.tsx
@@ -26,7 +26,7 @@ export function CodedPersonAttributeField({
           name={`attributes.${personAttributeType.uuid}`}
           labelText={label ?? personAttributeType?.display}
           light>
-          <SelectItem value={''} text="" />
+          <SelectItem value="" text="" />
           {conceptAnswers.map((answer) => (
             <SelectItem key={answer.uuid} value={answer.uuid} text={answer.display} />
           ))}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Currently, for coded attributes, the first option is always selected by default and by default no option should be selected. I therefore made the select Item value to be an empty string instead. 


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

(https://issues.openmrs.org/browse/O3-1228)


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
