### PR TITLE
(fix) Closing start visit form in outpatient app

### DIFF
--- a/packages/esm-outpatient-app/src/patient-search/patient-scheduled-visits.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-search/patient-scheduled-visits.component.tsx
@@ -9,7 +9,7 @@ import { useScheduledVisits } from './hooks/useScheduledVisits';
 import StartVisitForm from './visit-form/visit-form.component';
 import isNil from 'lodash-es/isNil';
 interface PatientSearchProps {
-  toggleSearchType: (searchMode: SearchTypes, patientUuid) => void;
+  toggleSearchType: (searchMode: SearchTypes, patientUuid, mode) => void;
   patientUuid: string;
 }
 
@@ -106,13 +106,7 @@ const PatientScheduledVisits: React.FC<PatientSearchProps> = ({ toggleSearchType
   }
 
   if (isNil(appointments.futureVisits) && isNil(appointments.recentVisits)) {
-    return (
-      <StartVisitForm
-        toggleSearchType={() => SearchTypes.VISIT_FORM}
-        patientUuid={patientUuid}
-        closePanel={() => false}
-      />
-    );
+    toggleSearchType(SearchTypes.VISIT_FORM, patientUuid, true);
   }
 
   return (
@@ -123,7 +117,7 @@ const PatientScheduledVisits: React.FC<PatientSearchProps> = ({ toggleSearchType
           renderIcon={ArrowLeft}
           iconDescription="Back to search results"
           size="sm"
-          onClick={() => toggleSearchType(SearchTypes.BASIC, patientUuid)}>
+          onClick={() => toggleSearchType(SearchTypes.BASIC, patientUuid, false)}>
           <span>{t('backToSearchResults', 'Back to search results')}</span>
         </Button>
       </div>
@@ -145,7 +139,7 @@ const PatientScheduledVisits: React.FC<PatientSearchProps> = ({ toggleSearchType
         <Button
           kind="ghost"
           iconDescription="Start another visit type"
-          onClick={() => toggleSearchType(SearchTypes.VISIT_FORM, patientUuid)}>
+          onClick={() => toggleSearchType(SearchTypes.VISIT_FORM, patientUuid, false)}>
           {t('anotherVisitType', 'Start another visit type')}
         </Button>
       </div>
@@ -154,7 +148,7 @@ const PatientScheduledVisits: React.FC<PatientSearchProps> = ({ toggleSearchType
         <Button
           className={styles.button}
           kind="secondary"
-          onClick={() => toggleSearchType(SearchTypes.BASIC, patientUuid)}>
+          onClick={() => toggleSearchType(SearchTypes.BASIC, patientUuid, false)}>
           {t('cancel', 'Cancel')}
         </Button>
         <Button className={styles.button} kind="primary" type="submit">

--- a/packages/esm-outpatient-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-search/patient-search.component.tsx
@@ -16,10 +16,12 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel }) => {
   const { t } = useTranslation();
   const [searchType, setSearchType] = useState<SearchTypes>(SearchTypes.BASIC);
   const [selectedPatientUuid, setSelectedPatientUuid] = useState('');
+  const [newVisitMode, setNewVisitMode] = useState<boolean>(false);
 
-  const toggleSearchType = (searchType: SearchTypes, patientUuid: string = '') => {
+  const toggleSearchType = (searchType: SearchTypes, patientUuid: string = '', mode: boolean = false) => {
     setSearchType(searchType);
     setSelectedPatientUuid(patientUuid);
+    setNewVisitMode(mode);
   };
 
   return (
@@ -35,7 +37,12 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel }) => {
           ) : searchType === SearchTypes.SCHEDULED_VISITS ? (
             <PatientScheduledVisits patientUuid={selectedPatientUuid} toggleSearchType={toggleSearchType} />
           ) : searchType === SearchTypes.VISIT_FORM ? (
-            <VisitForm patientUuid={selectedPatientUuid} toggleSearchType={toggleSearchType} closePanel={closePanel} />
+            <VisitForm
+              patientUuid={selectedPatientUuid}
+              toggleSearchType={toggleSearchType}
+              closePanel={closePanel}
+              mode={newVisitMode}
+            />
           ) : null}
         </div>
       </Overlay>

--- a/packages/esm-outpatient-app/src/patient-search/visit-form/visit-form.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-search/visit-form/visit-form.component.tsx
@@ -53,9 +53,10 @@ interface VisitFormProps {
   toggleSearchType: (searchMode: SearchTypes, patientUuid) => void;
   patientUuid: string;
   closePanel: () => void;
+  mode: boolean;
 }
 
-const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchType, closePanel }) => {
+const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchType, closePanel, mode }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const locations = useLocations();
@@ -213,14 +214,25 @@ const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchTyp
           </Row>
         )}
         <div className={styles.backButton}>
-          <Button
-            kind="ghost"
-            renderIcon={(props) => <ArrowLeft size={24} {...props} />}
-            iconDescription={t('backToScheduledVisits', 'Back to scheduled visits')}
-            size="sm"
-            onClick={() => toggleSearchType(SearchTypes.SCHEDULED_VISITS, patientUuid)}>
-            <span>{t('backToScheduledVisits', 'Back to scheduled visits')}</span>
-          </Button>
+          {mode === true ? (
+            <Button
+              kind="ghost"
+              renderIcon={ArrowLeft}
+              iconDescription="Back to search results"
+              size="sm"
+              onClick={() => toggleSearchType(SearchTypes.BASIC, patientUuid)}>
+              <span>{t('backToSearchResults', 'Back to search results')}</span>
+            </Button>
+          ) : (
+            <Button
+              kind="ghost"
+              renderIcon={(props) => <ArrowLeft size={24} {...props} />}
+              iconDescription={t('backToScheduledVisits', 'Back to scheduled visits')}
+              size="sm"
+              onClick={() => toggleSearchType(SearchTypes.SCHEDULED_VISITS, patientUuid)}>
+              <span>{t('backToScheduledVisits', 'Back to scheduled visits')}</span>
+            </Button>
+          )}
         </div>
         <Stack gap={8} className={styles.container}>
           <section className={styles.section}>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Bug fix : When starting a new visit if a patient has no appointments, add button to return to search and close form by clicking discard button

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
