### PR TITLE
(bug) Fix bug with processing Address Hierarchy

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.component.tsx
@@ -24,7 +24,6 @@ export const AddressHierarchy: React.FC = () => {
   const { t } = useTranslation();
   const { addressTemplate } = useContext(ResourcesContext);
   const addressTemplateXml = addressTemplate?.results[0].value;
-
   const setSelectedValue = (value: string) => {
     setSelected(value);
   };
@@ -33,9 +32,14 @@ export const AddressHierarchy: React.FC = () => {
     const templateXmlDoc = parseString(addressTemplateXml);
     const elementDefaults = getTagAsDocument('elementdefaults', templateXmlDoc);
     const nameMappings = getTagAsDocument('nameMappings', templateXmlDoc);
-    const properties = nameMappings.getElementsByTagName('property');
+    const properties =
+      Array.from(nameMappings.getElementsByTagName('property')).length > 0
+        ? nameMappings.getElementsByTagName('property')
+        : nameMappings.getElementsByTagName('entry');
+
     const propertiesObj = Array.prototype.map.call(properties, (property: Element) => {
-      const name = property.getAttribute('name');
+      const name = property.getAttribute('name') ?? property.getElementsByTagName('string')[0].innerHTML;
+      const label = property.getAttribute('value') ?? property.getElementsByTagName('string')[1].innerHTML;
       /*
         DO NOT REMOVE THIS COMMENT UNLESS YOU UNDERSTAND WHY IT IS HERE
 
@@ -45,7 +49,7 @@ export const AddressHierarchy: React.FC = () => {
         t('cityVillage')
         t('country')
       */
-      const labelText = t(name, property.getAttribute('value'));
+      const labelText = t(name, label);
       const value = getFieldValue(name, elementDefaults);
       return {
         id: name,

--- a/packages/esm-patient-registration-app/src/patient-registration/field/email/email-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/email/email-field.component.tsx
@@ -9,7 +9,7 @@ export const PhoneEmailField: React.FC = () => {
 
   return (
     <div>
-      <h4 className={styles.productiveHeading02Light}>{t('phoneEmailLabelText', 'Phone, Email, etc.')}</h4>
+      <h4 className={styles.productiveHeading02Light}>{t('phoneEmailLabelText', 'Phone, Email')}</h4>
       <div className={styles.grid}>
         <PhoneField />
         <Input


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- At the moment, address hierarchy template is returning an empty array. This is because we are wrongly retrieving properties of the `xml` document returned. This PR fixes the issue.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
