### PR TITLE
enhancement: Prevent user from picking appointment dates in the past & fix banner load error

### DIFF
--- a/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
@@ -63,13 +63,12 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
     appointmentNumber: undefined,
   };
   const appointmentState = !isEmpty(appointment) ? appointment : initialState;
-
   const { t } = useTranslation();
   const { mutate } = useSWRConfig();
   const { appointmentKinds } = useConfig() as ConfigObject;
   const { daysOfTheWeek } = useConfig() as ConfigObject;
   const { appointmentStatuses } = useConfig() as ConfigObject;
-  const { patient } = usePatient(appointmentState.patientUuid);
+  const { patient, isLoading } = usePatient(patientUuid ?? appointmentState.patientUuid);
   const locations = useLocations();
   const session = useSession();
   const { providers } = useProviders();
@@ -149,7 +148,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
 
   return (
     <div className={styles.formContainer}>
-      {patient === null ? (
+      {isLoading ? (
         <SkeletonText />
       ) : (
         <ExtensionSlot

--- a/packages/esm-appointments-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-appointments-app/src/patient-search/patient-search.component.tsx
@@ -8,11 +8,11 @@ import AppointmentForm from '../appointment-forms/appointments-form.component';
 
 const PatientSearch: React.FC = () => {
   const { t } = useTranslation();
-  const launchCreateAppointmentForm = (patient) => {
+  const launchCreateAppointmentForm = (patientUuid: string) => {
     closeOverlay();
     launchOverlay(
       t('appointmentForm', 'Create Appointment'),
-      <AppointmentForm patientUuid={patient.uuid} context="creating" />,
+      <AppointmentForm patientUuid={patientUuid} context="creating" />,
     );
   };
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Prevent users from creating an appointment in the past by picking a date in the past. 
- Fix error while loading the create and edit form as a result of patient object being null.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
