### PR TITLE
(chore) Add webpack as an explicit dev dependency

### DIFF
--- a/packages/esm-active-visits-app/package.json
+++ b/packages/esm-active-visits-app/package.json
@@ -43,5 +43,8 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-i18next": "11.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-appointments-app/package.json
+++ b/packages/esm-appointments-app/package.json
@@ -42,5 +42,8 @@
     "react": "18.x",
     "react-i18next": "11.x",
     "react-router-dom": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-outpatient-app/package.json
+++ b/packages/esm-outpatient-app/package.json
@@ -42,5 +42,8 @@
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-list-app/package.json
+++ b/packages/esm-patient-list-app/package.json
@@ -44,5 +44,8 @@
     "react": "18.x",
     "react-i18next": "11.x",
     "react-router-dom": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-registration-app/package.json
+++ b/packages/esm-patient-registration-app/package.json
@@ -48,5 +48,8 @@
     "react": "18.x",
     "react-i18next": "11.x",
     "react-router-dom": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-search-app/package.json
+++ b/packages/esm-patient-search-app/package.json
@@ -43,5 +43,8 @@
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x"
+  },
+  "devDependencies": {
+    "webpack": "^5.74.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3608,6 +3608,7 @@ __metadata:
   dependencies:
     "@carbon/react": ^1.8.0
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     dayjs: 1.x
@@ -3665,6 +3666,7 @@ __metadata:
   dependencies:
     "@carbon/react": ^1.8.0
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     react: 18.x
@@ -3774,6 +3776,7 @@ __metadata:
   dependencies:
     "@carbon/react": ^1.8.0
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     react: ^18.1.0
@@ -3790,6 +3793,7 @@ __metadata:
     d3: ^5.16.0
     dexie: ^3.0.3
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     react: 18.x
@@ -3867,6 +3871,7 @@ __metadata:
     lodash-es: ^4.17.15
     react-avatar: ^4.0.0
     uuid: ^8.3.2
+    webpack: ^5.74.0
     yup: ^0.29.1
   peerDependencies:
     "@openmrs/esm-framework": 4.x
@@ -3884,6 +3889,7 @@ __metadata:
     "@carbon/colors": ^11.2.0
     "@carbon/react": ^1.8.0
     lodash-es: ^4.17.15
+    webpack: ^5.74.0
   peerDependencies:
     "@openmrs/esm-framework": 4.x
     react: ^18.1.0


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Presently, developers are not able to run webpack-dependent scripts such as `yarn serve` in this repository. This is related to our recent migration to Yarn v3, where we are now required to explicitly state dev dependencies. To that end, this PR adds webpack as a dev dependency to all the packages in this repository.