### PR TITLE
(enhancement) Add ability to filter out undefined patient-identifiers

### DIFF
--- a/packages/esm-patient-registration-app/src/add-patient-link.tsx
+++ b/packages/esm-patient-registration-app/src/add-patient-link.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Add20 from '@carbon/icons-react/es/add/20';
+import UserFollow20 from '@carbon/icons-react/es/user--follow/20';
 import styles from './add-patient-link.scss';
 import { navigate } from '@openmrs/esm-framework';
 import { HeaderGlobalAction } from 'carbon-components-react';
@@ -14,7 +14,7 @@ export default function Root() {
       name="AddPatientIcon"
       onClick={addPatient}
       className={styles.slotStyles}>
-      <Add20 />
+      <UserFollow20 />
     </HeaderGlobalAction>
   );
 }

--- a/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.component.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import { Button, SkeletonText } from 'carbon-components-react';
 import { ArrowRight16 } from '@carbon/icons-react';
-import { useLayoutType, useConfig } from '@openmrs/esm-framework';
+import { useLayoutType, useConfig, UserHasAccess } from '@openmrs/esm-framework';
 import {
   FormValues,
   IdentifierSource,
@@ -113,16 +113,18 @@ export const Identifiers: React.FC = () => {
 
   return (
     <div className={styles.halfWidthInDesktopView}>
-      <div className={styles.identifierLabelText}>
-        <h4 className={styles.productiveHeading02Light}>{t('idFieldLabelText', 'Identifiers')}</h4>
-        <Button
-          kind="ghost"
-          className={styles.setIDNumberButton}
-          onClick={() => setShowIdentifierOverlay(true)}
-          size={desktop ? 'sm' : 'md'}>
-          {t('configure', 'Configure')} <ArrowRight16 />
-        </Button>
-      </div>
+      <UserHasAccess privilege="coreapps.systemAdministration">
+        <div className={styles.identifierLabelText}>
+          <h4 className={styles.productiveHeading02Light}>{t('idFieldLabelText', 'Identifiers')}</h4>
+          <Button
+            kind="ghost"
+            className={styles.setIDNumberButton}
+            onClick={() => setShowIdentifierOverlay(true)}
+            size={desktop ? 'sm' : 'md'}>
+            {t('configure', 'Configure')} <ArrowRight16 />
+          </Button>
+        </div>
+      </UserHasAccess>
       <div>
         {Object.entries(values.identifiers).map(([fieldName, identifier]) => (
           <IdentifierInput key={fieldName} fieldName={fieldName} patientIdentifier={identifier} />

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
@@ -7,7 +7,7 @@ import { PatientRegistrationContext } from '../../../patient-registration-contex
 import { TrashCan16, Edit16, Reset16 } from '@carbon/icons-react';
 import { Button } from 'carbon-components-react';
 import { ResourcesContext } from '../../../../offline.resources';
-import { showModal, useConfig } from '@openmrs/esm-framework';
+import { showModal, useConfig, UserHasAccess } from '@openmrs/esm-framework';
 import { shouldBlockPatientIdentifierInOfflineMode } from './utils';
 import { useField } from 'formik';
 import { deleteIdentifierType, setIdentifierSource } from '../../../field/id/id-field.component';
@@ -133,14 +133,16 @@ export const IdentifierInput: React.FC<IdentifierInputProps> = ({ patientIdentif
           </Button>
         )}
         {!patientIdentifier.required && !defaultPatientIdentifierTypesMap[patientIdentifier.identifierTypeUuid] && (
-          <Button
-            kind="danger--ghost"
-            onClick={handleDelete}
-            iconDescription={t('deleteIdentifierTooltip', 'Delete')}
-            disabled={disabled}
-            hasIconOnly>
-            <TrashCan16 />
-          </Button>
+          <UserHasAccess privilege="coreapps.systemAdministration">
+            <Button
+              kind="danger--ghost"
+              onClick={handleDelete}
+              iconDescription={t('deleteIdentifierTooltip', 'Delete')}
+              disabled={disabled}
+              hasIconOnly>
+              <TrashCan16 />
+            </Button>
+          </UserHasAccess>
         )}
       </div>
     </div>

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-utils.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-utils.ts
@@ -169,3 +169,10 @@ export function getPhonePersonAttributeValueFromFhirPatient(patient: fhir.Patien
   }
   return result;
 }
+
+export const filterUndefinedPatientIdenfier = (patientIdenfiers) =>
+  Object.fromEntries(
+    Object.entries<PatientIdentifierValue>(patientIdenfiers).filter(
+      ([key, value]) => value.identifierValue !== undefined,
+    ),
+  );

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -15,12 +15,17 @@ import {
 } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { validationSchema as initialSchema } from './validation/patient-registration-validation';
-import { FormValues, CapturePhotoProps } from './patient-registration-types';
+import { FormValues, CapturePhotoProps, PatientIdentifierValue } from './patient-registration-types';
 import { PatientRegistrationContext } from './patient-registration-context';
 import { SavePatientForm, SavePatientTransactionManager } from './form-manager';
 import { usePatientPhoto } from './patient-registration.resource';
 import { DummyDataInput } from './input/dummy-data/dummy-data-input.component';
-import { cancelRegistration, parseAddressTemplateXml, scrollIntoView } from './patient-registration-utils';
+import {
+  cancelRegistration,
+  filterUndefinedPatientIdenfier,
+  parseAddressTemplateXml,
+  scrollIntoView,
+} from './patient-registration-utils';
 import { useInitialAddressFieldValues, useInitialFormValues, usePatientUuidMap } from './patient-registration-hooks';
 import { ResourcesContext } from '../offline.resources';
 import { builtInSections, RegistrationConfig, SectionDefinition } from '../config-schema';
@@ -95,10 +100,12 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
     const abortController = new AbortController();
     helpers.setSubmitting(true);
 
+    const updatedFormValues = { ...values, identifiers: filterUndefinedPatientIdenfier(values.identifiers) };
+
     try {
       await savePatientForm(
         !inEditMode,
-        values,
+        updatedFormValues,
         patientUuidMap,
         initialAddressFieldValues,
         capturePhotoProps,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ x I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR has a number of changes namely.

1. Update the patient-registration icon on the primary-navigation bar to match [design](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/614b4096c82862b62d8422b7)
2. Add ability to filter out patient-identifiers without patientIdenfierValue, this is causing an error when creating a patient, since the specified identifier is either undefined or null therefore the rest endpoint returns an error object
3. Allow only Admin to configure patient-identifier but still users to view and add identifiers


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
