### PR TITLE
Fix: Add ability to edit future and today's appointments only

### DIFF
--- a/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/appointments-base-table.component.tsx
@@ -34,6 +34,8 @@ import styles from './appointments-base-table.scss';
 import CancelAppointment from '../appointment-forms/cancel-appointment.component';
 import VisitForm from '../patient-queue/visit-form/visit-form.component';
 import dayjs from 'dayjs';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+dayjs.extend(isSameOrAfter);
 
 interface AppointmentsProps {
   appointments: Array<MappedAppointment>;
@@ -218,7 +220,7 @@ const AppointmentsBaseTable: React.FC<AppointmentsProps> = ({ appointments, isLo
       startButton: {
         content: (
           <>
-            {dayjs(appointment.dateTime).format('DD-MM-YYYY') === dayjs(new Date()).format('DD-MM-YYYY') && (
+            {dayjs(appointment.dateTime).isSameOrAfter(new Date(), 'day') && (
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <Button onClick={() => handleAppointmentActionButtonClick(appointment)} kind="ghost">
                   {appointment.status === 'Scheduled' ? t('checkIn', 'Check In') : t('changeStatus', 'Change status')}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Add ability to edit appointments that occur in the future.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
