### PR TITLE
feat: Add ability to configure visibility of `capture-patient-photo` in name field

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -39,6 +39,7 @@ export interface RegistrationConfig {
       unidentifiedPatient: boolean;
       defaultUnknownGivenName: string;
       defaultUnknownFamilyName: string;
+      displayCapturePhoto: boolean;
     };
     gender: Array<Gender>;
     address: {
@@ -190,6 +191,11 @@ export const esmPatientRegistrationSchema = {
         _type: Type.String,
         _default: 'UNKNOWN',
         _description: 'The family/last name to record for unidentified patients.',
+      },
+      displayCapturePhoto: {
+        _type: Type.Boolean,
+        _default: true,
+        _description: 'Whether to display capture patient photo slot on name field',
       },
     },
     gender: {

--- a/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field.component.tsx
@@ -6,6 +6,7 @@ import { ExtensionSlot, useConfig } from '@openmrs/esm-framework';
 import { Input } from '../../input/basic-input/input/input.component';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import styles from '../field.scss';
+import { RegistrationConfig } from '../../../config-schema';
 
 const containsNoNumbers = /^([^0-9]*)$/;
 
@@ -18,6 +19,11 @@ function checkNumber(value: string) {
 }
 
 export const NameField = () => {
+  const {
+    fieldConfigurations: {
+      name: { displayCapturePhoto },
+    },
+  } = useConfig() as RegistrationConfig;
   const { t } = useTranslation();
   const { setCapturePhotoProps, currentPhoto, setFieldValue } = useContext(PatientRegistrationContext);
   const { fieldConfigurations } = useConfig();
@@ -53,11 +59,13 @@ export const NameField = () => {
     <div>
       <h4 className={styles.productiveHeading02Light}>{t('fullNameLabelText', 'Full Name')}</h4>
       <div className={styles.grid}>
-        <ExtensionSlot
-          className={styles.photoExtension}
-          extensionSlotName="capture-patient-photo-slot"
-          state={{ onCapturePhoto, initialState: currentPhoto }}
-        />
+        {displayCapturePhoto && (
+          <ExtensionSlot
+            className={styles.photoExtension}
+            extensionSlotName="capture-patient-photo-slot"
+            state={{ onCapturePhoto, initialState: currentPhoto }}
+          />
+        )}
 
         <div className={styles.nameField}>
           <div className={styles.dobContentSwitcherLabel}>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Add ability to configure the visibility of `capture-patient-photo`. This enable users that won't want this feature to hide it.
## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
