### PR TITLE
Add ability to launch overlay with component

### DIFF
--- a/packages/esm-appointments-app/src/appoinments-tabs/appointments-base-table.component.tsx
+++ b/packages/esm-appointments-app/src/appoinments-tabs/appointments-base-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -25,10 +25,11 @@ import Add16 from '@carbon/icons-react/es/add/16';
 import Omega16 from '@carbon/icons-react/es/omega/16';
 import Cough16 from '@carbon/icons-react/es/cough/16';
 import Medication16 from '@carbon/icons-react/es/medication/16';
-import { useLayoutType, ConfigurableLink, formatDatetime, parseDate } from '@openmrs/esm-framework';
+import { useLayoutType, ConfigurableLink } from '@openmrs/esm-framework';
 import PatientSearch from '../patient-search/patient-search.component';
 import styles from './appointments-base-table.scss';
-import { MappedAppointment, Appointment } from '../types';
+import { MappedAppointment } from '../types';
+import { launchOverlay } from '../hooks/useOverlay';
 import AppointmentDetails from '../appointment-details/appointment-details.component';
 
 interface AppointmentsProps {
@@ -73,7 +74,6 @@ function ServiceIcon({ service }) {
 
 const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLoading, tableHeading }) => {
   const { t } = useTranslation();
-  const [showOverlay, setShowOverlay] = useState(false);
   const isDesktop = useLayoutType() === 'desktop';
 
   const tableHeaders = useMemo(
@@ -152,7 +152,7 @@ const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLo
             size="small"
             kind="secondary"
             renderIcon={Add16}
-            onClick={() => setShowOverlay(true)}
+            onClick={() => launchOverlay(t('search', 'Search'), <PatientSearch />)}
             iconDescription={t('addNewAppointment', 'Add new Appointment')}>
             {t('addNewAppointment', 'Add new Appointment')}
           </Button>
@@ -219,7 +219,11 @@ const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLo
                       <p className={styles.helper}>{t('checkFilters', 'Check the filters above')}</p>
                     </div>
                     <p className={styles.separator}>{t('or', 'or')}</p>
-                    <Button kind="ghost" size="small" renderIcon={Add16} onClick={() => setShowOverlay(true)}>
+                    <Button
+                      kind="ghost"
+                      size="small"
+                      renderIcon={Add16}
+                      onClick={() => launchOverlay(t('search', 'Search'), <PatientSearch />)}>
                       {t('addNewAppointment', 'Add new Appointment')}
                     </Button>
                   </Tile>
@@ -228,7 +232,6 @@ const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLo
             </TableContainer>
           )}
         </DataTable>
-        {showOverlay && <PatientSearch closePanel={() => setShowOverlay(false)} />}
       </div>
     );
   }
@@ -238,12 +241,15 @@ const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLo
       <div className={styles.tileContainer}>
         <Tile className={styles.tile}>
           <p className={styles.content}>{t('noAppointmentsToDisplay', 'No appointments to display')}</p>
-          <Button kind="ghost" size="small" renderIcon={Add16} onClick={() => setShowOverlay(true)}>
+          <Button
+            kind="ghost"
+            size="small"
+            renderIcon={Add16}
+            onClick={() => launchOverlay(t('search', 'Search'), <PatientSearch />)}>
             {t('addNewAppointment', 'Add new Appointment')}
           </Button>
         </Tile>
       </div>
-      {showOverlay && <PatientSearch closePanel={() => setShowOverlay(false)} />}
     </div>
   );
 };

--- a/packages/esm-appointments-app/src/hooks/useOverlay.tsx
+++ b/packages/esm-appointments-app/src/hooks/useOverlay.tsx
@@ -1,0 +1,42 @@
+import { getGlobalStore } from '@openmrs/esm-framework';
+import { useEffect, useState } from 'react';
+
+interface OverlayStore {
+  isOverlayOpen: boolean;
+  component?: Function;
+  header: string;
+}
+
+const initialState = { isOverlayOpen: false, component: Function, header: '' };
+
+const getOverlayStore = () => {
+  return getGlobalStore('appointment-store', initialState);
+};
+
+export const launchOverlay = (headerTitle: string, componentToRender) => {
+  const store = getOverlayStore();
+  store.setState({ isOverlayOpen: true, component: componentToRender, header: headerTitle });
+};
+
+export const closeOverlay = () => {
+  const store = getOverlayStore();
+  store.setState({ component: null, isOverlayOpen: false });
+};
+
+export const useOverlay = () => {
+  const [overlay, setOverlay] = useState<OverlayStore>();
+
+  useEffect(() => {
+    function update(state: OverlayStore) {
+      setOverlay(state);
+    }
+    update(getOverlayStore().getState());
+    getOverlayStore().subscribe(update);
+  }, []);
+
+  return {
+    isOverlayOpen: overlay?.isOverlayOpen,
+    component: overlay?.component,
+    header: overlay?.header,
+  };
+};

--- a/packages/esm-appointments-app/src/overlay.component.tsx
+++ b/packages/esm-appointments-app/src/overlay.component.tsx
@@ -3,34 +3,35 @@ import { ArrowLeft16, Close16 } from '@carbon/icons-react';
 import { Button, Header } from 'carbon-components-react';
 import { useLayoutType } from '@openmrs/esm-framework';
 import styles from './overlay.scss';
+import { closeOverlay, useOverlay } from './hooks/useOverlay';
 
-interface OverlayProps {
-  closePanel: () => void;
-  header: string;
-}
-
-const Overlay: React.FC<OverlayProps> = ({ closePanel, children, header }) => {
+const Overlay: React.FC = () => {
+  const { header, component, isOverlayOpen } = useOverlay();
   const isDesktop = useLayoutType() === 'desktop';
 
   return (
-    <div className={isDesktop ? styles.desktopOverlay : styles.tabletOverlay}>
-      {isDesktop ? (
-        <div className={styles.desktopHeader}>
-          <div className={styles.headerContent}>{header}</div>
-          <Button className={styles.closePanelButton} onClick={closePanel} kind="ghost" hasIconOnly>
-            <Close16 />
-          </Button>
+    <>
+      {isOverlayOpen && (
+        <div className={isDesktop ? styles.desktopOverlay : styles.tabletOverlay}>
+          {isDesktop ? (
+            <div className={styles.desktopHeader}>
+              <div className={styles.headerContent}>{header}</div>
+              <Button className={styles.closePanelButton} onClick={() => closeOverlay()} kind="ghost" hasIconOnly>
+                <Close16 />
+              </Button>
+            </div>
+          ) : (
+            <Header onClick={() => closeOverlay()} aria-label="Tablet overlay" className={styles.tabletOverlayHeader}>
+              <Button hasIconOnly>
+                <ArrowLeft16 />
+              </Button>
+              <div className={styles.headerContent}>{header}</div>
+            </Header>
+          )}
+          <div>{component}</div>
         </div>
-      ) : (
-        <Header aria-label="Tablet overlay" className={styles.tabletOverlayHeader}>
-          <Button onClick={closePanel} hasIconOnly>
-            <ArrowLeft16 onClick={closePanel} />
-          </Button>
-          <div className={styles.headerContent}>{header}</div>
-        </Header>
       )}
-      <div>{children}</div>
-    </div>
+    </>
   );
 };
 

--- a/packages/esm-appointments-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-appointments-app/src/patient-search/patient-search.component.tsx
@@ -1,18 +1,12 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Overlay from '../overlay.component';
 import BasicSearch from './basic-search.component';
 import AdvancedSearch from './advanced-search.component';
 import PatientScheduledVisits from './patient-scheduled-visits.component';
 import SearchResults from './search-results.component';
 import { SearchTypes } from '../types';
 
-interface PatientSearchProps {
-  closePanel: () => void;
-}
-
-const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel }) => {
-  const { t } = useTranslation();
+const PatientSearch: React.FC = () => {
   const [searchType, setSearchType] = useState<SearchTypes>(SearchTypes.BASIC);
 
   const toggleSearchType = (searchType: SearchTypes) => {
@@ -21,19 +15,17 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel }) => {
 
   return (
     <>
-      <Overlay header={t('addNewAppointment', 'Add new Appointment')} closePanel={closePanel}>
-        <div className="omrs-main-content">
-          {searchType === SearchTypes.BASIC ? (
-            <BasicSearch toggleSearchType={toggleSearchType} />
-          ) : searchType === SearchTypes.ADVANCED ? (
-            <AdvancedSearch toggleSearchType={toggleSearchType} />
-          ) : searchType === SearchTypes.SEARCH_RESULTS ? (
-            <SearchResults patients={[]} toggleSearchType={toggleSearchType} />
-          ) : searchType === SearchTypes.SCHEDULED_VISITS ? (
-            <PatientScheduledVisits toggleSearchType={toggleSearchType} />
-          ) : null}
-        </div>
-      </Overlay>
+      <div className="omrs-main-content">
+        {searchType === SearchTypes.BASIC ? (
+          <BasicSearch toggleSearchType={toggleSearchType} />
+        ) : searchType === SearchTypes.ADVANCED ? (
+          <AdvancedSearch toggleSearchType={toggleSearchType} />
+        ) : searchType === SearchTypes.SEARCH_RESULTS ? (
+          <SearchResults patients={[]} toggleSearchType={toggleSearchType} />
+        ) : searchType === SearchTypes.SCHEDULED_VISITS ? (
+          <PatientScheduledVisits toggleSearchType={toggleSearchType} />
+        ) : null}
+      </div>
     </>
   );
 };

--- a/packages/esm-appointments-app/src/root.component.tsx
+++ b/packages/esm-appointments-app/src/root.component.tsx
@@ -3,6 +3,7 @@ import { SWRConfig } from 'swr';
 import { BrowserRouter, Route } from 'react-router-dom';
 import { spaBasePath } from './constants';
 import AppointmentsDashboard from './dashboard/appointments-dashboard.component';
+import Overlay from './overlay.component';
 
 const swrConfiguration = {
   errorRetryCount: 3,
@@ -14,6 +15,7 @@ const Root: React.FC = () => {
       <SWRConfig value={swrConfiguration}>
         <BrowserRouter basename={spaBasePath}>
           <Route path="/:view?" component={AppointmentsDashboard} />
+          <Overlay />
         </BrowserRouter>
       </SWRConfig>
     </main>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR adds ability to `launchOverlay` with a function specifying the headerTitle to be displayed on the overlay-component and the component to render once the overlay is opened. 


## Screenshots

![Peek 2022-08-02 18-45](https://user-images.githubusercontent.com/28008754/182416533-51e0ab5d-e605-404b-a758-7e53ccd0393e.gif)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
