### PR TITLE
(enhancement): Add spiner to indicate loading/fetching of queue status

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
@@ -119,10 +119,11 @@ export function useStatus() {
   } = config;
 
   const apiUrl = `/ws/rest/v1/concept/${statusConceptSetUuid}`;
-  const { data } = useSWRImmutable<FetchResponse>(apiUrl, openmrsFetch);
+  const { data, error } = useSWRImmutable<FetchResponse>(apiUrl, openmrsFetch);
 
   return {
     statuses: data ? data?.data?.setMembers : [],
+    isLoading: !data && !error,
   };
 }
 

--- a/packages/esm-outpatient-app/src/active-visits/change-status-dialog.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/change-status-dialog.component.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import {
   Button,
+  InlineLoading,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -36,7 +37,7 @@ const ChangeStatus: React.FC<ChangeStatusDialogProps> = ({
   const [status, setStatus] = useState('');
   const [priority, setPriority] = useState();
   const { priorities } = usePriority();
-  const { statuses } = useStatus();
+  const { statuses, isLoading } = useStatus();
   const { mutate } = useSWRConfig();
 
   const changeQueueStatus = useCallback(() => {
@@ -86,9 +87,13 @@ const ChangeStatus: React.FC<ChangeStatusDialogProps> = ({
               onChange={(event) => setStatus(event.toString())}
               name="radio-button-group"
               valueSelected="default-selected">
-              {statuses.map(({ uuid, display, name }) => (
-                <RadioButton key={uuid} className={styles.radioButton} id={name} labelText={display} value={uuid} />
-              ))}
+              {isLoading ? (
+                <InlineLoading description={t('loading', 'Loading...')} />
+              ) : (
+                statuses.map(({ uuid, display, name }) => (
+                  <RadioButton key={uuid} className={styles.radioButton} id={name} labelText={display} value={uuid} />
+                ))
+              )}
             </RadioButtonGroup>
           </FormGroup>
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
