### PR TITLE
bug: fix patient-registration navigation

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/before-save-prompt.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/before-save-prompt.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { showModal } from '@openmrs/esm-framework';
+import { showModal, navigate } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 
 function getUrlWithoutPrefix(url: string) {
@@ -13,7 +12,6 @@ interface BeforeSavePromptProps {
 }
 
 const BeforeSavePrompt: React.FC<BeforeSavePromptProps> = ({ when, redirect }) => {
-  const navigate = useNavigate();
   const { t } = useTranslation();
   const ref = useRef<boolean>(false);
   const [localTarget, setTarget] = useState<string | undefined>();
@@ -64,9 +62,9 @@ const BeforeSavePrompt: React.FC<BeforeSavePromptProps> = ({ when, redirect }) =
 
   useEffect(() => {
     if (typeof target === 'string') {
-      navigate(`/${getUrlWithoutPrefix(target)}`);
+      navigate({ to: `\${openmrsSpaBase}/${getUrlWithoutPrefix(target)}` });
     }
-  }, [navigate, target]);
+  }, [target]);
 
   return null;
 };


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- At the moment, navigating away from patient-registration users are navigated to the wrong URL with a prefix of `patient-registration` added to the URL. This PR fixes this issue by utilizing the `navigate` function from `@openmrs/esm-framework`


## Screenshots

![patient-registration navigation](https://user-images.githubusercontent.com/28008754/188954668-1fc8a594-9ac0-4d8c-93f8-68c520dedb9c.gif)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
