### PR TITLE
enhancement: Add ability toggle view for missed,booked and complete apointments

### DIFF
--- a/packages/esm-appointments-app/src/appointments/appointment-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-list.component.tsx
@@ -18,23 +18,6 @@ enum AppointmentTypes {
 const AppointmentList: React.FC = () => {
   const { t } = useTranslation();
   const [selectedTab, setSelectedTab] = useState(0);
-  const [selectedStatus, setSelectedStatus] = useState(AppointmentTypes.SCHEDULED);
-  const handleStatusChange = (index: number) => {
-    switch (index) {
-      case 0:
-        setSelectedStatus(AppointmentTypes.SCHEDULED);
-        setSelectedTab(0);
-        break;
-      case 1:
-        setSelectedStatus(AppointmentTypes.CANCELLED);
-        setSelectedTab(1);
-        break;
-      case 2:
-        setSelectedStatus(AppointmentTypes.COMPLETED);
-        setSelectedTab(2);
-        break;
-    }
-  };
   return (
     <div className={styles.appointmentList}>
       <Button
@@ -47,7 +30,10 @@ const AppointmentList: React.FC = () => {
         {t('viewCalendar', 'View Calendar')}
       </Button>
 
-      <Tabs className={styles.tabs}>
+      <Tabs
+        selectedIndex={selectedTab}
+        onChange={({ selectedIndex }) => setSelectedTab(selectedIndex)}
+        className={styles.tabs}>
         <TabList aria-label="Appointment tabs" contained>
           <Tab>{t('bookedForToday', 'Booked for today')}</Tab>
           <Tab>{t('cancelled', 'Cancelled')}</Tab>
@@ -55,12 +41,12 @@ const AppointmentList: React.FC = () => {
         </TabList>
         <TabPanels>
           <TabPanel style={{ padding: 0 }}>
-            <BookedAppointments status={selectedStatus} />
+            <BookedAppointments status={AppointmentTypes.SCHEDULED} />
           </TabPanel>
           <TabPanel style={{ padding: 0 }}>
-            <CancelledAppointment status={selectedStatus} />
+            <CancelledAppointment status={AppointmentTypes.CANCELLED} />
           </TabPanel>
-          <TabPanel style={{ padding: 0 }}>{<CompletedAppointments status={selectedStatus} />}</TabPanel>
+          <TabPanel style={{ padding: 0 }}>{<CompletedAppointments status={AppointmentTypes.COMPLETED} />}</TabPanel>
         </TabPanels>
       </Tabs>
     </div>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Add ability to toggle view between `booked` `cancelled` and `completed` appointments.


## Screenshots
![StatusTabs](https://user-images.githubusercontent.com/28008754/189625604-7011e9ea-bb77-4fbc-a8bc-648c002c2f93.gif)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
