### PR TITLE
(fix) Fix redundant React remounts within the Outpatient dashboards

### DIFF
--- a/packages/esm-outpatient-app/src/root.component.tsx
+++ b/packages/esm-outpatient-app/src/root.component.tsx
@@ -23,7 +23,8 @@ const Root: React.FC = () => {
       <SWRConfig value={swrConfiguration}>
         <BrowserRouter basename={spaBasePath}>
           <Routes>
-            <Route path="" element={<OutpatientDashboard />} />
+            <Route path="/" element={<OutpatientDashboard />} />
+            <Route path="/:view" element={<OutpatientDashboard />} />
             <Route path="/appointments-list/:value/" element={<AppointmentsTable />} />
             <Route path="/queue-list/:value/" element={<ServicesTable />} />
           </Routes>


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [X] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [X] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR fixes two issues:
1. Redundant Component Remounts. <br/> This issue was reported by @vasharma05 that made it difficult to interact with the workspace or overlay. Checkout [thread](https://openmrs.slack.com/archives/C02UNMKFH8V/p1662465987650649) for details
2. Automatically redirect to home dashboard if requested page wasn't found. NB: This doesn't override other peer routes. 

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

![2022-09-07 18-39-22 2022-09-07 18_41_18](https://user-images.githubusercontent.com/26084581/188920931-faf92739-7d35-4081-8d96-9450d41b133c.gif)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
