### PR TITLE
(fix) Fix clinic metrics UI

### DIFF
--- a/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -55,7 +55,7 @@ function ClinicMetrics() {
         <MetricsCard
           label={t('patients', 'Patients')}
           value={serviceCount}
-          headerLabel={t('waitingFor', 'Waiting for:')}
+          headerLabel={`${t('waitingFor', 'Waiting for')}:`}
           service={selectedService}
           serviceUuid={selectedServiceUuid}>
           <Dropdown

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.component.tsx
@@ -18,21 +18,27 @@ const MetricsCard: React.FC<MetricsCardProps> = ({ label, value, headerLabel, ch
   const { t } = useTranslation();
 
   return (
-    <Layer className={styles.container}>
-      <Tile className={styles.tileContainer}>
+    <Layer className={`${children && styles.cardWithChildren} ${styles.container}`}>
+      <Tile className={`${styles.tileContainer}`}>
         <div className={styles.tileHeader}>
           <div className={styles.headerLabelContainer}>
             <label className={styles.headerLabel}>{headerLabel}</label>
             {children}
           </div>
           {service == 'scheduled' ? (
-            <ConfigurableLink className={styles.link} to={`\${openmrsSpaBase}/appointments-list/${service}`}>
-              {t('patientList', 'Patient list')} <ArrowRight size={16} className={styles.patientListBtn} />
-            </ConfigurableLink>
+            <div className={styles.link}>
+              <ConfigurableLink className={styles.link} to={`\${openmrsSpaBase}/appointments-list/${service}`}>
+                {t('patientList', 'Patient list')}
+              </ConfigurableLink>
+              <ArrowRight size={16} />
+            </div>
           ) : service == 'waitTime' ? null : (
-            <ConfigurableLink className={styles.link} to={`\${openmrsSpaBase}/queue-list/${service}/${serviceUuid}/`}>
-              {t('patientList', 'Patient list')} <ArrowRight size={16} className={styles.patientListBtn} />
-            </ConfigurableLink>
+            <div className={styles.link}>
+              <ConfigurableLink className={styles.link} to={`\${openmrsSpaBase}/queue-list/${service}/${serviceUuid}/`}>
+                {t('patientList', 'Patient list')}
+              </ConfigurableLink>
+              <ArrowRight size={16} />
+            </div>
           )}
         </div>
         <div>

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.scss
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.scss
@@ -6,17 +6,25 @@
   flex-grow: 1;
 }
 
+/* Tablet viewport */
+:global(.omrs-breakpoint-lt-desktop) {
+  // The card containing the dropdown element should be the first to overflow on tablet
+  .cardWithChildren {
+    order: 3;
+  }
+}
+
 .tileContainer {
   border: 0.0625rem solid $ui-03;
   height: 7.875rem;
-  padding: 0 spacing.$spacing-05;
+  padding: spacing.$spacing-05;
   margin: spacing.$spacing-03 spacing.$spacing-03;
 }
 
 .tileHeader {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: baseline;
   margin-bottom: spacing.$spacing-03;
 }
 
@@ -37,14 +45,25 @@
 
 .headerLabelContainer {
   display: flex;
-  align-items: center;
   height: spacing.$spacing-07;
+
+  :global(.cds--dropdown__wrapper--inline) {
+    gap: 0;
+    margin-top: -0.75rem;
+  }
+
+  :global(.cds--list-box__menu-icon) {
+    height: 1rem;
+  }
 }
 
 .link {
   text-decoration: none;
-}
+  display: flex;
+  align-items: center;
+  color: $interactive-01;
 
-.patientListBtn {
-  margin: spacing.$spacing-04 0 0 spacing.$spacing-03;
+  svg {
+    margin-left: spacing.$spacing-03;
+  }
 }

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -166,7 +166,7 @@
   "vitals": "Vitals",
   "vitalsForm": "Vitals form",
   "vitalsNotRecordedForVisit": "Vitals has not been recorded for this patient for this visit",
-  "waitingFor": "Waiting for:",
+  "waitingFor": "Waiting for",
   "waitTime": "Wait time (mins)",
   "weight": "Weight",
   "youngest": "Youngest first"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Aligns the clinic metrics UI with the [available designs](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/61bb8858a0d6794e41a83280) by applying a bunch of visual fixes, including styling that ensures that the metric card with `children` overflows when the viewport changes to `tablet`.

## Screenshots

> Before

Desktop:

<img width="1171" alt="Screenshot 2022-09-14 at 13 20 07" src="https://user-images.githubusercontent.com/8509731/190128836-12408fbd-d0c0-458b-a163-acac054bc452.png">

Tablet:

<img width="876" alt="Screenshot 2022-09-14 at 13 18 35" src="https://user-images.githubusercontent.com/8509731/190128467-281769ec-591d-4762-94fa-b0e63d2ed0c4.png">

> After

Desktop (note fixes to spacing between elements):

<img width="1424" alt="Screenshot 2022-09-14 at 12 46 25" src="https://user-images.githubusercontent.com/8509731/190127210-b3a93b25-1f5f-457a-9efe-6451ea99a65f.png">

Tablet (note how the `Waiting for` card is the first to overflow):

<img width="923" alt="Screenshot 2022-09-14 at 12 46 50" src="https://user-images.githubusercontent.com/8509731/190127255-645fcf80-8bb2-4fff-b9da-da41908cddd0.png">
