### PR TITLE
(fix) Added default selected service in queue metrics

### DIFF
--- a/__mocks__/metrics.mock.ts
+++ b/__mocks__/metrics.mock.ts
@@ -1,0 +1,24 @@
+export const mockMetrics = {
+  scheduledAppointments: 100,
+  waiting: 8,
+  averageMinutes: 28,
+};
+
+export const mockServices = ['Clinical consultation', 'Triage'];
+
+export const mockServiceTypes = {
+  data: [
+    {
+      display: 'Clinical Consulltation',
+      uuid: '7bff050e-9a83-4fdb-9212-1a4c2cee349b',
+    },
+    {
+      display: 'Lab Testing',
+      uuid: '0e960ced-d35e-43de-b87f-bc08ef3b6ec3',
+    },
+    {
+      display: 'Triage',
+      uuid: 'dbc32cf4-e11d-4006-b398-c71204cfc0d0',
+    },
+  ],
+};

--- a/packages/esm-outpatient-app/__mocks__/metrics.mock.ts
+++ b/packages/esm-outpatient-app/__mocks__/metrics.mock.ts
@@ -1,7 +1,0 @@
-export const mockMetrics = {
-  scheduledAppointments: 100,
-  waiting: 8,
-  averageMinutes: 28,
-};
-
-export const mockServices = ['Clinical consultation', 'Triage'];

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -33,6 +33,14 @@ function ClinicMetrics() {
     }
   }, [session, locations, userLocation]);
 
+  useEffect(() => {
+    if (!selectedService && !selectedServiceUuid) {
+      const service = allServices.find((s) => s.display.toLowerCase() === 'triage');
+      setSelectedService(service?.display);
+      setSelectedServiceUuid(service?.uuid);
+    }
+  }, [allServices, selectedService, selectedServiceUuid]);
+
   const handleServiceCountChange = ({ selectedItem }: { selectedItem: Service }) => {
     setSelectedService(selectedItem.display);
     setSelectedServiceUuid(selectedItem.uuid);
@@ -61,10 +69,11 @@ function ClinicMetrics() {
           <Dropdown
             id="inline"
             type="inline"
+            initialSelectedItem={{ display: `${t('triage', 'Triage')}` }}
+            label={selectedService}
             items={allServices?.length ? [...allServices] : []}
             itemToString={(item) => (item ? item.display : '')}
             onChange={handleServiceCountChange}
-            label={t('selectService', 'Select a service')}
           />
         </MetricsCard>
         <MetricsCard

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.test.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.test.tsx
@@ -4,10 +4,9 @@ import { render, screen } from '@testing-library/react';
 import { openmrsFetch } from '@openmrs/esm-framework';
 
 import ClinicMetrics from './clinic-metrics.component';
-import { mockMetrics } from '../../__mocks__/metrics.mock';
+import { mockMetrics, mockServiceTypes } from '../../../../__mocks__/metrics.mock';
 import { waitForLoadingToFinish } from '../../../../tools/test-helpers';
 import { mockLocations } from '../../../../__mocks__/locations.mock';
-import { mockServiceTypes } from '../../../../__mocks__/appointments.mock';
 import { mockSession } from '../../../../__mocks__/session.mock';
 
 const mockedOpenmrsFetch = openmrsFetch as jest.Mock;
@@ -17,7 +16,7 @@ jest.mock('./queue-metrics.resource.ts', () => {
 
   return {
     ...originalModule,
-    useServices: jest.fn().mockImplementation(() => ({ services: mockServiceTypes.data })),
+    useServices: jest.fn().mockImplementation(() => ({ allServices: mockServiceTypes.data })),
   };
 });
 
@@ -49,7 +48,7 @@ describe('Clinic metrics', () => {
     expect(screen.getAllByText(/patient list/i));
 
     // Select a different service to show metrics for
-    expect(screen.getByLabelText(/Select a service/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/triage/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /open menu/i }));
   });
 });

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -154,6 +154,7 @@
   "time": "Time",
   "tirageNotYetCompleted": "Triage has not yet been completed",
   "today": "Today",
+  "triage": "Triage",
   "triageForm": "Triage form",
   "triageNote": "Triage note",
   "trySearchWithPatientUniqueID": "Try searching with the patient's unique ID number",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Added default selected service in queue metrics
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="945" alt="metrics" src="https://user-images.githubusercontent.com/19533785/190355518-07e369d8-3e97-4276-97c7-ae6c8b13a98a.PNG">


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
