### PR TITLE
03-1528: Appointment form patient banner fix.

### DIFF
--- a/packages/esm-appointments-app/__mocks__/appointments.mock.ts
+++ b/packages/esm-appointments-app/__mocks__/appointments.mock.ts
@@ -359,6 +359,21 @@
 //   ],
 // };
 
+export const mockPatient = {
+  identifier: '100GEJ',
+  name: 'John Wilson',
+  uuid: '8673ee4f-e2ab-4077-ba55-4980f408773e',
+  gender: 'M',
+  age: 35,
+  birthdate: '1986-04-03T00:00:00.000+0000',
+  phoneNumber: '0700000000',
+};
+
+export const mockServices = [
+  { uuid: '176052c7-5fd4-4b33-89cc-7bae6848c65a', display: 'Clinical consultation' },
+  { uuid: 'd80ff12a-06a7-11ed-b939-0242ac120002', display: 'Triage' },
+];
+
 export const mockServiceTypes = {
   data: [
     {

--- a/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
@@ -94,6 +94,8 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
 
   const appointmentSummary = useAppointmentSummary(new Date().toString(), selectedService);
 
+  const isMissingRequirements = !selectedService || !appointmentKind.length;
+
   useEffect(() => {
     if (selectedLocation && session?.sessionLocation?.uuid) {
       setSelectedLocation(session?.sessionLocation?.uuid);
@@ -424,7 +426,12 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
         <Button onClick={closeOverlay} className={styles.button} kind="secondary">
           {t('discard', 'Discard')}
         </Button>
-        <Button onClick={handleSubmit} className={styles.button} disabled={isSubmitting} kind="primary" type="submit">
+        <Button
+          onClick={handleSubmit}
+          className={styles.button}
+          disabled={isSubmitting || isMissingRequirements}
+          kind="primary"
+          type="submit">
           {t('save', 'Save')}
         </Button>
       </ButtonSet>

--- a/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
@@ -283,9 +283,9 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
         </div>
       </div>
 
-      <div className={styles.inputContainer}>
+      <div className={styles.inputContainer} id="appointment-place">
         <p>{t('selectAppointmentLocation', 'Select where the appointment will take place')}</p>
-        <ContentSwitcher className={styles.inputContainer}>
+        <ContentSwitcher className={styles.inputContainer} data-testid="appointment-place">
           <Switch value="facility" id="facility" text={t('facility', 'Facility')}>
             {t('facility', 'Facility')}
           </Switch>
@@ -385,9 +385,9 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
           ))}
       </Select>
 
-      <div className={styles.inputContainer}>
+      <div className={styles.inputContainer} id="radio-group">
         <label className="cds--label">
-          {t('getAppointmentReminder', 'Would you like to get a remider about this appointment?')}
+          {t('getAppointmentReminder', 'Would you like to get a reminder about this appointment?')}
         </label>
         <RadioButtonGroup
           defaultSelected="No"

--- a/packages/esm-appointments-app/src/appointment-forms/appointments-forms.test.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-forms.test.tsx
@@ -67,14 +67,16 @@ describe('AppointmentForm', () => {
       (content, element) => element.tagName.toLowerCase() === 'input',
     ) as Array<HTMLInputElement>;
     const allSelects = screen.queryAllByRole('combobox') as Array<HTMLInputElement>;
-    let inputAndSelectNames = [];
+    const allTabs = screen.queryAllByRole('tab') as Array<HTMLInputElement>;
+    let inputAndSelectNamesAndTabValues = [];
 
-    allInputs.forEach((input) => inputAndSelectNames.push(input.id));
-    allSelects.forEach((select) => inputAndSelectNames.push(select.id));
+    allInputs.forEach((input) => inputAndSelectNamesAndTabValues.push(input?.id));
+    allSelects.forEach((select) => inputAndSelectNamesAndTabValues.push(select?.id));
+    allTabs.forEach((tab) => inputAndSelectNamesAndTabValues.push(tab?.id));
 
     expect(screen.queryByLabelText('Reason For Changes')).not.toBeInTheDocument();
 
-    expect(inputAndSelectNames).toEqual([
+    expect(inputAndSelectNamesAndTabValues).toEqual([
       'visitStartDateInput',
       'start-time-picker',
       'end-time-picker',
@@ -89,6 +91,8 @@ describe('AppointmentForm', () => {
       'appointmentKind',
       'appointmentStatus',
       'providers',
+      'facility',
+      'community',
     ]);
   });
 
@@ -101,7 +105,6 @@ describe('AppointmentForm', () => {
   it('renders the expected appointment kinds', () => {
     renderAppointmentsForm('creating', mockPatient.uuid);
     const appointmentKindSelect = screen.getByLabelText('Select an appointment kind');
-    screen.debug(screen.getByLabelText('Select an appointment kind'));
 
     expect((screen.getByRole('option', { name: 'Select an appointment kind' }) as HTMLOptionElement).selected).toBe(
       true,

--- a/packages/esm-appointments-app/src/appointment-forms/appointments-forms.test.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-forms.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useConfig, usePatient } from '@openmrs/esm-framework';
+import { mockPatient, mockServices, mockProviders } from '../../__mocks__/appointments.mock';
+import { mockLocations } from '../../../../__mocks__/locations.mock';
+import { mockSession } from '../../../../__mocks__/session.mock';
+import { MappedAppointment } from '../types';
+import AppointmentForm from './appointments-form.component';
+
+const mockedUseConfig = useConfig as jest.Mock;
+const mockedUsePatient = usePatient as jest.Mock;
+
+function renderAppointmentsForm(context: string, patientUuid?: string, appointment?: MappedAppointment) {
+  render(<AppointmentForm patientUuid={patientUuid} context={context} appointment={appointment} />);
+}
+
+jest.mock('./appointment-forms.resource.ts', () => {
+  const originalModule = jest.requireActual('./appointment-forms.resource.ts');
+
+  return {
+    ...originalModule,
+    useServices: jest.fn().mockReturnValue({ services: mockServices }),
+  };
+});
+
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+  return {
+    ...originalModule,
+    openmrsFetch: jest.fn(),
+    useLocations: jest.fn().mockImplementation(() => mockLocations.data),
+    useSession: jest.fn().mockImplementation(() => mockSession.data),
+    useProviders: jest.fn().mockImplementation(() => mockProviders.data),
+  };
+});
+
+let mockOpenmrsConfig = {
+  daysOfTheWeek: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  appointmentKinds: ['Scheduled', 'WalkIn', 'Virtual'],
+  appointmentStatuses: ['Requested', 'Scheduled', 'CheckedIn', 'Completed', 'Cancelled', 'Missed'],
+};
+
+describe('AppointmentForm', () => {
+  const patient = mockPatient;
+  beforeEach(() => {
+    mockedUseConfig.mockReturnValue(mockOpenmrsConfig);
+    mockedUsePatient.mockReturnValue({
+      patient,
+      isLoading: false,
+      error: null,
+      patientUuid: patient.uuid,
+    });
+  });
+
+  it('renders the patient banner with the right patient', () => {
+    renderAppointmentsForm('creating', mockPatient.uuid);
+
+    expect(screen.getByText(/Appointments Date and Time/i)).toBeInTheDocument();
+    // Need to test the banner extension
+  });
+
+  it('renders the form with all expected inputs in create mode', () => {
+    renderAppointmentsForm('creating', mockPatient.uuid);
+
+    const allInputs = screen.queryAllByLabelText(
+      (content, element) => element.tagName.toLowerCase() === 'input',
+    ) as Array<HTMLInputElement>;
+    const allSelects = screen.queryAllByRole('combobox') as Array<HTMLInputElement>;
+    let inputAndSelectNames = [];
+
+    allInputs.forEach((input) => inputAndSelectNames.push(input.id));
+    allSelects.forEach((select) => inputAndSelectNames.push(select.id));
+
+    expect(screen.queryByLabelText('Reason For Changes')).not.toBeInTheDocument();
+
+    expect(inputAndSelectNames).toEqual([
+      'visitStartDateInput',
+      'start-time-picker',
+      'end-time-picker',
+      'Yes',
+      'No',
+      '',
+      'start-time-picker',
+      'end-time-picker',
+      'frequency',
+      'location',
+      'service',
+      'appointmentKind',
+      'appointmentStatus',
+      'providers',
+    ]);
+  });
+
+  it('renders the form with all expected inputs in edit mode', () => {
+    renderAppointmentsForm('editing', mockPatient.uuid);
+
+    expect(screen.getByLabelText('Reason For Changes')).toBeInTheDocument();
+  });
+
+  it('renders the expected appointment kinds', () => {
+    renderAppointmentsForm('creating', mockPatient.uuid);
+    const appointmentKindSelect = screen.getByLabelText('Select an appointment kind');
+    screen.debug(screen.getByLabelText('Select an appointment kind'));
+
+    expect((screen.getByRole('option', { name: 'Select an appointment kind' }) as HTMLOptionElement).selected).toBe(
+      true,
+    );
+    expect(within(appointmentKindSelect).getAllByRole('option')).toHaveLength(4);
+    expect(within(appointmentKindSelect).getAllByRole('option')[1]).toHaveValue('Scheduled');
+    expect(within(appointmentKindSelect).getAllByRole('option')[2]).toHaveValue('WalkIn');
+    expect(within(appointmentKindSelect).getAllByRole('option')[3]).toHaveValue('Virtual');
+
+    // TODO handle onselect an option
+  });
+});

--- a/packages/esm-appointments-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-appointments-app/src/patient-search/patient-search.component.tsx
@@ -8,11 +8,11 @@ import AppointmentForm from '../appointment-forms/appointments-form.component';
 
 const PatientSearch: React.FC = () => {
   const { t } = useTranslation();
-  const launchCreateAppointmentForm = (patientUuid: string) => {
+  const launchCreateAppointmentForm = (patient) => {
     closeOverlay();
     launchOverlay(
       t('appointmentForm', 'Create Appointment'),
-      <AppointmentForm patientUuid={patientUuid} context="creating" />,
+      <AppointmentForm patientUuid={patient.uuid} context="creating" />,
     );
   };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Fixed the `undefined`  patient in the appointments form the patient banner. This was causing the creating of an appointment to fail.
Disable `Save` button if there is no selected service or appointmentKind. These are required fields for creating an appointment.


## Screenshots

Dev3
<img width="593" alt="Screenshot 2022-09-15 at 21 56 37" src="https://user-images.githubusercontent.com/30952856/190487316-15ed120f-3939-495c-9a2c-8b40f123eb5f.png">

Locally Fixed
<img width="589" alt="Screenshot 2022-09-15 at 21 58 42" src="https://user-images.githubusercontent.com/30952856/190487327-524913f8-3e8c-439f-8c9b-ed408c80861b.png">


## Related Issue
[Patient banner in the appointments for showing undefined.](https://issues.openmrs.org/browse/O3-1528)

