### PR TITLE
03-1536: Add privileges to today's appointments widget.

### DIFF
--- a/packages/esm-appointments-app/src/config-schema.ts
+++ b/packages/esm-appointments-app/src/config-schema.ts
@@ -31,6 +31,18 @@ export const configSchema = {
     _description: 'Open links in Bahmni Appointments UI instead of O3 UI',
     _default: false,
   },
+
+  useFullViewPrivilege: {
+    _type: Type.Boolean,
+    _description: "if set to 'false', will always display the full view, disregarding any privilege",
+    _default: false,
+  },
+
+  fullViewPrivilege: {
+    _type: Type.String,
+    _description: 'Display for the privilege to view and manage appointments',
+    _default: "Today's Appointments Widget: Display Full View",
+  },
 };
 
 export interface ConfigObject {
@@ -42,4 +54,6 @@ export interface ConfigObject {
   daysOfTheWeek: Array<string>;
   appointmentStatuses: Array<string>;
   useBahmniAppointmentsUI: boolean;
+  useFullViewPrivilege: boolean;
+  fullViewPrivilege: string;
 }

--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
@@ -232,7 +232,7 @@ const AppointmentsBaseTable = () => {
           overflowMenuOnHover={isDesktop(layout)}
           rows={tableRows}
           size={isDesktop(layout) ? 'xs' : 'md'}
-          useZebraStyles={filteredAppointments?.length > 1}>
+          useZebraStyles={true}>
           {({ rows, headers, getHeaderProps, getTableProps, getRowProps }) => (
             <TableContainer className={styles.tableContainer}>
               <Table {...getTableProps()} className={styles.appointmentsTable}>

--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
@@ -91,8 +91,7 @@ const AppointmentsBaseTable = () => {
   const { useBahmniAppointmentsUI: useBahmniUI, useFullViewPrivilege, fullViewPrivilege } = useConfig();
   const { isLoading, appointments } = useTodayAppointments();
 
-  const userHasFullAccess = useFullViewPrivilege && userHasAccess(fullViewPrivilege, user);
-  const fullView = userHasFullAccess || !useFullViewPrivilege;
+  const fullView = userHasAccess(fullViewPrivilege, user) || !useFullViewPrivilege;
 
   const filteredAppointments = !fullView
     ? appointments.filter((appointment) => appointment.status === 'Scheduled')

--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
@@ -1,11 +1,10 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
   DataTable,
   Layer,
   DataTableSkeleton,
-  DataTableHeader,
   Table,
   TableBody,
   TableCell,
@@ -92,20 +91,12 @@ const AppointmentsBaseTable = () => {
   const { useBahmniAppointmentsUI: useBahmniUI, useFullViewPrivilege, fullViewPrivilege } = useConfig();
   const { isLoading, appointments } = useTodayAppointments();
 
-  const [fullView, setFullView] = useState(false);
+  const userHasFullAccess = useFullViewPrivilege && userHasAccess(fullViewPrivilege, user);
+  const fullView = userHasFullAccess || !useFullViewPrivilege;
 
   const filteredAppointments = !fullView
     ? appointments.filter((appointment) => appointment.status === 'Scheduled')
     : appointments;
-
-  const userHasFullAccess = useFullViewPrivilege && userHasAccess(fullViewPrivilege, user);
-  useEffect(() => {
-    if (!useFullViewPrivilege || userHasFullAccess) {
-      setFullView(true);
-    } else {
-      setFullView(false);
-    }
-  }, []);
 
   const pageSizes = [10, 20, 30, 40, 50];
   const [currentPageSize, setPageSize] = useState(10);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Check if the userHasAccess and they want to use the privileges, by default the use of privileges is `false`. If you want to use privileges you can turn it true in the config. Else you will have a full view.
```{
  "@openmrs/esm-appointments-app": {
    "useFullViewPrivilege": true
  }
}
```
If you are using privileges and have limited access, the view will be limited.

## Screenshots
Limited Access View. Can only see `Scheduled`,  add, see all or checkin appointments.
<img width="1391" alt="Screenshot 2022-09-23 at 22 28 37" src="https://user-images.githubusercontent.com/30952856/192045384-fce9f675-edc0-4bfe-88b6-e2ffafd89f75.png">

Full View Access: Can do all actions and can see all appointments
<img width="1401" alt="Screenshot 2022-09-23 at 22 27 55" src="https://user-images.githubusercontent.com/30952856/192045536-d0617fce-e4c7-41aa-a62e-ed8246e3f752.png">

## Related Issue
[Add privileges to today's appointments widget.](https://issues.openmrs.org/browse/O3-1536)

