### PR TITLE
(fix) Propagates selectPatientAction to PatientSearch

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -7,9 +7,14 @@ import PatientSearch from './patient-search.component';
 interface CompactPatientSearchProps {
   query: string;
   searchPage: boolean;
+  selectPatientAction?: () => undefined;
 }
 
-const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({ query, searchPage = false }) => {
+const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
+  query,
+  searchPage = false,
+  selectPatientAction,
+}) => {
   const [searchTerm, setSearchTerm] = useState(query);
 
   const onSubmit = useCallback(
@@ -39,7 +44,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({ qu
       />
       {!!searchTerm && !searchPage && (
         <div className={styles.floatingSearchResultsContainer}>
-          <PatientSearch query={searchTerm} />
+          <PatientSearch query={searchTerm} selectPatientAction={selectPatientAction} />
         </div>
       )}
     </div>

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -7,7 +7,7 @@ import PatientSearch from './patient-search.component';
 interface CompactPatientSearchProps {
   query: string;
   searchPage: boolean;
-  selectPatientAction?: () => undefined;
+  selectPatientAction?: (patientUuid: string) => undefined;
 }
 
 const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This is a bug fix which allows the variable selectPatientAction to get passed down from `compact-patient-search.component` to its now child `PatientSearch`

## Screenshots

*None.*


## Related Issue

*None.*

## Other

*None.*
