### PR TITLE
enhancement: Align metrics text with icon

### DIFF
--- a/packages/esm-appointments-app/src/appointments-metrics/metrics-card.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-metrics/metrics-card.component.tsx
@@ -29,7 +29,7 @@ const MetricsCard: React.FC<MetricsCardProps> = ({ label, value, headerLabel, ch
           {children}
         </div>
         <ConfigurableLink className={styles.link} to={`\${openmrsSpaBase}/${metricsLink[view]}`}>
-          {t('view', 'View')} <ArrowRight size={16} className={styles.viewListBtn} />
+          <span>{t('view', 'View')}</span> <ArrowRight size={16} className={styles.viewListBtn} />
         </ConfigurableLink>
       </div>
       <div>

--- a/packages/esm-appointments-app/src/appointments-metrics/metrics-card.scss
+++ b/packages/esm-appointments-app/src/appointments-metrics/metrics-card.scss
@@ -40,6 +40,8 @@
 
 .link {
   text-decoration: none;
+  display: flex;
+  align-items: flex-end;
 }
 
 .viewListBtn {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Align metrics button with icon as indicated on the screenshot below


## Screenshots
<img width="1436" alt="Screenshot 2022-10-06 at 3 51 56 pm" src="https://user-images.githubusercontent.com/28008754/194317491-7eb7e5ff-6dde-4df9-b1b4-18e42d246c2c.png">

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
