### PR TITLE
(fix) Add type property to `patientResultUrl` config schema

### DIFF
--- a/packages/esm-patient-search-app/src/config-schema.ts
+++ b/packages/esm-patient-search-app/src/config-schema.ts
@@ -2,6 +2,7 @@ import { Type, validators } from '@openmrs/esm-framework';
 export const configSchema = {
   search: {
     patientResultUrl: {
+      _type: Type.String,
       _default: '${openmrsSpaBase}/patient/${patientUuid}/chart',
       _description: 'Where clicking a patient result takes the user. Accepts template parameter ${patientUuid}',
       _validators: [validators.isUrlWithTemplateParameters(['patientUuid'])],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Adds a `Type` property to the `patientResultUrl` config schema property. Presently, the `patientResultUrl` property is not editable via the implementer tools, and though I don't think this fixes it, it's still a worthwhile fix nonetheless.