### PR TITLE
Restoring address hierarchy and fixing the configurations

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -228,7 +228,7 @@ export const esmPatientRegistrationSchema = {
       _description: 'Provide ability to configure sex options.',
     },
     address: {
-      useAddressHeirarchy: {
+      useAddressHierarchy: {
         _type: Type.Boolean,
         _description: 'Whether to use the Address heirarchy in the registration form or not',
         _default: false,

--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -41,6 +41,9 @@ export interface RegistrationConfig {
       defaultUnknownFamilyName: string;
     };
     gender: Array<Gender>;
+    address: {
+      useAddressHierarchy: boolean;
+    };
   };
   links: {
     submitButton: string;

--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.component.tsx
@@ -31,7 +31,9 @@ export const AddressHierarchy: React.FC = () => {
   };
   const config = useConfig();
   const {
-    fieldConfigurations: { useAddressHeirarchy },
+    fieldConfigurations: {
+      address: { useAddressHierarchy },
+    },
   } = config;
 
   useEffect(() => {
@@ -85,7 +87,7 @@ export const AddressHierarchy: React.FC = () => {
           width: '50%',
           paddingBottom: '5%',
         }}>
-        {useAddressHeirarchy
+        {useAddressHierarchy
           ? addressLayout.map((attributes, index) => (
               <ComboInput
                 key={`combo_input_${index}`}

--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.test.tsx
@@ -8,7 +8,9 @@ jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   useConfig: () => ({
     fieldConfigurations: {
-      useAddressHierarchy: false,
+      address: {
+        useAddressHierarchy: false,
+      },
     },
   }),
 }));

--- a/packages/esm-patient-registration-app/src/patient-registration/input/combo-input/combo-input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/combo-input/combo-input.component.tsx
@@ -1,4 +1,4 @@
-import { ComboBox, ComboBoxProps } from '@carbon/react';
+import { ComboBox, ComboBoxProps, Layer } from '@carbon/react';
 import { useField } from 'formik';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -36,27 +36,30 @@ export const ComboInput: React.FC<ComboInputProps> = ({ name, labelText, placeho
   }
 
   return (
-    <ComboBox
-      id={name}
-      onInputChange={(event) => {
-        comboBoxEvent(event, name);
-        setValue(event);
-      }}
-      items={listItems}
-      itemToString={(item) => item?.text ?? ''}
-      {...field}
-      onChange={(e) => {
-        if (Boolean(e.selectedItem)) {
-          setSelectedValue(e.selectedItem.id);
-          setValue(e.selectedItem.text);
-        } else {
-          setSelectedValue(undefined);
-          setValue(undefined);
-        }
-      }}
-      placeholder={placeholder}
-      titleText={labelText}
-      light
-    />
+    <div style={{ marginBottom: '1rem' }}>
+      <Layer>
+        <ComboBox
+          id={name}
+          onInputChange={(event) => {
+            comboBoxEvent(event, name);
+            setValue(event);
+          }}
+          items={listItems}
+          itemToString={(item) => item?.text ?? ''}
+          {...field}
+          onChange={(e) => {
+            if (Boolean(e.selectedItem)) {
+              setSelectedValue(e.selectedItem.id);
+              setValue(e.selectedItem.text);
+            } else {
+              setSelectedValue(undefined);
+              setValue(undefined);
+            }
+          }}
+          placeholder={placeholder}
+          titleText={labelText}
+        />
+      </Layer>
+    </div>
   );
 };

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -98,6 +98,9 @@ let mockOpenmrsConfig: RegistrationConfig = {
         id: 'male',
       },
     ],
+    address: {
+      useAddressHierarchy: false,
+    },
   },
   concepts: {
     patientPhotoUuid: '736e8771-e501-4615-bfa7-570c03f4bef5',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR works on restoring the previous address hierarchy and also allow us to switch between the use of address hierarchy or not, on the basis of the configuration as follows:

```
{
    "@openmrs/esm-patient-registration-app": {
        fieldConfigurations: {
            address: {
                useAddressHierarchy: true (boolean value)
            }
        }
    }
}
``` 


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
