### PR TITLE
KHP3-1714 - Retrieve cancelled appointments for the current date

### DIFF
--- a/packages/esm-appointments-app/src/appointments/appointment-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-list.component.tsx
@@ -55,12 +55,12 @@ const AppointmentList: React.FC = () => {
         </TabList>
         <TabPanels>
           <TabPanel>
-            <BookedAppointments status={selectedStatus} />
+            <BookedAppointments status={AppointmentTypes.SCHEDULED} />
           </TabPanel>
           <TabPanel>
-            <CancelledAppointment status={selectedStatus} />
+            <CancelledAppointment status={AppointmentTypes.CANCELLED} />
           </TabPanel>
-          <TabPanel>{<CompletedAppointments status={selectedStatus} />}</TabPanel>
+          <TabPanel>{<CompletedAppointments status={AppointmentTypes.COMPLETED} />}</TabPanel>
         </TabPanels>
       </Tabs>
     </div>


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [X] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [X] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Filter the list of appointments for display on the various Tabs ("scheduled", "cancelled" and "completed") for the current page.
<url>/openmrs/spa/appointments

## Screenshots

![app cancelled-2022-08-29 16-11-25](https://user-images.githubusercontent.com/97954453/187212693-c28682b6-203a-428b-b196-d7843b570ace.png)
![app completed-2022-08-29 16-12-10](https://user-images.githubusercontent.com/97954453/187212703-7cba9f57-b98b-4154-b148-5ded54517a46.png)
![app scheduled-2022-08-29 16-10-42](https://user-images.githubusercontent.com/97954453/187212708-d70f00c8-4e7b-48fd-9269-36a299b6ef83.png)

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
