### PR TITLE
O3-1561: (Address Hierarchy) Show search results in a manner that only the above levels of the search string are shown and are selected

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -238,7 +238,7 @@ export const esmPatientRegistrationSchema = {
       useAddressHierarchy: {
         enabled: {
           _type: Type.Boolean,
-          _description: 'Whether to use the Address heirarchy in the registration form or not',
+          _description: 'Whether to use the Address hierarchy in the registration form or not',
           _default: true,
         },
         useQuickSearch: {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR brings changes to the Address Hierarchy in the Patient registration page.
### Currently
When we search an address, it shows hundreds of results from the highest hierarchical field to the lowest ones.
E.g. When I search for Battambang state in Cambodia, it returns all the search results including every district, address and village in Battambang.
![image](https://user-images.githubusercontent.com/51502471/195551176-b5a6b018-2f1b-47e1-92c2-803b0fa17c50.png)
When we select an option, it fills all the fields as shown below:
![image](https://user-images.githubusercontent.com/51502471/195551290-e0238112-fe39-488c-8b8c-03362c513815.png)

### Changes from PR
When we search Battambang, it will only show the higher hierarchical positions to the search string, as shown in the image:
![image](https://user-images.githubusercontent.com/51502471/195551680-ba40b839-fbaf-41b3-86b1-d27b948dfc08.png)
![image](https://user-images.githubusercontent.com/51502471/195551866-98fa371e-d831-45db-9265-9f744775b8d0.png)

When we select an option, it only fills the appropriate fields, except filling all the fields.
![image](https://user-images.githubusercontent.com/51502471/195552043-49d9d092-1df5-44bd-b70a-765d6edce37e.png)

## Screenshots

*Attached above*

## Related Issue

https://issues.openmrs.org/browse/O3-1561

## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
