### PR TITLE
(fix): Reload queue entry on change of status

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/change-status-dialog.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/change-status-dialog.component.tsx
@@ -15,6 +15,7 @@ import { showNotification, showToast, toDateObjectStrict, toOmrsIsoString } from
 import { updateQueueEntry, usePriority, useStatus } from './active-visits-table.resource';
 import { useTranslation } from 'react-i18next';
 import styles from './change-status-dialog.scss';
+import { useSWRConfig } from 'swr';
 
 interface ChangeStatusDialogProps {
   patientUuid: string;
@@ -36,6 +37,7 @@ const ChangeStatus: React.FC<ChangeStatusDialogProps> = ({
   const [priority, setPriority] = useState();
   const { priorities } = usePriority();
   const { statuses } = useStatus();
+  const { mutate } = useSWRConfig();
 
   const changeQueueStatus = useCallback(() => {
     const endDate = toDateObjectStrict(toOmrsIsoString(new Date()));
@@ -57,6 +59,7 @@ const ChangeStatus: React.FC<ChangeStatusDialogProps> = ({
             description: t('queueEntryUpdateSuccessfully', 'Queue Entry Updated Successfully'),
           });
           closeModal();
+          mutate(`/ws/rest/v1/visit-queue-entry?v=full`);
         }
       },
       (error) => {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
