### PR TITLE
(chore)Changed the address field separator to > in the address hierarchy

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-search.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-search.component.tsx
@@ -11,18 +11,18 @@ interface AddressSearchComponentProps {
 
 const AddressSearchComponent: React.FC<AddressSearchComponentProps> = ({ addressLayout }) => {
   const { t } = useTranslation();
-  const seprator = ', ';
+  const separator = ' > ';
   const searchBox = useRef(null);
   const wrapper = useRef(null);
   const [searchString, setSearchString] = useState<string>('');
-  const { addresses, isLoading, error } = useAddressHierarchy(searchString);
+  const { addresses, isLoading, error } = useAddressHierarchy(searchString, separator);
   const addressOptions: Array<string> = useMemo(() => {
     const options: Set<string> = new Set();
     addresses.forEach((address) => {
-      const values = address.split(seprator);
+      const values = address.split(separator);
       values.forEach((val, index) => {
         if (val.toLowerCase().includes(searchString.toLowerCase())) {
-          options.add(values.slice(0, index + 1).join(seprator));
+          options.add(values.slice(0, index + 1).join(separator));
         }
       });
     });
@@ -37,9 +37,9 @@ const AddressSearchComponent: React.FC<AddressSearchComponentProps> = ({ address
 
   const handleChange = (address) => {
     if (address) {
-      const values = address.split(seprator);
-      values.map((value, index) => {
-        setFieldValue(`address.${addressLayout[index].name}`, value);
+      const values = address.split(separator);
+      addressLayout.map(({ name }, index) => {
+        setFieldValue(`address.${name}`, values?.[index] ?? '');
       });
       setSearchString('');
     }
@@ -61,7 +61,6 @@ const AddressSearchComponent: React.FC<AddressSearchComponentProps> = ({ address
 
   return (
     <div className={styles.autocomplete} ref={wrapper} style={{ marginBottom: '1rem' }}>
-      {/* <Layer> */}
       <Search
         onChange={handleInputChange}
         labelText={t('searchAddress', 'Search address')}
@@ -80,7 +79,6 @@ const AddressSearchComponent: React.FC<AddressSearchComponentProps> = ({ address
         }
         value={searchString}
       />
-      {/* </Layer> */}
       {addressOptions.length > 0 && (
         /* Since the input has a marginBottom of 1rem */
         <ul className={styles.suggestions}>

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.resource.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.resource.tsx
@@ -221,7 +221,10 @@ export async function deletePatientIdentifier(
   });
 }
 
-export function useAddressHierarchy(searchString): {
+export function useAddressHierarchy(
+  searchString,
+  separator,
+): {
   addresses: Array<string>;
   isLoading: boolean;
   error: Error;
@@ -235,7 +238,7 @@ export function useAddressHierarchy(searchString): {
     Error
   >(
     searchString
-      ? `/module/addresshierarchy/ajax/getPossibleFullAddresses.form?separator=%2C%20&searchString=${searchString}`
+      ? `/module/addresshierarchy/ajax/getPossibleFullAddresses.form?separator=${separator}&searchString=${searchString}`
       : null,
     openmrsFetch,
   );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR brings the change to separate the searched addresses in the Address Hierarchy from ', ' to ' > '.


## Screenshots

*None.*

## Related Issue

*None.*


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
