### PR TITLE
(fix) Removed cancel appointment option for cancelled, completed and …

### DIFF
--- a/packages/esm-appointments-app/src/appointment-forms/cancel-appointment.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/cancel-appointment.component.tsx
@@ -40,6 +40,7 @@ const CancelAppointment: React.FC<CancelAppointmentProps> = ({ appointment }) =>
         title: t('appointmentCancelled', 'Appointment cancelled'),
       });
       mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${startDate}&status=Scheduled`);
+      mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${startDate}&status=Cancelled`);
       closeOverlay();
     } else {
       showNotification({

--- a/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
@@ -43,6 +43,7 @@ interface AppointmentsProps {
 
 interface ActionMenuProps {
   appointment: MappedAppointment;
+  appointmentTitle: String;
   mutate?: () => void;
 }
 
@@ -54,7 +55,7 @@ type FilterProps = {
   getCellId: (row, key) => string;
 };
 
-function ActionsMenu({ appointment, mutate }: ActionMenuProps) {
+function ActionsMenu({ appointmentTitle, appointment, mutate }: ActionMenuProps) {
   const { t } = useTranslation();
 
   return (
@@ -72,15 +73,20 @@ function ActionsMenu({ appointment, mutate }: ActionMenuProps) {
           itemText={t('editAppointment', 'Edit Appointment')}>
           {t('editAppointment', 'Edit Appointment')}
         </OverflowMenuItem>
-        <OverflowMenuItem
-          className={styles.menuItem}
-          id="#cancelAppointment"
-          onClick={() =>
-            launchOverlay(t('cancelAppointment', 'Cancel Appointment'), <CancelAppointment appointment={appointment} />)
-          }
-          itemText={t('cancelAppointment', 'Cancel Appointment')}>
-          {t('cancelAppointment', 'Cancel Appointment')}
-        </OverflowMenuItem>
+        {appointmentTitle === 'scheduled' ? (
+          <OverflowMenuItem
+            className={styles.menuItem}
+            id="#cancelAppointment"
+            onClick={() =>
+              launchOverlay(
+                t('cancelAppointment', 'Cancel Appointment'),
+                <CancelAppointment appointment={appointment} />,
+              )
+            }
+            itemText={t('cancelAppointment', 'Cancel Appointment')}>
+            {t('cancelAppointment', 'Cancel Appointment')}
+          </OverflowMenuItem>
+        ) : null}
       </OverflowMenu>
     </Layer>
   );
@@ -215,7 +221,7 @@ const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLo
               {appointment.status === 'Scheduled' ? t('checkedIn', 'Checked In') : t('changeStatus', 'Change status')}
             </Button>
 
-            <ActionsMenu appointment={appointments?.[index]} />
+            <ActionsMenu appointmentTitle={tableHeading} appointment={appointments?.[index]} />
           </div>
         ),
       },

--- a/packages/esm-appointments-app/src/appointments-tabs/cancelled-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/cancelled-appointments.component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppointments } from './appointments-table.resource';
 import AppointmentsBaseTable from './appointments-base-table.component';
+import { AppointmentTypes } from '../types';
 
 interface CancelledAppointmentProps {
   status: string;
@@ -16,7 +17,7 @@ const CancelledAppointment: React.FC<CancelledAppointmentProps> = ({ status }) =
       <AppointmentsBaseTable
         appointments={appointments}
         isLoading={isLoading}
-        tableHeading={t('cancelAppointment', 'Cancelled Appointments')}
+        tableHeading={AppointmentTypes.CANCELLED}
       />
     </div>
   );

--- a/packages/esm-appointments-app/src/appointments-tabs/checkedinappointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/checkedinappointments.component.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { AppointmentTypes } from '../types';
 import AppointmentsBaseTable from './appointments-base-table.component';
 import { useAppointments } from './appointments-table.resource';
 
@@ -16,7 +17,7 @@ const CheckInAppointments: React.FC<checkedInAppointmentsProps> = ({ status }) =
       <AppointmentsBaseTable
         appointments={appointments}
         isLoading={isLoading}
-        tableHeading={t('checkedInAppointments', 'CheckedIn appointments')}
+        tableHeading={AppointmentTypes.CHECKEDIN}
       />
     </div>
   );

--- a/packages/esm-appointments-app/src/appointments-tabs/completed-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/completed-appointments.component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppointments } from './appointments-table.resource';
 import AppointmentsBaseTable from './appointments-base-table.component';
+import { AppointmentTypes } from '../types';
 
 interface CompletedAppointmentsProps {
   status: string;
@@ -16,7 +17,7 @@ const CompletedAppointments: React.FC<CompletedAppointmentsProps> = ({ status })
       <AppointmentsBaseTable
         appointments={appointments}
         isLoading={isLoading}
-        tableHeading={t('completedAppointments', 'Completed appointments')}
+        tableHeading={AppointmentTypes.COMPLETED}
       />
     </div>
   );

--- a/packages/esm-appointments-app/src/appointments-tabs/schedule-appointment.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/schedule-appointment.component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppointments } from './appointments-table.resource';
 import AppointmentsBaseTable from './appointments-base-table.component';
+import { AppointmentTypes } from '../types';
 
 interface ScheduledAppointmentsProps {
   status: string;
@@ -16,7 +17,7 @@ const ScheduledAppointments: React.FC<ScheduledAppointmentsProps> = ({ status })
       <AppointmentsBaseTable
         appointments={appointments}
         isLoading={isLoading}
-        tableHeading={t('scheduledAppointments', 'Scheduled appointments')}
+        tableHeading={AppointmentTypes.SCHEDULED}
       />
     </div>
   );

--- a/packages/esm-appointments-app/src/types/index.ts
+++ b/packages/esm-appointments-app/src/types/index.ts
@@ -177,3 +177,11 @@ export enum DurationPeriod {
   weekly,
   daily,
 }
+
+export enum AppointmentTypes {
+  SCHEDULED = 'scheduled',
+  CANCELLED = 'cancelled',
+  MISSED = 'missed',
+  CHECKEDIN = 'checkedin',
+  COMPLETED = 'completed',
+}

--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -43,7 +43,6 @@
   "community": "Community",
   "complete": "Complete",
   "completed": "Completed",
-  "completedAppointments": "Completed appointments",
   "daily": "Daily",
   "date": "Date",
   "dateAndTimeOfVisit": "Date and time of visit",


### PR DESCRIPTION
…checkin appointments

## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Removed cancel appointment option in overflow menu for cancelled, completed and checkin appointment tabs

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="810" alt="appointment overflow" src="https://user-images.githubusercontent.com/19533785/194007782-cb5f982e-d1ec-4b9e-ba70-35e6b7b4bb27.PNG">

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
