### PR TITLE
(test) Restore disabled specs in `AppointmentsBaseTable` component

### DIFF
--- a/packages/esm-appointments-app/src/appointments-tabs/booked-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/booked-appointments.component.tsx
@@ -6,6 +6,7 @@ import AppointmentsBaseTable from './appointments-base-table.component';
 interface BookedAppointmentsProps {
   status: string;
 }
+
 const BookedAppointments: React.FC<BookedAppointmentsProps> = ({ status }) => {
   const { appointments, isLoading, mutate } = useAppointments(status);
   const { t } = useTranslation();

--- a/packages/esm-appointments-app/src/appointments-tabs/cancelled-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/cancelled-appointments.component.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import AppointmentsBaseTable from './appointments-base-table.component';
 import { useTranslation } from 'react-i18next';
 import { useAppointments } from './appointments-table.resource';
+import AppointmentsBaseTable from './appointments-base-table.component';
 
 interface CancelledAppointmentProps {
   status: string;
 }
+
 const CancelledAppointment: React.FC<CancelledAppointmentProps> = ({ status }) => {
   const { t } = useTranslation();
   const { appointments, isLoading } = useAppointments(status);

--- a/packages/esm-appointments-app/src/appointments-tabs/completed-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/completed-appointments.component.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import AppointmentsBaseTable from './appointments-base-table.component';
-import { useAppointments } from './appointments-table.resource';
 import { useTranslation } from 'react-i18next';
+import { useAppointments } from './appointments-table.resource';
+import AppointmentsBaseTable from './appointments-base-table.component';
 
 interface CompletedAppointmentsProps {
   status: string;
 }
+
 const CompletedAppointments: React.FC<CompletedAppointmentsProps> = ({ status }) => {
   const { t } = useTranslation();
   const { appointments, isLoading } = useAppointments(status);

--- a/packages/esm-appointments-app/src/appointments-tabs/missed-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/missed-appointments.component.tsx
@@ -7,7 +7,8 @@ interface MissedAppointmentsProps {
   status: string;
   title: string;
 }
-const MissedAppointmentsList: React.FC<MissedAppointmentsProps> = ({ status, title }) => {
+
+const MissedAppointments: React.FC<MissedAppointmentsProps> = ({ status, title }) => {
   const { appointments, isLoading, mutate } = useAppointments(status);
   const { t } = useTranslation();
 
@@ -18,4 +19,4 @@ const MissedAppointmentsList: React.FC<MissedAppointmentsProps> = ({ status, tit
   );
 };
 
-export default MissedAppointmentsList;
+export default MissedAppointments;

--- a/packages/esm-appointments-app/src/appointments/missed-appointment-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/missed-appointment-list.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tab, TabList, Tabs, TabPanel, TabPanels } from '@carbon/react';
+import MissedAppointments from '../appointments-tabs/missed-appointments.component';
 import styles from './missed-appointment-list.scss';
-import MissedAppointmentsList from '../appointments-tabs/missed-appointments.component';
 
 enum MissedAppointmentTypes {
   MISSED = 'Scheduled',
@@ -28,20 +28,17 @@ const MissedAppointmentList: React.FC = () => {
           </TabList>
           <TabPanels>
             <TabPanel>
-              <MissedAppointmentsList
+              <MissedAppointments
                 status={MissedAppointmentTypes.MISSED}
                 title={t('missedAppointmentsList', 'Missed Appointments List')}
               />
             </TabPanel>
             <TabPanel>
-              <MissedAppointmentsList
-                status={MissedAppointmentTypes.DEFAULTERS}
-                title={t('defaulters', 'Defaulters')}
-              />
+              <MissedAppointments status={MissedAppointmentTypes.DEFAULTERS} title={t('defaulters', 'Defaulters')} />
             </TabPanel>
             <TabPanel>
               {
-                <MissedAppointmentsList
+                <MissedAppointments
                   status={MissedAppointmentTypes.LTFU}
                   title={t('lostToFollowupAppointments', 'Lost To Followup Appointments')}
                 />
@@ -49,9 +46,9 @@ const MissedAppointmentList: React.FC = () => {
             </TabPanel>
             <TabPanel>
               {
-                <MissedAppointmentsList
+                <MissedAppointments
                   status={MissedAppointmentTypes.PROMISED}
-                  title={t('promisedPateints', 'Promised Pateints')}
+                  title={t('promisedPateints', 'Promised Patients')}
                 />
               }
             </TabPanel>

--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "addNewAppointment": "Add new Appointment",
+  "addNewAppointment": "Add new appointment",
   "addNewClinicDay": "Add new clinic day",
   "anotherVisitType": "Start another visit type",
   "appointmentDateAndTime": "Appointments Date and Time",

--- a/packages/esm-outpatient-app/src/patient-search/patient-scheduled-visits.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-search/patient-scheduled-visits.component.tsx
@@ -79,7 +79,7 @@ export const ScheduledVisits: React.FC<{ visits; visitType; scheduledVisitHeader
           </TileGroup>
         ) : (
           <div className={styles.emptyAppointment}>
-            <p>{t('noAppointmentsFound', 'No appointements found')} </p>
+            <p>{t('noAppointmentsFound', 'No appointments found')} </p>
           </div>
         )}
       </div>

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -65,7 +65,7 @@
   "moreMetrics": "See more metrics",
   "name": "Name",
   "ncdCare": "NCD Care",
-  "noAppointmentsFound": "No appointements found",
+  "noAppointmentsFound": "No appointments found",
   "noEncountersFound": "No encounters found",
   "noLastEncounter": "There is no last encounter to display for this patient",
   "noMedicationsFound": "No medications found",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR restores disabled specs for the `AppointmentsBaseTable` component. It also fixes a bunch of typos and makes a bunch of useful refactors.