### PR TITLE
(fix) Updated styling in outpatient table expansion and tabs

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -25,6 +25,9 @@ import {
   TableToolbarContent,
   TableToolbarSearch,
   Tabs,
+  TabPanels,
+  TabPanel,
+  TabList,
   Tag,
   Tile,
 } from '@carbon/react';
@@ -395,15 +398,21 @@ function ActiveVisitsTable() {
                           <TableExpandedRow className={styles.expandedActiveVisitRow} colSpan={headers.length + 2}>
                             <>
                               <Tabs>
-                                <Tab label={t('currentVisit', 'Current visit')}>
-                                  <CurrentVisit
-                                    patientUuid={tableRows?.[index]?.patientUuid}
-                                    visitUuid={tableRows?.[index]?.visitUuid}
-                                  />
-                                </Tab>
-                                <Tab label={t('previousVisit', 'Previous visit')}>
-                                  <PastVisit patientUuid={tableRows?.[index]?.patientUuid} />
-                                </Tab>
+                                <TabList>
+                                  <Tab>{t('currentVisit', 'Current visit')}</Tab>
+                                  <Tab>{t('previousVisit', 'Previous visit')} </Tab>
+                                </TabList>
+                                <TabPanels>
+                                  <TabPanel>
+                                    <CurrentVisit
+                                      patientUuid={tableRows?.[index]?.patientUuid}
+                                      visitUuid={tableRows?.[index]?.visitUuid}
+                                    />
+                                  </TabPanel>
+                                  <TabPanel>
+                                    <PastVisit patientUuid={tableRows?.[index]?.patientUuid} />
+                                  </TabPanel>
+                                </TabPanels>
                               </Tabs>
                             </>
                           </TableExpandedRow>

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
@@ -128,6 +128,7 @@
 
     > div {
       max-height: max-content !important;
+      background-color: $ui-02;
     }
   }
 

--- a/packages/esm-outpatient-app/src/current-visit/current-visit.scss
+++ b/packages/esm-outpatient-app/src/current-visit/current-visit.scss
@@ -28,3 +28,7 @@
 .structuredList {
   margin-bottom: 0;
 }
+
+.wrapper {
+  margin: spacing.$spacing-03;
+}

--- a/packages/esm-outpatient-app/src/past-visit/past-visit-details/past-visit-summary.component.tsx
+++ b/packages/esm-outpatient-app/src/past-visit/past-visit-details/past-visit-summary.component.tsx
@@ -5,6 +5,10 @@ import { formatTime, parseDate, useLayoutType, formatDatetime } from '@openmrs/e
 import { Encounter, OrderItem, Order, Note, DiagnosisItem, Observation } from '../../types/index';
 import EncounterList from './encounter-list.component';
 import styles from '../past-visit.scss';
+import Vitals from '../../current-visit/visit-details/vitals.component';
+import { useVitalsFromObs } from '../../current-visit/hooks/useVitalsConceptMetadata';
+import Notes from './notes-list.component';
+import Medications from './medications-list.component';
 
 interface PastVisitSummaryProps {
   encounters: Array<any>;
@@ -110,7 +114,7 @@ const PastVisitSummary: React.FC<PastVisitSummaryProps> = ({ encounters, patient
     <div className={styles.wrapper}>
       <div className={styles.visitContainer}>
         <Tabs className={`${styles.verticalTabs} ${isTablet ? styles.tabletTabs : styles.desktopTabs}`}>
-          <TabList aria-label="Past visits tabs">
+          <TabList className={styles.verticalTabList} aria-label="Past visits tabs">
             <Tab
               className={`${styles.tab} ${styles.bodyLong01} ${selectedTabIndex === 0 && styles.selectedTab}`}
               id="vitals-tab"
@@ -138,7 +142,20 @@ const PastVisitSummary: React.FC<PastVisitSummaryProps> = ({ encounters, patient
           </TabList>
           <TabPanels>
             <TabPanel>
-              <EncounterList encounters={encounters} />
+              <Vitals
+                vitals={useVitalsFromObs(vitalsToRetrieve)}
+                patientUuid={patientUuid}
+                visitType={visitTypes.PAST}
+              />
+            </TabPanel>
+            <TabPanel>
+              <Notes notes={notes} diagnoses={diagnoses} />
+            </TabPanel>
+            <TabPanel>
+              <Medications medications={medications} />
+            </TabPanel>
+            <TabPanel>
+              <EncounterList encounters={encountersToDisplay} />
             </TabPanel>
           </TabPanels>
         </Tabs>

--- a/packages/esm-outpatient-app/src/past-visit/past-visit.scss
+++ b/packages/esm-outpatient-app/src/past-visit/past-visit.scss
@@ -26,7 +26,6 @@
 
 .container {
   background-color: $ui-background;
-  border: 1px solid $grey-2;
   padding: spacing.$spacing-05;
   margin: spacing.$spacing-05 0rem spacing.$spacing-05;
   width: 100%;
@@ -48,6 +47,7 @@
   background-color: $ui-background;
   display: grid;
   grid-template-columns: max-content auto;
+  min-height: spacing.$spacing-13;
 }
 
 .flexSections {
@@ -60,10 +60,18 @@
   &:global(.cds--tabs--scrollable .cds--tabs--scrollable__nav-item + .cds--tabs--scrollable__nav-item) {
     margin-left: 0rem;
   }
+
+  > ul {
+    flex-direction: column !important;
+  }
 }
 
-.verticalTabs > ul {
-  flex-direction: column !important;
+.verticalTabList {
+  :global(.cds--tab--list) {
+    flex-direction: column;
+    max-height: fit-content;
+    overflow-x: visible;
+  }
 }
 
 .desktopTabs {
@@ -78,16 +86,27 @@
   }
 }
 
-.tab > button {
-  border-bottom: 0 !important;
-  border-left: 3px solid $ui-03 !important;
-}
+.tab {
+  outline: 0;
+  outline-offset: 0;
 
-.tab > button,
-.tab > button:focus,
-.tab > button:active {
-  outline: 0 !important;
-  outline-offset: 0 !important;
+  &:active,
+  &:focus {
+    outline: 2px solid var(--brand-03) !important;
+  }
+
+  &[aria-selected='true'] {
+    border-left: 3px solid var(--brand-03);
+    border-bottom: none;
+    font-weight: 600;
+    margin-left: 0rem !important;
+  }
+
+  &[aria-selected='false'] {
+    border-bottom: none;
+    border-left: 2px solid $ui-03;
+    margin-left: 0rem !important;
+  }
 }
 
 .selectedTab > button {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
-Adjusted distorted expansion slot design in service queue according to design. Returned previous visit tab details ie vitals, notes,encounters and medication 

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="777" alt="tabs" src="https://user-images.githubusercontent.com/19533785/185114268-a6671ea9-764a-4b32-ae20-1882cc3a8bb9.PNG">


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
