### PR TITLE
feat: Add ability to configure estimated date of birth initial date

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -49,6 +49,13 @@ export interface RegistrationConfig {
         searchAddressByLevel: boolean;
       };
     };
+    dateOfBirth: {
+      useEstimatedDateOfBirth: {
+        enabled: boolean;
+        dayOfMonth: number;
+        month: number;
+      };
+    };
   };
   links: {
     submitButton: string;
@@ -263,6 +270,25 @@ export const esmPatientRegistrationSchema = {
           _type: Type.Object,
           _description: 'Whether to use custom labels for address hierarchy',
           _default: {},
+        },
+      },
+    },
+    dateOfBirth: {
+      useEstimatedDateOfBirth: {
+        enabled: {
+          _type: Type.Boolean,
+          _description: 'Whether to use custom day and month for estimated date of birth',
+          _default: false,
+        },
+        dayOfMonth: {
+          _type: Type.Number,
+          _description: 'The custom day of the month use on the estimated date of birth',
+          _default: 0,
+        },
+        month: {
+          _type: Type.Number,
+          _description: 'The custom month to use on the estimated date of birth i.e 0 = Jan 11 = Dec',
+          _default: 0,
         },
       },
     },

--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
@@ -5,8 +5,11 @@ import { useField } from 'formik';
 import { generateFormatting } from '../../date-util';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import styles from '../field.scss';
+import { useConfig } from '@openmrs/esm-framework';
+import { RegistrationConfig } from '../../../config-schema';
 
-const calcBirthdate = (yearDelta, monthDelta) => {
+const calcBirthdate = (yearDelta, monthDelta, dateOfBirth) => {
+  const { enabled, month, dayOfMonth } = dateOfBirth.useEstimatedDateOfBirth;
   const startDate = new Date();
   const resultMonth = new Date(startDate.getFullYear() - yearDelta, startDate.getMonth() - monthDelta, 1);
   const daysInResultMonth = new Date(resultMonth.getFullYear(), resultMonth.getMonth() + 1, 0).getDate();
@@ -15,11 +18,14 @@ const calcBirthdate = (yearDelta, monthDelta) => {
     resultMonth.getMonth(),
     Math.min(startDate.getDate(), daysInResultMonth),
   );
-  return resultDate;
+  return enabled ? new Date(resultDate.getFullYear(), month, dayOfMonth) : resultDate;
 };
 
 export const DobField: React.FC = () => {
   const { t } = useTranslation();
+  const {
+    fieldConfigurations: { dateOfBirth },
+  } = useConfig() as RegistrationConfig;
   const [dobUnknown] = useField('birthdateEstimated');
   const dobKnown = !dobUnknown.value;
   const [birthdate, birthdateMeta] = useField('birthdate');
@@ -45,7 +51,7 @@ export const DobField: React.FC = () => {
 
     if (!isNaN(years) && years < 140 && years >= 0) {
       setFieldValue('yearsEstimated', years);
-      setFieldValue('birthdate', calcBirthdate(years, monthsEstimateMeta.value));
+      setFieldValue('birthdate', calcBirthdate(years, monthsEstimateMeta.value, dateOfBirth));
     }
   };
 
@@ -54,7 +60,7 @@ export const DobField: React.FC = () => {
 
     if (!isNaN(months) && months <= 11 && months >= 0) {
       setFieldValue('monthsEstimated', months);
-      setFieldValue('birthdate', calcBirthdate(yearsEstimateMeta.value, months));
+      setFieldValue('birthdate', calcBirthdate(yearsEstimateMeta.value, months, dateOfBirth));
     }
   };
 

--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
@@ -9,6 +9,16 @@ import { PatientRegistrationContext } from '../../patient-registration-context';
 import { initialFormValues } from '../../patient-registration.component';
 import { FormValues } from '../../patient-registration-types';
 
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+  return {
+    ...originalModule,
+    useConfig: jest.fn().mockImplementation(() => ({
+      fieldConfigurations: { dateOfBirth: { useEstimatedDateOfBirth: { enabled: true, dayOfMonth: 0, month: 0 } } },
+    })),
+  };
+});
+
 describe('Dob', () => {
   it('renders the fields in the birth section of the registration form', async () => {
     renderDob();

--- a/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
@@ -12,6 +12,9 @@ jest.mock('@openmrs/esm-framework', () => {
   return {
     ...originalModule,
     validator: jest.fn(),
+    useConfig: jest.fn().mockImplementation(() => ({
+      fieldConfigurations: { dateOfBirth: { useEstimatedDateOfBirth: { enabled: true, dayOfMonth: 0, month: 0 } } },
+    })),
   };
 });
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Add ability to configure estimated date of birth to default to a specific Month and day 


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
