### PR TITLE
feat: Add ability to change patient appointment status

### DIFF
--- a/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -25,7 +25,14 @@ import {
   Tile,
 } from '@carbon/react';
 import { Add, Cough, Medication, Omega } from '@carbon/react/icons';
-import { isDesktop, useLayoutType, ConfigurableLink, formatDatetime, parseDate } from '@openmrs/esm-framework';
+import {
+  isDesktop,
+  useLayoutType,
+  ConfigurableLink,
+  formatDatetime,
+  parseDate,
+  showModal,
+} from '@openmrs/esm-framework';
 import { launchOverlay } from '../hooks/useOverlay';
 import { MappedAppointment } from '../types';
 import { useServices } from './appointments-table.resource';
@@ -144,6 +151,13 @@ const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLo
     );
   };
 
+  const launchAppointmentStatusModal = (appointments: MappedAppointment) => {
+    const dispose = showModal('change-appointment-status-modal', {
+      closeModal: () => dispose(),
+      appointments,
+    });
+  };
+
   const tableHeaders = useMemo(
     () => [
       {
@@ -202,7 +216,11 @@ const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLo
         ),
       },
       startButton: {
-        content: <Button kind="ghost">Start</Button>,
+        content: (
+          <Button onClick={() => launchAppointmentStatusModal(appointment)} kind="ghost">
+            Start
+          </Button>
+        ),
       },
     }));
   }, [filteredRows, appointments]);

--- a/packages/esm-appointments-app/src/appointments-tabs/appointments-table.resource.ts
+++ b/packages/esm-appointments-app/src/appointments-tabs/appointments-table.resource.ts
@@ -7,6 +7,7 @@ import { getAppointment, startDate } from '../helpers';
 export function useAppointments(status: string) {
   const apiUrl = `/ws/rest/v1/appointment/appointmentStatus?forDate=${startDate}&status=${status}`;
   const { data, error, isValidating, mutate } = useSWR<{ data: Array<Appointment> }, Error>(apiUrl, openmrsFetch);
+
   const appointments = useMemo(() => data?.data?.map((appointment) => getAppointment(appointment)) ?? [], [data?.data]);
 
   return {

--- a/packages/esm-appointments-app/src/change-appointment-status/appointment-status.resource.tsx
+++ b/packages/esm-appointments-app/src/change-appointment-status/appointment-status.resource.tsx
@@ -1,0 +1,14 @@
+import { openmrsFetch } from '@openmrs/esm-framework';
+import dayjs from 'dayjs';
+import { omrsDateFormat } from '../constants';
+
+export const changeAppointmentStatus = async (toStatus: string, appointmentUuid: string, ac: AbortController) => {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const statusChangeTime = dayjs(new Date()).format(omrsDateFormat);
+  const url = `/ws/rest/v1/appointments/${appointmentUuid}/status-change`;
+  return await openmrsFetch(url, {
+    body: { toStatus, onDate: statusChangeTime, timeZone: timeZone },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/packages/esm-appointments-app/src/change-appointment-status/change-appointment-status.component.tsx
+++ b/packages/esm-appointments-app/src/change-appointment-status/change-appointment-status.component.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Form,
+  FormGroup,
+  RadioButton,
+  RadioButtonGroup,
+} from '@carbon/react';
+import { useTranslation } from 'react-i18next';
+import styles from './change-appointment-status.scss';
+import { MappedAppointment } from '../types';
+import { changeAppointmentStatus } from './appointment-status.resource';
+import { navigate, showNotification, showToast } from '@openmrs/esm-framework';
+import { useSWRConfig } from 'swr';
+import { startDate } from '../helpers';
+
+interface ChangeAppointmentStatusModalProps {
+  appointments: MappedAppointment;
+  closeModal: () => void;
+}
+
+const ChangeAppointmentStatusModal: React.FC<ChangeAppointmentStatusModalProps> = ({ appointments, closeModal }) => {
+  const { t } = useTranslation();
+  const { mutate } = useSWRConfig();
+  const { name, id, dateTime, serviceType, status } = appointments;
+  const [selectedStatus, setSelectedStatus] = useState(status);
+  const appointmentStatus = [
+    { display: t('checkedIn', 'CheckedIn'), value: 'CheckedIn' },
+    { display: t('missed', 'Missed'), value: 'Missed' },
+    { display: t('completed', 'Completed'), value: 'Completed' },
+  ];
+
+  const handleChangeAppointmentStatus = async () => {
+    const ac = new AbortController();
+    const { status, statusText } = await changeAppointmentStatus(selectedStatus, id, ac);
+    status === 200
+      ? showToast({
+          critical: true,
+          kind: 'success',
+          description: t(
+            'appointmentStatusChange',
+            `Appointment status has been successfuly changed to ${selectedStatus}`,
+          ),
+          title: t('appointmentStatusTitleMessage', 'Appointment status'),
+        })
+      : showNotification({
+          title: t('appointmentFormError', 'Error updating appointment status'),
+          kind: 'error',
+          critical: true,
+          description: statusText,
+        });
+    selectedStatus === 'CheckedIn' && navigate({ to: `\${openmrsSpaBase}/outpatient` });
+    mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${startDate}&status=Scheduled`);
+    closeModal();
+  };
+
+  return (
+    <div>
+      <ModalHeader closeModal={closeModal} title={t('changeAppointmentStatus', 'Change appointment status')} />
+      <ModalBody>
+        <div className={styles.modalBody}>
+          <h4>
+            {t('patientName', 'Patient name')}&nbsp;
+            {name}
+          </h4>
+          <h5>
+            {t('serviceType', 'Service type')}&nbsp;
+            {serviceType}
+          </h5>
+          <h6>
+            {t('startTime', 'Start time')}&nbsp;
+            {dateTime}
+          </h6>
+        </div>
+        <Form onSubmit={() => {}}>
+          <FormGroup legendText="">
+            <RadioButtonGroup
+              className={styles.radioButtonGroup}
+              valueSelected={selectedStatus}
+              orientation="vertical"
+              onChange={(value) => setSelectedStatus(value)}
+              name="radio-button-group">
+              {appointmentStatus.map(({ value, display }) => (
+                <RadioButton key={value} className={styles.radioButton} id={value} labelText={display} value={value} />
+              ))}
+            </RadioButtonGroup>
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={closeModal}>
+          {t('cancel', 'Cancel')}
+        </Button>
+        <Button onClick={handleChangeAppointmentStatus}>{t('exitAndChangeStatus', 'Change status')}</Button>
+      </ModalFooter>
+    </div>
+  );
+};
+
+export default ChangeAppointmentStatusModal;

--- a/packages/esm-appointments-app/src/change-appointment-status/change-appointment-status.scss
+++ b/packages/esm-appointments-app/src/change-appointment-status/change-appointment-status.scss
@@ -1,0 +1,32 @@
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/styles/scss/type';
+@import '~@openmrs/esm-styleguide/src/vars';
+
+.radioButtonGroup {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-top: spacing.$spacing-03;
+    min-height: spacing.$spacing-10;
+    width: 100%;
+    @include type.type-style('body-compact-01');
+}
+
+.radioButton {
+    padding: spacing.$spacing-02 spacing.$spacing-02;
+    margin: spacing.$spacing-03 0;
+}
+
+section {
+    margin: spacing.$spacing-03;
+}
+
+.sectionTitle {
+    @include type.type-style('heading-compact-02');
+    color: $text-02;
+    margin-bottom: spacing.$spacing-04;
+}
+
+.modalBody {
+
+}

--- a/packages/esm-appointments-app/src/index.ts
+++ b/packages/esm-appointments-app/src/index.ts
@@ -63,6 +63,15 @@ function setupOpenMRS() {
         offline: true,
       },
       {
+        name: 'change-appointment-status-modal',
+        load: getAsyncLifecycle(
+          () => import('./change-appointment-status/change-appointment-status.component'),
+          options,
+        ),
+        online: true,
+        offline: false,
+      },
+      {
         name: 'patient-table',
         load: getAsyncLifecycle(() => import('./patient-table/patient-table.component'), {
           featureName: 'patient-table',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Add ability to change appointment status. If the status is `CheckeIn` then we redirect the user to the `outpatient` services. This is based on the available designs.


## Screenshots
![Peek 2022-09-07 07-00](https://user-images.githubusercontent.com/28008754/188786055-a060dca3-5326-4f41-8e88-03b10b70bba2.gif)




## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
