### PR TITLE
feat: Add ability to re-validate booked-appointment on add or edittin…

### DIFF
--- a/packages/esm-appointments-app/src/appointment-forms/create-appointment-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/create-appointment-form.component.tsx
@@ -36,6 +36,7 @@ import { ConfigObject } from '../config-schema';
 import { mockFrequency } from '../../../../__mocks__/appointments.mock';
 import { closeOverlay } from '../hooks/useOverlay';
 import { useProviders } from '../hooks/useProviders';
+import { startDate as fromDate } from '../helpers';
 
 import styles from './create-appointment-form.scss';
 
@@ -61,7 +62,6 @@ const CreateAppointmentsForm: React.FC<AppointmentFormProps> = ({ patientUuid })
   const [endTime, setEndTime] = useState(dayjs(new Date()).format('hh:mm'));
   const [timeFormat, setTimeFormat] = useState<amPm>(new Date().getHours() >= 12 ? 'PM' : 'AM');
   const [userLocation, setUserLocation] = useState('');
-  const [contentSwitcherValue, setContentSwitcherValue] = useState(0);
   const [appointmentReminder, setAppointmentReminder] = useState(null);
   const [appointmentKind, setAppointmentKind] = useState('');
   const [frequency, setFrequency] = useState('');
@@ -129,7 +129,7 @@ const CreateAppointmentsForm: React.FC<AppointmentFormProps> = ({ patientUuid })
           });
         }
 
-        mutate(`${appointmentsSearchUrl}`);
+        mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${fromDate}&status=Scheduled`);
       },
       (error) => {
         showNotification({

--- a/packages/esm-appointments-app/src/appointment-forms/edit-appointment-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/edit-appointment-form.component.tsx
@@ -28,20 +28,20 @@ import {
   parseDate,
 } from '@openmrs/esm-framework';
 import { AppointmentPayload, MappedAppointment } from '../types';
-import { amPm } from '../helpers';
+import { amPm, startDate } from '../helpers';
 import { saveAppointment, useServices } from './appointment-forms.resource';
 import { ConfigObject } from '../config-schema';
 import { useProviders } from '../hooks/useProviders';
 import { closeOverlay } from '../hooks/useOverlay';
 import { mockFrequency } from '../../__mocks__/appointments.mock';
 import styles from './edit-appointment-form.scss';
-
+import { useSWRConfig } from 'swr';
 interface AppointmentFormProps {
   appointment: MappedAppointment;
-  mutate: () => void;
 }
-const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment, mutate = () => {} }) => {
+const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment }) => {
   const { t } = useTranslation();
+  const { mutate } = useSWRConfig();
   const { appointmentKinds } = useConfig() as ConfigObject;
   const { daysOfTheWeek } = useConfig() as ConfigObject;
   const { appointmentStatuses } = useConfig() as ConfigObject;
@@ -103,7 +103,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment, mutate =
             title: t('appointmentScheduled', 'Appointment scheduled'),
           });
           setIsSubmitting(false);
-          mutate();
+          mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${startDate}&status=Scheduled`);
           closeOverlay();
         }
       },

--- a/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
@@ -64,10 +64,7 @@ function ActionsMenu({ appointment, mutate }: ActionMenuProps) {
           className={styles.menuItem}
           id="#editAppointment"
           onClick={() =>
-            launchOverlay(
-              t('editAppointment', 'Edit Appointment'),
-              <AppointmentForm mutate={mutate} appointment={appointment} />,
-            )
+            launchOverlay(t('editAppointment', 'Edit Appointment'), <AppointmentForm appointment={appointment} />)
           }
           itemText={t('editAppointment', 'Edit Appointment')}>
           {t('editAppointment', 'Edit Appointment')}


### PR DESCRIPTION
…g appointments

## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Add ability to re-validate `scheduled` appointments. This is to enable auto-refresh of the scheduled appointments table to reflect with the correct data as shown in the GIF below.


## Screenshots
![re-validate](https://user-images.githubusercontent.com/28008754/188787590-bbebc2c5-ef04-4ecf-931e-f05b0059514a.gif)




## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
