### PR TITLE
feat: Add ability to auto-calculate end-time using appointment duration time

### DIFF
--- a/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
@@ -67,7 +67,6 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
     provider: '',
     appointmentNumber: undefined,
   };
-
   const appointmentState = !isEmpty(appointment) ? appointment : initialState;
   const { t } = useTranslation();
   const { mutate } = useSWRConfig();
@@ -79,8 +78,12 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
   const session = useSession();
   const { providers } = useProviders();
   const { services } = useServices();
-  const [startDate, setStartDate] = useState(appointmentState.dateTime || dayjs(new Date()).format('hh:mm'));
-  const [endDate, setEndDate] = useState(appointmentState.dateTime || dayjs(new Date()).format('hh:mm'));
+  const [startDate, setStartDate] = useState(
+    dayjs(appointmentState.dateTime).format('hh:mm') || dayjs(new Date()).format('hh:mm'),
+  );
+  const [endDate, setEndDate] = useState(
+    dayjs(appointmentState.dateTime).format('hh:mm') || dayjs(new Date()).format('hh:mm'),
+  );
   const [frequency, setFrequency] = useState('');
   const [selectedLocation, setSelectedLocation] = useState(appointmentState.location);
   const [selectedService, setSelectedService] = useState(appointmentState.serviceUuid);
@@ -90,7 +93,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
   const [reason, setReason] = useState('');
   const [timeFormat, setTimeFormat] = useState<amPm>(new Date().getHours() >= 12 ? 'PM' : 'AM');
   const [visitDate, setVisitDate] = React.useState(
-    appointmentState.dateTime ? parseDate(appointmentState.dateTime) : new Date(),
+    appointmentState.dateTime ? new Date(appointmentState.dateTime) : new Date(),
   );
   const [isFullDay, setIsFullDay] = useState<boolean>(false);
   const [day, setDay] = useState(appointmentState.dateTime);
@@ -98,8 +101,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
   const [appointmentStatus, setAppointmentStatus] = useState(appointmentState.status);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const appointmentStartDate = useAppointmentDate();
-
-  const appointmentSummary = useAppointmentSummary(new Date().toString(), selectedService);
+  const appointmentSummary = useAppointmentSummary(visitDate?.toString(), selectedService);
 
   const isMissingRequirements = !selectedService || !appointmentKind.length;
 
@@ -216,26 +218,6 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
         />
       )}
 
-      <div className={styles.workLoadContainer}>
-        {appointmentSummary.length > 0 && (
-          <>
-            <p className={styles.workLoadTitle}>
-              {t(
-                'serviceWorkloadTitle',
-                `${selectedService} clinic work load on the week of ${dayjs(first(appointmentSummary).date).format(
-                  'DD/MM',
-                )}`,
-              )}
-            </p>
-            <div className={styles.workLoadCard}>
-              {appointmentSummary?.map(({ date, count }, index) => (
-                <WorkloadCard key={date} date={dayjs(date).format('DD/MM')} count={count} isActive={index === 0} />
-              ))}
-            </div>
-          </>
-        )}
-      </div>
-
       <div className={styles.childRow}>
         <div className={styles.row}>
           <Select
@@ -329,8 +311,8 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
           datePickerType="single"
           id="visitDate"
           light
-          className={styles.datePickerInput}
           minDate={visitDate}
+          className={styles.datePickerInput}
           onChange={([date]) => setVisitDate(date)}
           value={visitDate}>
           <DatePickerInput
@@ -386,6 +368,34 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
           </TimePicker>
         </div>
       ) : null}
+
+      {appointmentSummary.length > 0 && (
+        <div className={styles.workLoadContainer}>
+          <>
+            <p className={styles.workLoadTitle}>
+              {t(
+                'serviceWorkloadTitle',
+                `${appointmentService.name} clinic work load on the week of ${dayjs(
+                  first(appointmentSummary).date,
+                ).format('DD/MM')}`,
+              )}
+            </p>
+            <div className={styles.workLoadCard}>
+              {appointmentSummary?.map(({ date, count }, index) => {
+                return (
+                  <WorkloadCard
+                    onClick={() => setVisitDate(new Date(date))}
+                    key={date}
+                    date={dayjs(date).format('DD/MM')}
+                    count={count}
+                    isActive={dayjs(date).format('DD-MM-YYYY') === dayjs(visitDate).format('DD-MM-YYYY')}
+                  />
+                );
+              })}
+            </div>
+          </>
+        </div>
+      )}
 
       <Select
         id="appointmentKind"

--- a/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
@@ -103,6 +103,26 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
 
   const isMissingRequirements = !selectedService || !appointmentKind.length;
 
+  const appointmentService = services?.find(({ uuid }) => uuid === selectedService);
+
+  useEffect(() => {
+    if (appointmentService) {
+      const [hours, minutes] = convertTime12to24(startDate, timeFormat);
+      const startDatetime = new Date(
+        dayjs(visitDate).year(),
+        dayjs(visitDate).month(),
+        dayjs(visitDate).date(),
+        hours,
+        minutes,
+      );
+      setEndDate(
+        dayjs(startDatetime)
+          .add(parseInt(appointmentService?.durationMins ?? '0'), 'minutes')
+          .format('hh:mm'),
+      );
+    }
+  }, [startDate, timeFormat, appointmentService, visitDate]);
+
   useEffect(() => {
     if (selectedLocation && session?.sessionLocation?.uuid) {
       setSelectedLocation(session?.sessionLocation?.uuid);
@@ -196,28 +216,6 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
         />
       )}
 
-      <p>{t('appointmentDateAndTime', 'Appointments Date and Time')}</p>
-
-      <div className={styles.row}>
-        <Toggle onToggle={(value) => setIsFullDay(value)} id="allDay" labelA="Off" labelB="On" labelText="All Day" />
-        <DatePicker
-          dateFormat="d/m/Y"
-          datePickerType="single"
-          id="visitDate"
-          light
-          className={styles.datePickerInput}
-          minDate={visitDate}
-          onChange={([date]) => setVisitDate(date)}
-          value={visitDate}>
-          <DatePickerInput
-            id="visitStartDateInput"
-            labelText={t('date', 'Date')}
-            placeholder="dd/mm/yyyy"
-            style={{ width: '100%' }}
-          />
-        </DatePicker>
-      </div>
-
       <div className={styles.workLoadContainer}>
         {appointmentSummary.length > 0 && (
           <>
@@ -239,48 +237,6 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
       </div>
 
       <div className={styles.childRow}>
-        {!isFullDay ? (
-          <div className={styles.row}>
-            <TimePicker
-              light
-              className={styles.timePickerInput}
-              pattern="([\d]+:[\d]{2})"
-              onChange={(event) => setStartDate(event.target.value)}
-              value={startDate}
-              labelText={t('startTime', 'Start Time')}
-              id="start-time-picker">
-              <TimePickerSelect
-                id="start-time-picker"
-                onChange={(event) => setTimeFormat(event.target.value as amPm)}
-                value={timeFormat}
-                labelText={t('time', 'Time')}
-                aria-label={t('time', 'Time')}>
-                <SelectItem value="AM" text="AM" />
-                <SelectItem value="PM" text="PM" />
-              </TimePickerSelect>
-            </TimePicker>
-
-            <TimePicker
-              light
-              className={styles.timePickerInput}
-              pattern="([\d]+:[\d]{2})"
-              onChange={(event) => setEndDate(event.target.value)}
-              value={endDate}
-              labelText={t('endTime', 'End Time')}
-              id="end-time-picker">
-              <TimePickerSelect
-                id="end-time-picker"
-                onChange={(event) => setTimeFormat(event.target.value as amPm)}
-                value={timeFormat}
-                labelText={t('time', 'Time')}
-                aria-label={t('time', 'Time')}>
-                <SelectItem value="AM" text="AM" />
-                <SelectItem value="PM" text="PM" />
-              </TimePickerSelect>
-            </TimePicker>
-          </div>
-        ) : null}
-
         <div className={styles.row}>
           <Select
             labelText={t('frequency', 'Frequency')}
@@ -363,6 +319,73 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment = {}, pat
             </SelectItem>
           ))}
       </Select>
+
+      <p>{t('appointmentDateAndTime', 'Appointments Date and Time')}</p>
+
+      <div className={styles.row}>
+        <Toggle onToggle={(value) => setIsFullDay(value)} id="allDay" labelA="Off" labelB="On" labelText="All Day" />
+        <DatePicker
+          dateFormat="d/m/Y"
+          datePickerType="single"
+          id="visitDate"
+          light
+          className={styles.datePickerInput}
+          minDate={visitDate}
+          onChange={([date]) => setVisitDate(date)}
+          value={visitDate}>
+          <DatePickerInput
+            id="visitStartDateInput"
+            labelText={t('date', 'Date')}
+            placeholder="dd/mm/yyyy"
+            style={{ width: '100%' }}
+          />
+        </DatePicker>
+      </div>
+      {!isFullDay ? (
+        <div className={styles.row}>
+          <TimePicker
+            disabled={!appointmentService}
+            light
+            className={styles.timePickerInput}
+            pattern="([\d]+:[\d]{2})"
+            onChange={(event) => setStartDate(event.target.value)}
+            value={startDate}
+            labelText={t('startTime', 'Start Time')}
+            id="start-time-picker">
+            <TimePickerSelect
+              disabled={!appointmentService}
+              id="start-time-picker"
+              onChange={(event) => setTimeFormat(event.target.value as amPm)}
+              value={timeFormat}
+              labelText={t('time', 'Time')}
+              aria-label={t('time', 'Time')}>
+              <SelectItem value="AM" text="AM" />
+              <SelectItem value="PM" text="PM" />
+            </TimePickerSelect>
+          </TimePicker>
+
+          <TimePicker
+            disabled={!appointmentService}
+            light
+            className={styles.timePickerInput}
+            pattern="([\d]+:[\d]{2})"
+            onChange={(event) => setEndDate(event.target.value)}
+            value={endDate}
+            labelText={t('endTime', 'End Time')}
+            id="end-time-picker">
+            <TimePickerSelect
+              disabled={!appointmentService}
+              id="end-time-picker"
+              onChange={(event) => setTimeFormat(event.target.value as amPm)}
+              value={timeFormat}
+              labelText={t('time', 'Time')}
+              aria-label={t('time', 'Time')}>
+              <SelectItem value="AM" text="AM" />
+              <SelectItem value="PM" text="PM" />
+            </TimePickerSelect>
+          </TimePicker>
+        </div>
+      ) : null}
 
       <Select
         id="appointmentKind"

--- a/packages/esm-appointments-app/src/appointment-forms/appointments-form.scss
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-form.scss
@@ -50,9 +50,12 @@
 .workLoadContainer {
   display: flex;
   flex-direction: column;
+  background-color: white;
+  padding-bottom: 1rem;
 }
 
 .workLoadTitle {
+  padding-top: spacing.$spacing-05;
   color: #525252;
   margin: 0 spacing.$spacing-05 spacing.$spacing-05 spacing.$spacing-05;
   @include type.type-style('legal-01');

--- a/packages/esm-appointments-app/src/appointment-forms/appointments-forms.test.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-forms.test.tsx
@@ -75,7 +75,6 @@ describe('AppointmentForm', () => {
     allTabs.forEach((tab) => inputAndSelectNamesAndTabValues.push(tab?.id));
 
     expect(screen.queryByLabelText('Reason For Changes')).not.toBeInTheDocument();
-
     expect(inputAndSelectNamesAndTabValues).toEqual([
       'visitStartDateInput',
       'start-time-picker',
@@ -83,11 +82,11 @@ describe('AppointmentForm', () => {
       'Yes',
       'No',
       '',
-      'start-time-picker',
-      'end-time-picker',
       'frequency',
       'location',
       'service',
+      'start-time-picker',
+      'end-time-picker',
       'appointmentKind',
       'appointmentStatus',
       'providers',

--- a/packages/esm-appointments-app/src/appointment-forms/workload.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/workload.component.tsx
@@ -6,11 +6,16 @@ interface WorkloadCardProp {
   date: string;
   count: number;
   isActive: boolean;
+  onClick: () => void;
 }
-const WorkloadCard: React.FC<WorkloadCardProp> = ({ date, count, isActive }) => {
+const WorkloadCard: React.FC<WorkloadCardProp> = ({ date, count, isActive, onClick }) => {
   const { t } = useTranslation();
   return (
-    <div className={`${styles.tileContainer}  ${isActive && styles.activeWorkloadCard}`}>
+    <div
+      tabIndex={0}
+      role="button"
+      onClick={onClick}
+      className={`${styles.tileContainer}  ${isActive && styles.activeWorkloadCard}`}>
       <div className={styles.tileHeader}>
         <label className={styles.headerLabel}>{date}</label>
       </div>

--- a/packages/esm-appointments-app/src/appointment-forms/workload.scss
+++ b/packages/esm-appointments-app/src/appointment-forms/workload.scss
@@ -4,68 +4,67 @@
 @import '~carbon-components/src/globals/scss/vars';
 @import '~carbon-components/src/globals/scss/mixins';
 
-
 .cardContainer {
-    background-color: $ui-02;
-    display: flex;
-    height: spacing.$spacing-12;
+  background-color: $ui-02;
+  display: flex;
+  height: spacing.$spacing-12;
 }
 
 .tileContainer {
-    padding: 0.5rem;
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    cursor: pointer;
-    border: 1px solid colors.$blue-30;
-    border-left-width: 0;
+  padding: 0.5rem;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  cursor: pointer;
+  border: 1px solid colors.$blue-30;
+  border-left-width: 0;
 
-    &:first-child {
-        border-left-width: 1px;
-    }
+  &:first-child {
+    border-left-width: 1px;
+  }
 
-    & label {
-        color: colors.$gray-70;
-    }
+  & label {
+    color: colors.$gray-70;
+  }
 }
 
 .tileHeader {
-    display: flex;
-    justify-content: space-between;
-    padding-bottom: 1rem;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: spacing.$spacing-05;
 }
 
 .headerLabel {
-    @include carbon--type-style('productive-heading-01');
-    color: $text-02;
+  @include carbon--type-style('productive-heading-01');
+  color: $text-02;
 }
 
 .totalsLabel {
-    @include carbon--type-style('label-01');
-    color: $text-02;
+  @include carbon--type-style('label-01');
+  color: $text-02;
 }
 
 .totalsValue {
-    @include carbon--type-style('productive-heading-04');
-    color: $ui-05;
+  @include carbon--type-style('productive-heading-04');
+  color: $ui-05;
 }
 
 .headerLabelContainer {
-    display: flex;
-    align-items: center;
-    height: $spacing-07;
+  display: flex;
+  align-items: center;
+  height: $spacing-07;
 }
 
 .link {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .activeWorkloadCard {
-    background-color: colors.$blue-10;
+  background-color: colors.$blue-10;
 
-    & label {
-        color: colors.$blue-60;
-    }
+  & label {
+    color: colors.$blue-60;
+  }
 }

--- a/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
@@ -24,7 +24,7 @@ import {
   Tile,
 } from '@carbon/react';
 import { Add, Cough, Medication, Omega } from '@carbon/react/icons';
-import { ConfigurableLink, showModal } from '@openmrs/esm-framework';
+import { ConfigurableLink, formatDatetime, parseDate, showModal } from '@openmrs/esm-framework';
 import { launchOverlay } from '../hooks/useOverlay';
 import { MappedAppointment } from '../types';
 import AppointmentDetails from '../appointment-details/appointment-details.component';
@@ -204,7 +204,7 @@ const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLo
         ),
       },
       dateTime: {
-        content: <span className={styles.statusContainer}>{appointment.dateTime}</span>,
+        content: <span className={styles.statusContainer}>{formatDatetime(parseDate(appointment.dateTime))}</span>,
       },
       serviceType: {
         content: (

--- a/packages/esm-appointments-app/src/helpers/functions.ts
+++ b/packages/esm-appointments-app/src/helpers/functions.ts
@@ -80,7 +80,7 @@ export const getAppointment = (appointment: Appointment) => {
     phoneNumber: appointment.patient?.contact,
     dob: formatDate(parseDate(appointment.patient?.birthDate), { mode: 'wide' }),
     patientUuid: appointment.patient?.uuid,
-    dateTime: formatDatetime(parseDate(appointment.startDateTime)),
+    dateTime: appointment.startDateTime,
     serviceType: appointment.service ? appointment.service.name : '--',
     serviceUuid: appointment.service ? appointment.service.uuid : null,
     appointmentKind: appointment.appointmentKind ? appointment.appointmentKind : '--',

--- a/packages/esm-appointments-app/src/helpers/time.tsx
+++ b/packages/esm-appointments-app/src/helpers/time.tsx
@@ -6,7 +6,7 @@ import { omrsDateFormat } from '../constants';
 export type amPm = 'AM' | 'PM';
 
 export const convertTime12to24 = (time12h, timeFormat: amPm) => {
-  let [hours, minutes] = time12h.split(':');
+  let [hours, minutes] = time12h?.split(':');
 
   if (hours === '12' && timeFormat === 'AM') {
     hours = '00';

--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -117,7 +117,6 @@
   "selectVisitType": "Please select a Visit Type",
   "service": "Service",
   "serviceType": "Service Type",
-  "serviceWorkloadTitle": "",
   "startTime": "Start Time",
   "startVisit": "Start a visit",
   "startVisitError": "Error starting visit",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Add ability to auto-calculate the end-time for an appointment based on the service time-slot. i.e. Should add appointment duration to the start-time to achieve end-time of the appointment


## Screenshots

![Kapture 2022-10-06 at 12 25 55](https://user-images.githubusercontent.com/28008754/194282518-966616a2-c74e-4594-be1a-358788947a1e.gif)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
