### PR TITLE
feat: Add checkedIn appointments tab

### DIFF
--- a/packages/esm-appointments-app/src/appointments-tabs/checkedinappointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/checkedinappointments.component.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import AppointmentsBaseTable from './appointments-base-table.component';
+import { useAppointments } from './appointments-table.resource';
+
+interface checkedInAppointmentsProps {
+  status: string;
+}
+
+const CheckInAppointments: React.FC<checkedInAppointmentsProps> = ({ status }) => {
+  const { t } = useTranslation();
+  const { appointments, isLoading } = useAppointments(status);
+
+  return (
+    <div>
+      <AppointmentsBaseTable
+        appointments={appointments}
+        isLoading={isLoading}
+        tableHeading={t('checkedInAppointments', 'CheckedIn appointments')}
+      />
+    </div>
+  );
+};
+
+export default CheckInAppointments;

--- a/packages/esm-appointments-app/src/appointments/appointment-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-list.component.tsx
@@ -8,11 +8,13 @@ import styles from './appointment-list.scss';
 import { navigate } from '@openmrs/esm-framework';
 import { spaBasePath } from '../constants';
 import ScheduledAppointments from '../appointments-tabs/schedule-appointment.component';
+import CheckInAppointments from '../appointments-tabs/checkedinappointments.component';
 
 enum AppointmentTypes {
   SCHEDULED = 'Scheduled',
   COMPLETED = 'Completed',
   CANCELLED = 'Cancelled',
+  CHECKEDIN = 'CheckedIn',
 }
 
 const AppointmentList: React.FC = () => {
@@ -28,6 +30,7 @@ const AppointmentList: React.FC = () => {
           <Tab>{t('scheduled', 'Scheduled')}</Tab>
           <Tab>{t('cancelled', 'Cancelled')}</Tab>
           <Tab>{t('completed', 'Completed')}</Tab>
+          <Tab>{t('checkedIn', 'CheckedIn')}</Tab>
           <Button
             className={styles.calendarButton}
             kind="primary"
@@ -46,6 +49,7 @@ const AppointmentList: React.FC = () => {
             <CancelledAppointment status={AppointmentTypes.CANCELLED} />
           </TabPanel>
           <TabPanel style={{ padding: 0 }}>{<CompletedAppointments status={AppointmentTypes.COMPLETED} />}</TabPanel>
+          <TabPanel style={{ padding: 0 }}>{<CheckInAppointments status={AppointmentTypes.CHECKEDIN} />}</TabPanel>
         </TabPanels>
       </Tabs>
     </div>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Add `checkedIn` Appointments tab to appointment landing page


## Screenshots

<img width="1433" alt="Screenshot 2022-10-04 at 12 40 21 pm" src="https://user-images.githubusercontent.com/28008754/193787709-cdb046f9-24ce-4b25-b8ba-4dd7f22e606c.png">



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
