### PR TITLE
Fix: Put back the close patient chart function

### DIFF
--- a/packages/esm-outpatient-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-outpatient-app/src/visit-header/visit-header.component.tsx
@@ -67,11 +67,12 @@ const VisitHeader: React.FC = () => {
 
   const originPage = localStorage.getItem('fromPage');
 
-  const onClosePatientChart = () => {
+  const onClosePatientChart = useCallback(() => {
     originPage ? navigate({ to: `${window.spaBase}/${originPage}` }) : navigate({ to: `${window.spaBase}/home` });
     setShowVisitHeader((prevState) => !prevState);
     localStorage.removeItem('fromPage');
-  };
+  }, [originPage]);
+
   const render = useCallback(() => {
     if (!showVisitHeader) {
       return null;

--- a/packages/esm-outpatient-app/src/visit-header/visit-header.component.tsx
+++ b/packages/esm-outpatient-app/src/visit-header/visit-header.component.tsx
@@ -118,7 +118,7 @@ const VisitHeader: React.FC = () => {
               <HeaderGlobalAction
                 className={styles.headerGlobalBarCloseButton}
                 aria-label={t('close', 'Close')}
-                onClick={() => setShowVisitHeader((prevState) => !prevState)}>
+                onClick={onClosePatientChart}>
                 <CloseFilled size={20} />
               </HeaderGlobalAction>
             </HeaderGlobalBar>
@@ -137,6 +137,7 @@ const VisitHeader: React.FC = () => {
     showVisitHeader,
     t,
     toggleSideMenu,
+    onClosePatientChart,
   ]);
 
   return <HeaderContainer render={render} />;

--- a/packages/esm-outpatient-app/src/visit-header/visit-header.test.tsx
+++ b/packages/esm-outpatient-app/src/visit-header/visit-header.test.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useAssignedExtensions, useLayoutType, useOnClickOutside, usePatient, useVisit } from '@openmrs/esm-framework';
+
+import {
+  useAssignedExtensions,
+  useLayoutType,
+  useOnClickOutside,
+  usePatient,
+  useVisit,
+  navigate,
+} from '@openmrs/esm-framework';
 import { mockPatient, mockPatientWithLongName } from '../../../../__mocks__/patient.mock';
 import { registerWorkspace, launchPatientWorkspace } from './workspaces';
 import VisitHeader from './visit-header.component';
@@ -35,11 +43,12 @@ jest.mock('./workspaces', () => {
   return {
     ...originalModule,
     launchPatientWorkspace: jest.fn(),
+    navigate: jest.fn(),
   };
 });
 
 describe('Visit Header', () => {
-  xtest('should display visit header and left nav bar hamburger icon', async () => {
+  test('should display visit header and left nav bar hamburger icon', async () => {
     const user = userEvent.setup();
 
     registerWorkspace({ name: 'start-visit-workspace-form', title: 'Start visit', load: jest.fn() });
@@ -87,7 +96,7 @@ describe('Visit Header', () => {
 
     // Should close the visit-header
     await user.click(closeButton);
-    expect(screen.queryByRole('banner', { name: /OpenMRS/i })).not.toBeInTheDocument();
+    expect(navigate).toHaveBeenCalledWith({ to: '/spa/home' });
   });
 
   test('should display a truncated name when the patient name is very long', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Put back the functionality for closing the patient chart close button


## Screenshots

*None.*

## Related Issue

*None.*


## Other

*None.*
