### PR TITLE
(fix) Fix tests for the Date of Birth component

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
@@ -1,11 +1,11 @@
 import React, { useContext } from 'react';
-import { ContentSwitcher, DatePicker, DatePickerInput, Layer, Switch, TextInput } from '@carbon/react';
+import { ContentSwitcher, DatePicker, DatePickerInput, Switch } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { useField } from 'formik';
-import { PatientRegistrationContext } from '../../patient-registration-context';
 import { generateFormatting } from '../../date-util';
-import styles from '../field.scss';
+import { PatientRegistrationContext } from '../../patient-registration-context';
 import { Input } from '../../input/basic-input/input/input.component';
+import styles from '../field.scss';
 
 const calcBirthdate = (yearDelta, monthDelta) => {
   const startDate = new Date();
@@ -73,19 +73,17 @@ export const DobField: React.FC = () => {
       </div>
       {dobKnown ? (
         <div className={styles.dobField}>
-          <Layer>
-            <DatePicker dateFormat={dateFormat} datePickerType="simple" onChange={onDateChange} maxDate={format(today)}>
-              <DatePickerInput
-                id="birthdate"
-                {...birthdate}
-                placeholder={placeHolder}
-                labelText={t('dateOfBirthLabelText', 'Date of Birth')}
-                invalid={!!(birthdateMeta.touched && birthdateMeta.error)}
-                invalidText={birthdateMeta.error && t(birthdateMeta.error)}
-                value={format(birthdate.value)}
-              />
-            </DatePicker>
-          </Layer>
+          <DatePicker dateFormat={dateFormat} datePickerType="simple" onChange={onDateChange} maxDate={format(today)}>
+            <DatePickerInput
+              id="birthdate"
+              {...birthdate}
+              placeholder={placeHolder}
+              labelText={t('dateOfBirthLabelText', 'Date of Birth')}
+              invalid={!!(birthdateMeta.touched && birthdateMeta.error)}
+              invalidText={birthdateMeta.error && t(birthdateMeta.error)}
+              value={format(birthdate.value)}
+            />
+          </DatePicker>
         </div>
       ) : (
         <div className={styles.grid}>

--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
@@ -1,54 +1,62 @@
-import React, { useContext } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Formik, Form } from 'formik';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import '@testing-library/jest-dom';
-import { Formik, Form, useField } from 'formik';
 import { DobField } from './dob.component';
+import { PatientRegistrationContext } from '../../patient-registration-context';
+import { initialFormValues } from '../../patient-registration.component';
+import { FormValues } from '../../patient-registration-types';
 
-jest.mock('formik', () => {
-  const originalModule = jest.requireActual('formik');
-  return {
-    ...originalModule,
-    useField: jest.fn(() => [{}, {}]),
-  };
-});
-
-jest.mock('react', () => {
-  const originalModule = jest.requireActual('react');
-  return {
-    ...originalModule,
-    useContext: jest.fn(() => ({
-      setFieldValue: jest.fn(),
-    })),
-  };
-});
-
-describe('dob', () => {
-  it('renders the date of birth component', () => {
+describe('Dob', () => {
+  it('renders the fields in the birth section of the registration form', async () => {
     renderDob();
 
     expect(screen.getByRole('heading', { name: /birth/i })).toBeInTheDocument();
+    expect(screen.getByText(/date of birth known?/i)).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /no/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /yes/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /yes/i })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: /no/i })).toHaveAttribute('aria-selected', 'false');
     expect(screen.getByRole('textbox', { name: /date of birth/i })).toBeInTheDocument();
-    expect(screen.getByText(/date of birth known?/i)).toBeInTheDocument();
   });
 
-  it('changes value of datepicker', () => {
+  it('typing in the date picker input sets the date of birth', async () => {
+    const user = userEvent.setup();
+
     renderDob();
 
-    fireEvent.change(screen.getByPlaceholderText('dd/mm/YYYY'), {
-      target: { value: '01/01/2020' },
-    });
-    expect(screen.getByPlaceholderText('dd/mm/YYYY')).toHaveValue('01/01/2020');
+    const dateInput = screen.getByRole('textbox', { name: /date of birth/i });
+    expect(dateInput).toBeInTheDocument();
+
+    await user.type(dateInput, '10/10/2022');
+
+    expect(screen.getByPlaceholderText('dd/mm/YYYY')).toHaveValue('10/10/2022');
   });
 });
 
 function renderDob() {
+  let formValues: FormValues = initialFormValues;
+
   render(
-    <Formik initialValues={{}} onSubmit={null}>
+    <Formik initialValues={{ birthdate: '' }} onSubmit={() => {}}>
       <Form>
-        <DobField />
+        <PatientRegistrationContext.Provider
+          value={{
+            identifierTypes: [],
+            values: formValues,
+            validationSchema: null,
+            setValidationSchema: (value) => {},
+            inEditMode: false,
+            setFieldValue: () => {},
+            setCapturePhotoProps: (value) => {},
+            currentPhoto: '',
+            isOffline: false,
+            initialFormValues: formValues,
+          }}>
+          <DobField />
+        </PatientRegistrationContext.Provider>
       </Form>
     </Formik>,
   );

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-context.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-context.ts
@@ -1,5 +1,5 @@
 import { useConfig } from '@openmrs/esm-framework';
-import { createContext, SetStateAction, useContext } from 'react';
+import { createContext, SetStateAction } from 'react';
 import { RegistrationConfig } from '../config-schema';
 import { FormValues, CapturePhotoProps } from './patient-registration-types';
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR provides a bunch of anticipatory fixes necessary to support a tweak to the registration form. More specifically, @makombe wishes to change the type of `datePickerType` prop from `simple` to `single`. The big benefit from that would be the provision of a calendar UI from which users can more conveniently select the date of the birth value. Applying that change with the current setup yields a test failure. This failure is caused by the react module mock in `dob.test.tsx`. More specifically, that mock went on to provide a partial `useContext` mock. This wound up breaking some of the Carbon date picker component functionality that depends on `useContext`.

This PR gets rid of module mocks for React and Formik in the `DobComponent` test suite and refactors the `render` function to return a component wrapped in a `PatientRegistrationContext`. This refactor enables the test to pass both with the current setup as well as with @makombe's anticipated change.