### PR TITLE
O3-1575: Adding keyboard controls on the compact patient search

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
@@ -57,8 +57,21 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
   );
 
   const bannerContainerRef = useRef(null);
-  const inputRef = useRef(null);
-  const focussedResult = useArrowNavigation(patients?.length ?? 0, handlePatientSelection, -1);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFocusToInput = useCallback(() => {
+    var len = inputRef.current.value?.length ?? 0;
+    inputRef.current.setSelectionRange(len, len);
+    inputRef.current.focus();
+  }, [inputRef]);
+
+  const focussedResult = useArrowNavigation(
+    inputRef,
+    patients?.length ?? 0,
+    handlePatientSelection,
+    handleFocusToInput,
+    -1,
+  );
 
   useEffect(() => {
     if (bannerContainerRef.current && focussedResult > -1) {
@@ -69,10 +82,9 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
         inline: 'nearest',
       });
     } else if (bannerContainerRef.current && inputRef.current && focussedResult === -1) {
-      bannerContainerRef.current.children?.[0]?.blur();
-      inputRef.current?.focus();
+      handleFocusToInput();
     }
-  }, [focussedResult, bannerContainerRef]);
+  }, [focussedResult, bannerContainerRef, handleFocusToInput]);
 
   return (
     <div className={styles.patientSearchBar}>

--- a/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
@@ -1,9 +1,12 @@
-import React, { useCallback, useState, useMemo } from 'react';
+import React, { useCallback, useState, useMemo, useRef, useEffect } from 'react';
 import PatientSearch from '../compact-patient-search/patient-search.component';
 import { SearchedPatient } from '../types';
 import { Search, Button } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import styles from './compact-patient-search.scss';
+import { usePatientSearchInfinite } from '../patient-search.resource';
+import { useConfig, navigate, interpolateString } from '@openmrs/esm-framework';
+import useArrowNavigation from '../hooks/useArrowNavigation';
 
 interface CompactPatientSearchProps {
   initialSearchTerm: string;
@@ -20,6 +23,9 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const handleChange = useCallback((val) => setSearchTerm(val), [setSearchTerm]);
   const showSearchResults = useMemo(() => !!searchTerm?.trim(), [searchTerm]);
+  const config = useConfig();
+  const patientSearchResponse = usePatientSearchInfinite(searchTerm, config.includeDead, showSearchResults);
+  const { data: patients } = patientSearchResponse;
 
   const handleSubmit = useCallback((evt) => {
     evt.preventDefault();
@@ -33,6 +39,41 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
     setSearchTerm('');
   }, [setSearchTerm]);
 
+  const handlePatientSelection = useCallback(
+    (evt, index: number) => {
+      evt.preventDefault();
+      if (selectPatientAction) {
+        selectPatientAction(patients[index]);
+      } else {
+        navigate({
+          to: `${interpolateString(config.search.patientResultUrl, {
+            patientUuid: patients[index].uuid,
+          })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`,
+        });
+      }
+      handleReset();
+    },
+    [config.search, selectPatientAction, patients, handleReset],
+  );
+
+  const bannerContainerRef = useRef(null);
+  const inputRef = useRef(null);
+  const focussedResult = useArrowNavigation(patients?.length ?? 0, handlePatientSelection, -1);
+
+  useEffect(() => {
+    if (bannerContainerRef.current && focussedResult > -1) {
+      bannerContainerRef.current.children?.[focussedResult]?.focus();
+      bannerContainerRef.current.children?.[focussedResult]?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end',
+        inline: 'nearest',
+      });
+    } else if (bannerContainerRef.current && inputRef.current && focussedResult === -1) {
+      bannerContainerRef.current.children?.[0]?.blur();
+      inputRef.current?.focus();
+    }
+  }, [focussedResult, bannerContainerRef]);
+
   return (
     <div className={styles.patientSearchBar}>
       <form onSubmit={handleSubmit} className={styles.searchArea}>
@@ -45,6 +86,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
           placeholder={t('searchForPatient', 'Search for a patient by name or identifier number')}
           value={searchTerm}
           size="lg"
+          ref={inputRef}
         />
         <Button type="submit" onClick={handleSubmit} {...buttonProps}>
           {t('search', 'Search')}
@@ -52,7 +94,12 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
       </form>
       {showSearchResults && (
         <div className={styles.floatingSearchResultsContainer}>
-          <PatientSearch query={searchTerm} selectPatientAction={selectPatientAction} hidePanel={handleReset} />
+          <PatientSearch
+            query={searchTerm}
+            selectPatientAction={handlePatientSelection}
+            ref={bannerContainerRef}
+            {...patientSearchResponse}
+          />
         </div>
       )}
     </div>

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -1,124 +1,106 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SkeletonIcon, SkeletonText } from '@carbon/react';
-import { ExtensionSlot, useConfig, interpolateString, navigate, ConfigurableLink, age } from '@openmrs/esm-framework';
+import { ExtensionSlot, useConfig, interpolateString, ConfigurableLink, age } from '@openmrs/esm-framework';
 import { SearchedPatient } from '../types/index';
 import styles from './compact-patient-banner.scss';
 
 interface PatientSearchResultsProps {
   patients: Array<SearchedPatient>;
-  hidePanel?: any;
-  selectPatientAction?: (patient: SearchedPatient) => void;
+  selectPatientAction?: (evt: any, index: number) => void;
 }
 
-const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({ patients, hidePanel, selectPatientAction }) => {
-  const config = useConfig();
-  const { t } = useTranslation();
+const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResultsProps>(
+  ({ patients, selectPatientAction }, ref) => {
+    const config = useConfig();
+    const { t } = useTranslation();
 
-  const getGender = (gender) => {
-    switch (gender) {
-      case 'M':
-        return t('male', 'Male');
-      case 'F':
-        return t('female', 'Female');
-      case 'O':
-        return t('other', 'Other');
-      case 'U':
-        return t('unknown', 'Unknown');
-      default:
-        return gender;
-    }
-  };
-
-  const onClickSearchResult = useCallback(
-    (evt, patient: SearchedPatient) => {
-      evt.preventDefault();
-      if (selectPatientAction) {
-        selectPatientAction(patient);
-      } else {
-        navigate({
-          to: `${interpolateString(config.search.patientResultUrl, {
-            patientUuid: patient.uuid,
-          })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`,
-        });
+    const getGender = (gender) => {
+      switch (gender) {
+        case 'M':
+          return t('male', 'Male');
+        case 'F':
+          return t('female', 'Female');
+        case 'O':
+          return t('other', 'Other');
+        case 'U':
+          return t('unknown', 'Unknown');
+        default:
+          return gender;
       }
-      if (hidePanel) {
-        hidePanel();
-      }
-    },
-    [config.search, hidePanel, selectPatientAction],
-  );
+    };
 
-  const fhirPatients = useMemo(() => {
-    // TODO: If/When the online patient search is migrated to the FHIR API at some point, this could
-    // be removed. In fact, it could maybe be done at this point already, but doing it when the
-    // search returns FHIR objects is much simpler because the code which uses the `fhirPatients`
-    // doesn't have to be touched then.
-    return patients.map((patient) => {
-      const preferredAddress = patient.person.addresses?.find((address) => address.preferred);
-      return {
-        id: patient.uuid,
-        name: [
-          {
-            given: [patient.person.personName.givenName, patient.person.personName.middleName],
-            family: patient.person.personName.familyName,
-          },
-        ],
-        gender: patient.person.gender,
-        birthDate: patient.person.birthdate,
-        deceasedDateTime: patient.person.deathDate,
-        deceasedBoolean: patient.person.death,
-        identifier: patient.identifiers,
-        address: preferredAddress
-          ? [
-              {
-                city: preferredAddress.cityVillage,
-                country: preferredAddress.country,
-                postalCode: preferredAddress.postalCode,
-                state: preferredAddress.stateProvince,
-                use: 'home',
-              },
-            ]
-          : [],
-        telecom: patient.attributes?.filter((attribute) => attribute.attributeType.display == 'Telephone Number'),
-      };
-    });
-  }, [patients]);
+    const fhirPatients = useMemo(() => {
+      // TODO: If/When the online patient search is migrated to the FHIR API at some point, this could
+      // be removed. In fact, it could maybe be done at this point already, but doing it when the
+      // search returns FHIR objects is much simpler because the code which uses the `fhirPatients`
+      // doesn't have to be touched then.
+      return patients.map((patient) => {
+        const preferredAddress = patient.person.addresses?.find((address) => address.preferred);
+        return {
+          id: patient.uuid,
+          name: [
+            {
+              given: [patient.person.personName.givenName, patient.person.personName.middleName],
+              family: patient.person.personName.familyName,
+            },
+          ],
+          gender: patient.person.gender,
+          birthDate: patient.person.birthdate,
+          deceasedDateTime: patient.person.deathDate,
+          deceasedBoolean: patient.person.death,
+          identifier: patient.identifiers,
+          address: preferredAddress
+            ? [
+                {
+                  city: preferredAddress.cityVillage,
+                  country: preferredAddress.country,
+                  postalCode: preferredAddress.postalCode,
+                  state: preferredAddress.stateProvince,
+                  use: 'home',
+                },
+              ]
+            : [],
+          telecom: patient.attributes?.filter((attribute) => attribute.attributeType.display == 'Telephone Number'),
+        };
+      });
+    }, [patients]);
 
-  return (
-    <>
-      {fhirPatients.map((patient, indx) => (
-        <ConfigurableLink
-          onClick={(evt) => onClickSearchResult(evt, patients[indx])}
-          to={`${interpolateString(config.search.patientResultUrl, {
-            patientUuid: patient.id,
-          })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`}
-          key={patient.id}
-          className={styles.patientSearchResult}>
-          <div className={styles.patientAvatar} role="img">
-            <ExtensionSlot
-              extensionSlotName="patient-photo-slot"
-              state={{
-                patientUuid: patient.id,
-                patientName: `${patient.name?.[0]?.given?.join(' ')} ${patient.name?.[0]?.family}`,
-                size: 'small',
-              }}
-            />
-          </div>
-          <div>
-            <h2 className={styles.patientName}>{`${patient.name?.[0]?.given?.join(' ')} ${
-              patient.name?.[0]?.family
-            }`}</h2>
-            <p className={styles.demographics}>
-              {getGender(patient.gender)} <span className={styles.middot}>&middot;</span> {age(patient.birthDate)}{' '}
-              <span className={styles.middot}>&middot;</span> {patient.identifier?.[0]?.identifier}
-            </p>
-          </div>
-        </ConfigurableLink>
-      ))}
-    </>
-  );
-};
+    return (
+      <div ref={ref}>
+        {fhirPatients.map((patient, indx) => (
+          <ConfigurableLink
+            onClick={(evt) => selectPatientAction(evt, indx)}
+            to={`${interpolateString(config.search.patientResultUrl, {
+              patientUuid: patient.id,
+            })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`}
+            key={patient.id}
+            className={styles.patientSearchResult}>
+            <div className={styles.patientAvatar} role="img">
+              <ExtensionSlot
+                extensionSlotName="patient-photo-slot"
+                state={{
+                  patientUuid: patient.id,
+                  patientName: `${patient.name?.[0]?.given?.join(' ')} ${patient.name?.[0]?.family}`,
+                  size: 'small',
+                }}
+              />
+            </div>
+            <div>
+              <h2 className={styles.patientName}>{`${patient.name?.[0]?.given?.join(' ')} ${
+                patient.name?.[0]?.family
+              }`}</h2>
+              <p className={styles.demographics}>
+                {getGender(patient.gender)} <span className={styles.middot}>&middot;</span> {age(patient.birthDate)}{' '}
+                <span className={styles.middot}>&middot;</span> {patient.identifier?.[0]?.identifier}
+              </p>
+            </div>
+          </ConfigurableLink>
+        ))}
+      </div>
+    );
+  },
+);
 
 export const SearchResultSkeleton = () => {
   return (

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
@@ -12,6 +12,8 @@
   &:hover,
   &:focus {
     background-color: $ui-01;
+    border: 0;
+    outline: 0;
   }
 }
 

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -1,10 +1,12 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import { navigate } from '@openmrs/esm-framework';
+import React, { useCallback, useMemo, useRef, useState, useEffect } from 'react';
+import { navigate, interpolateString, useConfig } from '@openmrs/esm-framework';
 import PatientSearch from './patient-search.component';
 import PatientSearchBar from '../patient-search-bar/patient-search-bar.component';
 import styles from './compact-patient-search.scss';
 import { SearchedPatient } from '../types';
 import debounce from 'lodash-es/debounce';
+import useArrowNavigation from '../hooks/useArrowNavigation';
+import { usePatientSearchInfinite } from '../patient-search.resource';
 
 interface CompactPatientSearchProps {
   isSearchPage: boolean;
@@ -23,6 +25,48 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
 }) => {
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const showSearchResults = useMemo(() => !!searchTerm.trim(), [searchTerm]);
+  const bannerContainerRef = useRef(null);
+  const inputRef = useRef(null);
+  const config = useConfig();
+  const patientSearchResponse = usePatientSearchInfinite(searchTerm, config.includeDead, showSearchResults);
+  const { data: patients } = patientSearchResponse;
+
+  const handleCloseSearchResults = useCallback(() => {
+    setSearchTerm('');
+    onPatientSelect?.();
+  }, [onPatientSelect, setSearchTerm]);
+
+  const handlePatientSelection = useCallback(
+    (evt, index: number) => {
+      evt.preventDefault();
+      if (selectPatientAction) {
+        selectPatientAction(patients[index]);
+      } else {
+        navigate({
+          to: `${interpolateString(config.search.patientResultUrl, {
+            patientUuid: patients[index].uuid,
+          })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`,
+        });
+      }
+      handleCloseSearchResults();
+    },
+    [config.search, selectPatientAction, patients, handleCloseSearchResults],
+  );
+  const focussedResult = useArrowNavigation(patients?.length ?? 0, handlePatientSelection, -1);
+
+  useEffect(() => {
+    if (bannerContainerRef.current && focussedResult > -1) {
+      bannerContainerRef.current.children?.[focussedResult]?.focus();
+      bannerContainerRef.current.children?.[focussedResult]?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end',
+        inline: 'nearest',
+      });
+    } else if (bannerContainerRef.current && inputRef.current && focussedResult === -1) {
+      bannerContainerRef.current.children?.[0]?.blur();
+      inputRef.current?.focus();
+    }
+  }, [focussedResult, bannerContainerRef]);
 
   const onSubmit = useCallback(
     (searchTerm) => {
@@ -42,11 +86,6 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
     setSearchTerm('');
   }, [setSearchTerm]);
 
-  const handleCloseSearchResults = useCallback(() => {
-    setSearchTerm('');
-    onPatientSelect?.();
-  }, [onPatientSelect, setSearchTerm]);
-
   const handleSearchQueryChange = debounce((val) => setSearchTerm(val), 300);
 
   return (
@@ -57,13 +96,15 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
         onChange={handleSearchQueryChange}
         onSubmit={onSubmit}
         onClear={onClear}
+        ref={inputRef}
       />
       {!isSearchPage && showSearchResults && (
         <div className={styles.floatingSearchResultsContainer}>
           <PatientSearch
             query={searchTerm}
-            selectPatientAction={selectPatientAction}
-            hidePanel={handleCloseSearchResults}
+            selectPatientAction={handlePatientSelection}
+            ref={bannerContainerRef}
+            {...patientSearchResponse}
           />
         </div>
       )}

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -26,10 +26,16 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const showSearchResults = useMemo(() => !!searchTerm.trim(), [searchTerm]);
   const bannerContainerRef = useRef(null);
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const config = useConfig();
   const patientSearchResponse = usePatientSearchInfinite(searchTerm, config.includeDead, showSearchResults);
   const { data: patients } = patientSearchResponse;
+
+  const handleFocusToInput = useCallback(() => {
+    var len = inputRef.current.value?.length ?? 0;
+    inputRef.current.setSelectionRange(len, len);
+    inputRef.current.focus();
+  }, [inputRef]);
 
   const handleCloseSearchResults = useCallback(() => {
     setSearchTerm('');
@@ -52,7 +58,13 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
     },
     [config.search, selectPatientAction, patients, handleCloseSearchResults],
   );
-  const focussedResult = useArrowNavigation(patients?.length ?? 0, handlePatientSelection, -1);
+  const focussedResult = useArrowNavigation(
+    inputRef,
+    patients?.length ?? 0,
+    handlePatientSelection,
+    handleFocusToInput,
+    -1,
+  );
 
   useEffect(() => {
     if (bannerContainerRef.current && focussedResult > -1) {
@@ -63,10 +75,9 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
         inline: 'nearest',
       });
     } else if (bannerContainerRef.current && inputRef.current && focussedResult === -1) {
-      bannerContainerRef.current.children?.[0]?.blur();
-      inputRef.current?.focus();
+      handleFocusToInput();
     }
-  }, [focussedResult, bannerContainerRef]);
+  }, [focussedResult, bannerContainerRef, handleFocusToInput]);
 
   const onSubmit = useCallback(
     (searchTerm) => {

--- a/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
@@ -2,130 +2,119 @@ import React, { useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Layer, Loading, Tile } from '@carbon/react';
 import isEmpty from 'lodash-es/isEmpty';
-import { useConfig } from '@openmrs/esm-framework';
-import { usePatientSearchInfinite } from '../patient-search.resource';
 import PatientSearchResults, { SearchResultSkeleton } from './compact-patient-banner.component';
 import EmptyDataIllustration from '../ui-components/empty-data-illustration.component';
 import styles from './patient-search.scss';
-import { SearchedPatient } from '../types';
+import { PatientSearchResponse } from '../types';
 
-interface PatientSearchProps {
-  hidePanel?: () => void;
+interface PatientSearchProps extends PatientSearchResponse {
   query: string;
-  selectPatientAction?: (patient: SearchedPatient) => void;
+  selectPatientAction?: (evt: any, index: number) => void;
 }
 
-const PatientSearch: React.FC<PatientSearchProps> = ({ hidePanel, query = '', selectPatientAction }) => {
-  const { t } = useTranslation();
-  const config = useConfig();
-  const {
-    isLoading,
-    data: searchResults,
-    fetchError,
-    loadingNewData,
-    setPage,
-    hasMore,
-    totalResults,
-  } = usePatientSearchInfinite(query, config.includeDead, !!query);
+const PatientSearch = React.forwardRef<HTMLDivElement, PatientSearchProps>(
+  (
+    { selectPatientAction, isLoading, data: searchResults, fetchError, loadingNewData, setPage, hasMore, totalResults },
+    ref,
+  ) => {
+    const { t } = useTranslation();
+    const observer = useRef(null);
+    const loadingIconRef = useCallback(
+      (node) => {
+        if (loadingNewData) {
+          return;
+        }
+        if (observer.current) {
+          observer.current.disconnect();
+        }
+        observer.current = new IntersectionObserver(
+          (entries) => {
+            if (entries[0].isIntersecting && hasMore) {
+              setPage((page) => page + 1);
+            }
+          },
+          {
+            threshold: 0.75,
+          },
+        );
+        if (node) {
+          observer.current.observe(node);
+        }
+      },
+      [loadingNewData, hasMore, setPage],
+    );
 
-  const observer = useRef(null);
-  const loadingIconRef = useCallback(
-    (node) => {
-      if (loadingNewData) {
-        return;
-      }
-      if (observer.current) {
-        observer.current.disconnect();
-      }
-      observer.current = new IntersectionObserver(
-        (entries) => {
-          if (entries[0].isIntersecting && hasMore) {
-            setPage((page) => page + 1);
-          }
-        },
-        {
-          threshold: 0.75,
-        },
+    if (isLoading) {
+      return (
+        <div className={styles.searchResultsContainer}>
+          <SearchResultSkeleton />
+          <SearchResultSkeleton />
+          <SearchResultSkeleton />
+          <SearchResultSkeleton />
+          <SearchResultSkeleton />
+        </div>
       );
-      if (node) {
-        observer.current.observe(node);
-      }
-    },
-    [loadingNewData, hasMore, setPage],
-  );
+    }
 
-  if (isLoading) {
     return (
       <div className={styles.searchResultsContainer}>
-        <SearchResultSkeleton />
-        <SearchResultSkeleton />
-        <SearchResultSkeleton />
-        <SearchResultSkeleton />
-        <SearchResultSkeleton />
-      </div>
-    );
-  }
-
-  return (
-    <div className={styles.searchResultsContainer}>
-      {!fetchError ? (
-        !isEmpty(searchResults) ? (
-          <div
-            className={styles.searchResults}
-            style={{
-              maxHeight: '22rem',
-            }}>
-            <p className={styles.resultsText}>
-              {totalResults} {t('searchResultsText', 'search result(s)')}
-            </p>
-            <PatientSearchResults
-              hidePanel={hidePanel}
-              patients={searchResults}
-              selectPatientAction={selectPatientAction}
-            />
-            {hasMore && (
-              <div className={styles.loadingIcon} ref={loadingIconRef}>
-                <Loading withOverlay={false} small />
-              </div>
-            )}
-          </div>
+        {!fetchError ? (
+          !isEmpty(searchResults) ? (
+            <div
+              className={styles.searchResults}
+              style={{
+                maxHeight: '22rem',
+              }}>
+              <p className={styles.resultsText}>
+                {totalResults} {t('searchResultsText', 'search result(s)')}
+              </p>
+              <PatientSearchResults patients={searchResults} selectPatientAction={selectPatientAction} ref={ref} />
+              {hasMore && (
+                <div className={styles.loadingIcon} ref={loadingIconRef}>
+                  <Loading withOverlay={false} small />
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className={styles.searchResults}>
+              <Layer>
+                <Tile className={styles.emptySearchResultsTile}>
+                  <EmptyDataIllustration />
+                  <p className={styles.emptyResultText}>
+                    {t('noPatientChartsFoundMessage', 'Sorry, no patient charts have been found')}
+                  </p>
+                  <p className={styles.actionText}>
+                    <span>
+                      {t('trySearchWithPatientUniqueID', "Try searching with the patient's unique ID number")}
+                    </span>
+                    <br />
+                    <span>{t('orPatientName', "OR the patient's name(s)")}</span>
+                  </p>
+                </Tile>
+              </Layer>
+            </div>
+          )
         ) : (
           <div className={styles.searchResults}>
             <Layer>
               <Tile className={styles.emptySearchResultsTile}>
                 <EmptyDataIllustration />
-                <p className={styles.emptyResultText}>
-                  {t('noPatientChartsFoundMessage', 'Sorry, no patient charts have been found')}
-                </p>
-                <p className={styles.actionText}>
-                  <span>{t('trySearchWithPatientUniqueID', "Try searching with the patient's unique ID number")}</span>
-                  <br />
-                  <span>{t('orPatientName', "OR the patient's name(s)")}</span>
-                </p>
+                <div>
+                  <p className={styles.errorMessage}>{t('error', 'Error')}</p>
+                  <p className={styles.errorCopy}>
+                    {t(
+                      'errorCopy',
+                      'Sorry, there was an error. You can try to reload this page, or contact the site administrator and quote the error code above.',
+                    )}
+                  </p>
+                </div>
               </Tile>
             </Layer>
           </div>
-        )
-      ) : (
-        <div className={styles.searchResults}>
-          <Layer>
-            <Tile className={styles.emptySearchResultsTile}>
-              <EmptyDataIllustration />
-              <div>
-                <p className={styles.errorMessage}>{t('error', 'Error')}</p>
-                <p className={styles.errorCopy}>
-                  {t(
-                    'errorCopy',
-                    'Sorry, there was an error. You can try to reload this page, or contact the site administrator and quote the error code above.',
-                  )}
-                </p>
-              </div>
-            </Tile>
-          </Layer>
-        </div>
-      )}
-    </div>
-  );
-};
+        )}
+      </div>
+    );
+  },
+);
 
 export default PatientSearch;

--- a/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
+++ b/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
@@ -1,21 +1,36 @@
 import { useEffect, useState, useCallback } from 'react';
 
-const useArrowNavigation = (totalResults, enterCallback, initalFocussedResult = -1) => {
-  const [focussedResult, setFocussedResult] = useState(-1);
+const useArrowNavigation = (
+  inputRef: React.MutableRefObject<HTMLInputElement>,
+  totalResults: number,
+  enterCallback: (evt: any, index: number) => void,
+  resetFocusCallback: () => void,
+  initalFocussedResult: number = -1,
+) => {
+  const [focussedResult, setFocussedResult] = useState(initalFocussedResult);
 
   const handleKeyPress = useCallback(
     (e) => {
       if (e.key === 'ArrowUp') {
         setFocussedResult((prev) => Math.max(-1, prev - 1));
-      }
-      if (e.key === 'ArrowDown') {
+      } else if (e.key === 'ArrowDown') {
         setFocussedResult((prev) => Math.min(totalResults - 1, prev + 1));
-      }
-      if (e.key === 'Enter' && focussedResult > -1) {
+      } else if (e.key === 'Enter' && focussedResult > -1) {
         enterCallback(e, focussedResult);
+      } else if (document.activeElement !== inputRef.current) {
+        resetFocusCallback();
+        setFocussedResult(initalFocussedResult);
       }
     },
-    [setFocussedResult, totalResults, focussedResult, enterCallback],
+    [
+      setFocussedResult,
+      totalResults,
+      focussedResult,
+      enterCallback,
+      initalFocussedResult,
+      inputRef,
+      resetFocusCallback,
+    ],
   );
 
   useEffect(() => {
@@ -23,7 +38,7 @@ const useArrowNavigation = (totalResults, enterCallback, initalFocussedResult = 
     return () => {
       window.removeEventListener('keydown', handleKeyPress);
     };
-  });
+  }, [handleKeyPress]);
 
   return focussedResult;
 };

--- a/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
+++ b/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState, useCallback } from 'react';
+
+const useArrowNavigation = (totalResults, enterCallback, initalFocussedResult = -1) => {
+  const [focussedResult, setFocussedResult] = useState(-1);
+
+  const handleKeyPress = useCallback(
+    (e) => {
+      if (e.key === 'ArrowUp') {
+        setFocussedResult((prev) => Math.max(-1, prev - 1));
+      }
+      if (e.key === 'ArrowDown') {
+        setFocussedResult((prev) => Math.min(totalResults - 1, prev + 1));
+      }
+      if (e.key === 'Enter' && focussedResult > -1) {
+        enterCallback(e, focussedResult);
+      }
+    },
+    [setFocussedResult, totalResults, focussedResult, enterCallback],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyPress);
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress);
+    };
+  });
+
+  return focussedResult;
+};
+
+export default useArrowNavigation;

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { RefAttributes, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Search } from '@carbon/react';
 import styles from './patient-search-bar.scss';
@@ -12,53 +12,49 @@ interface PatientSearchBarProps {
   small?: boolean;
 }
 
-const PatientSearchBar: React.FC<PatientSearchBarProps> = ({
-  buttonProps,
-  initialSearchTerm,
-  onChange,
-  onClear,
-  onSubmit,
-  small,
-}) => {
-  const { t } = useTranslation();
-  const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
+const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChildren<PatientSearchBarProps>>(
+  ({ buttonProps, initialSearchTerm, onChange, onClear, onSubmit, small }, ref) => {
+    const { t } = useTranslation();
+    const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
 
-  const handleChange = useCallback(
-    (val) => {
-      if (onChange) {
-        onChange(val);
-      }
-      setSearchTerm(val);
-    },
-    [onChange, setSearchTerm],
-  );
+    const handleChange = useCallback(
+      (val) => {
+        if (onChange) {
+          onChange(val);
+        }
+        setSearchTerm(val);
+      },
+      [onChange, setSearchTerm],
+    );
 
-  const handleSubmit = useCallback(
-    (evt) => {
-      evt.preventDefault();
-      onSubmit(searchTerm);
-    },
-    [searchTerm, onSubmit],
-  );
+    const handleSubmit = useCallback(
+      (evt) => {
+        evt.preventDefault();
+        onSubmit(searchTerm);
+      },
+      [searchTerm, onSubmit],
+    );
 
-  return (
-    <form onSubmit={handleSubmit} className={styles.searchArea}>
-      <Search
-        autoFocus
-        className={styles.patientSearchInput}
-        closeButtonLabelText={t('clearSearch', 'Clear')}
-        labelText=""
-        onChange={(event) => handleChange(event.target.value)}
-        onClear={onClear}
-        placeholder={t('searchForPatient', 'Search for a patient by name or identifier number')}
-        size={small ? 'sm' : 'lg'}
-        value={searchTerm}
-      />
-      <Button type="submit" kind="secondary" size={small ? 'sm' : 'lg'} onClick={handleSubmit} {...buttonProps}>
-        {t('search', 'Search')}
-      </Button>
-    </form>
-  );
-};
+    return (
+      <form onSubmit={handleSubmit} className={styles.searchArea}>
+        <Search
+          autoFocus
+          className={styles.patientSearchInput}
+          closeButtonLabelText={t('clearSearch', 'Clear')}
+          labelText=""
+          onChange={(event) => handleChange(event.target.value)}
+          onClear={onClear}
+          placeholder={t('searchForPatient', 'Search for a patient by name or identifier number')}
+          size={small ? 'sm' : 'lg'}
+          value={searchTerm}
+          ref={ref}
+        />
+        <Button type="submit" kind="secondary" size={small ? 'sm' : 'lg'} onClick={handleSubmit} {...buttonProps}>
+          {t('search', 'Search')}
+        </Button>
+      </form>
+    );
+  },
+);
 
 export default PatientSearchBar;

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -19,7 +19,7 @@ const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChild
 
     const handleChange = useCallback(
       (val) => {
-        if (onChange) {
+        if (typeof onChange === 'function') {
           onChange(val);
         }
         setSearchTerm(val);
@@ -27,13 +27,10 @@ const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChild
       [onChange, setSearchTerm],
     );
 
-    const handleSubmit = useCallback(
-      (evt) => {
-        evt.preventDefault();
-        onSubmit(searchTerm);
-      },
-      [searchTerm, onSubmit],
-    );
+    const handleSubmit = (evt) => {
+      evt.preventDefault();
+      onSubmit(searchTerm);
+    };
 
     return (
       <form onSubmit={handleSubmit} className={styles.searchArea}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@ __metadata:
   linkType: hard
 
 "@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.19.4, @babel/compat-data@npm:^7.20.0":
-  version: 7.20.0
-  resolution: "@babel/compat-data@npm:7.20.0"
-  checksum: 325148e2961edcfc17d53ec4b27f85ebdd6be1aa33d1d297acf84fb5879f58c0a18bfb6418f9f108b4c84a98606adb1668250a15fd4fab2cc84c537b454b9a42
+  version: 7.20.1
+  resolution: "@babel/compat-data@npm:7.20.1"
+  checksum: 989b9b7a6fe43c547bb8329241bd0ba6983488b83d29cc59de35536272ee6bb4cc7487ba6c8a4bceebb3a57f8c5fea1434f80bbbe75202bc79bc1110f955ff25
   languageName: node
   linkType: hard
 
@@ -83,14 +83,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.19.6, @babel/generator@npm:^7.20.0, @babel/generator@npm:^7.7.2":
-  version: 7.20.0
-  resolution: "@babel/generator@npm:7.20.0"
+"@babel/generator@npm:^7.19.6, @babel/generator@npm:^7.20.1, @babel/generator@npm:^7.7.2":
+  version: 7.20.1
+  resolution: "@babel/generator@npm:7.20.1"
   dependencies:
     "@babel/types": ^7.20.0
     "@jridgewell/gen-mapping": ^0.3.2
     jsesc: ^2.5.1
-  checksum: df2fef0ac305cf031013e311d4582b15b5c297fd538bec71e6cae3b689189ac4be6055482487b06da1be2f007b8985d5162a84e14e43a20435b8c89551910509
+  checksum: e6846d88c59a5dae4c86f3cc84f84972cf9cc5fa0f4944606303a9df3ba1be388e0cb08a625c86f7282ab03faf54acd72efba34f019b6762f4739a175173783e
   languageName: node
   linkType: hard
 
@@ -345,13 +345,13 @@ __metadata:
   linkType: hard
 
 "@babel/helpers@npm:^7.19.4":
-  version: 7.20.0
-  resolution: "@babel/helpers@npm:7.20.0"
+  version: 7.20.1
+  resolution: "@babel/helpers@npm:7.20.1"
   dependencies:
     "@babel/template": ^7.18.10
-    "@babel/traverse": ^7.20.0
+    "@babel/traverse": ^7.20.1
     "@babel/types": ^7.20.0
-  checksum: a68f271474eabc06d64db3d22f435068c3451ba55828f22b72db0e392dff911a6813de3c7bb783e6e4756fd97f8910904d6d647de92a3dc3bfae14688a1a907a
+  checksum: be35f78666bdab895775ed94dbeb098f7b4fa08ce4cfb0c3a9e69b7220cce56960dcdc2b14f5df9d3b80388d4bf7df155c97f6cf6768c0138f4e6931d0f44955
   languageName: node
   linkType: hard
 
@@ -366,12 +366,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.18.10, @babel/parser@npm:^7.19.6, @babel/parser@npm:^7.20.0":
-  version: 7.20.0
-  resolution: "@babel/parser@npm:7.20.0"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.18.10, @babel/parser@npm:^7.19.6, @babel/parser@npm:^7.20.1":
+  version: 7.20.1
+  resolution: "@babel/parser@npm:7.20.1"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: d54d68e45ff1b9a0c50a3f79d9031f482eb58f18928525949dc20da5b1658ee79167e756129371fd75d3e8fc7e218ab707727145a68958636be9672c7b71768e
+  checksum: 2db7ba692b8b3054df129876b115ed8b265d5c138dee5e1db56a999209df3dd3d508e0985bf3cc44fc432498da094c164906b531d049608e55e208dae0678d42
   languageName: node
   linkType: hard
 
@@ -400,8 +400,8 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-proposal-async-generator-functions@npm:^7.19.1":
-  version: 7.19.1
-  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.19.1"
+  version: 7.20.1
+  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.20.1"
   dependencies:
     "@babel/helper-environment-visitor": ^7.18.9
     "@babel/helper-plugin-utils": ^7.19.0
@@ -409,7 +409,7 @@ __metadata:
     "@babel/plugin-syntax-async-generators": ^7.8.4
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: f101555b00aee6ee0107c9e40d872ad646bbd3094abdbeda56d17b107df69a0cb49e5d02dcf5f9d8753e25564e798d08429f12d811aaa1b307b6a725c0b8159c
+  checksum: 518483a68c5618932109913eb7316ed5e656c575cbd9d22667bc0451e35a1be45f8eaeb8e2065834b36c8a93c4840f78cebf8f1d067b07c422f7be16d58eca60
   languageName: node
   linkType: hard
 
@@ -1041,13 +1041,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-parameters@npm:^7.18.8":
-  version: 7.18.8
-  resolution: "@babel/plugin-transform-parameters@npm:7.18.8"
+  version: 7.20.1
+  resolution: "@babel/plugin-transform-parameters@npm:7.20.1"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.19.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 2b5863300da60face8a250d91da16294333bd5626e9721b13a3ba2078bd2a5a190e32c6e7a1323d5f547f579aeb2804ff49a62a55fcad2b1d099e55a55b788ea
+  checksum: 37dd4eac477f585275f56adee26e7db1f7c867d17ecfc9fb792d560ab12bb7e5bd3b29ab715cb70fb875e4671a76103999bdac55558e4c34ebb1d2a734366fba
   languageName: node
   linkType: hard
 
@@ -1265,21 +1265,21 @@ __metadata:
   linkType: hard
 
 "@babel/runtime-corejs3@npm:^7.10.2":
-  version: 7.20.0
-  resolution: "@babel/runtime-corejs3@npm:7.20.0"
+  version: 7.20.1
+  resolution: "@babel/runtime-corejs3@npm:7.20.1"
   dependencies:
     core-js-pure: ^3.25.1
     regenerator-runtime: ^0.13.10
-  checksum: 6cc7045fe9dcb9e7c7114b6e16521c5d51b592cb2ded9df423f2585a7b7aa5a3f197ba77dea7e3c27982ebc7160393a60e1752122897dbb765af6f0f154f2dfb
+  checksum: bac1463304deb0e395f78aef2bf0e042d0ae303285b9f55e443d8ce4d3d05ccb92ac0aa5ca4bf83526695d21b12a239317537b00918d6ebf7a4132e5ec2f6f33
   languageName: node
   linkType: hard
 
 "@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.5, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.1, @babel/runtime@npm:^7.9.2":
-  version: 7.20.0
-  resolution: "@babel/runtime@npm:7.20.0"
+  version: 7.20.1
+  resolution: "@babel/runtime@npm:7.20.1"
   dependencies:
     regenerator-runtime: ^0.13.10
-  checksum: 637fca51db34f3a59d329b7e0d01163769fe94915fdb04e4ac4ba62de9f1ca637ce3a564fe3b0166ccdd7f02f14b6a5707ee3e550b3e01c72327c6620d8e6a8b
+  checksum: 00567a333d3357925742a6f5e39394dcc0af6e6029103fe188158bf7ae8b0b3ee3c6c0f68fccc217f0a6cfa455f6be252298baf56b3f5ff37b34313b170cd9f6
   languageName: node
   linkType: hard
 
@@ -1294,21 +1294,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.19.0, @babel/traverse@npm:^7.19.1, @babel/traverse@npm:^7.19.6, @babel/traverse@npm:^7.20.0, @babel/traverse@npm:^7.7.2":
-  version: 7.20.0
-  resolution: "@babel/traverse@npm:7.20.0"
+"@babel/traverse@npm:^7.19.0, @babel/traverse@npm:^7.19.1, @babel/traverse@npm:^7.19.6, @babel/traverse@npm:^7.20.1, @babel/traverse@npm:^7.7.2":
+  version: 7.20.1
+  resolution: "@babel/traverse@npm:7.20.1"
   dependencies:
     "@babel/code-frame": ^7.18.6
-    "@babel/generator": ^7.20.0
+    "@babel/generator": ^7.20.1
     "@babel/helper-environment-visitor": ^7.18.9
     "@babel/helper-function-name": ^7.19.0
     "@babel/helper-hoist-variables": ^7.18.6
     "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/parser": ^7.20.0
+    "@babel/parser": ^7.20.1
     "@babel/types": ^7.20.0
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: 19615ec2c3467f929dfa2ae98494961a2c7b333b6628e1c7643188d936abc167c41f5af541b692b1ca776a4d066291a7eb8b22f98aba3d496f362bae4c2082cd
+  checksum: 6696176d574b7ff93466848010bc7e94b250169379ec2a84f1b10da46a7cc2018ea5e3a520c3078487db51e3a4afab9ecff48f25d1dbad8c1319362f4148fb4b
   languageName: node
   linkType: hard
 
@@ -3288,6 +3288,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/fs@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@npmcli/fs@npm:3.0.0"
+  dependencies:
+    semver: ^7.3.5
+  checksum: a95714f2369ede1fffbcaf2e7ef2db36819316d240ff0cca883ddf243544aee3519c36e4eaaa760cd2721d077a415f71f6808c71382c20a03d0cbb6e753ccd4f
+  languageName: node
+  linkType: hard
+
+"@npmcli/git@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "@npmcli/git@npm:4.0.3"
+  dependencies:
+    "@npmcli/promise-spawn": ^6.0.0
+    lru-cache: ^7.4.4
+    mkdirp: ^1.0.4
+    npm-pick-manifest: ^8.0.0
+    proc-log: ^3.0.0
+    promise-inflight: ^1.0.1
+    promise-retry: ^2.0.1
+    semver: ^7.3.5
+    which: ^3.0.0
+  checksum: 2ed12b8fe6acb1fb4e0c351c7db80f144a842fe9dfad3d67ff88b1505956e74337775de0e09d2995da47000c6589590ef8c5277a517e5bb5396d00c572ef4b88
+  languageName: node
+  linkType: hard
+
+"@npmcli/installed-package-contents@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@npmcli/installed-package-contents@npm:2.0.1"
+  dependencies:
+    npm-bundled: ^3.0.0
+    npm-normalize-package-bin: ^3.0.0
+  bin:
+    installed-package-contents: lib/index.js
+  checksum: 75126a3b3a741cd68e78ccea25256e87734379e5e0d827674fc3ec1f39b6ed356ae2c3e2d906c9c0247c192e8ca7e67188ad346f86042baabbac274e9b02d770
+  languageName: node
+  linkType: hard
+
 "@npmcli/move-file@npm:^2.0.0":
   version: 2.0.1
   resolution: "@npmcli/move-file@npm:2.0.1"
@@ -3295,6 +3333,45 @@ __metadata:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
   checksum: 52dc02259d98da517fae4cb3a0a3850227bdae4939dda1980b788a7670636ca2b4a01b58df03dd5f65c1e3cb70c50fa8ce5762b582b3f499ec30ee5ce1fd9380
+  languageName: node
+  linkType: hard
+
+"@npmcli/move-file@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@npmcli/move-file@npm:3.0.0"
+  dependencies:
+    mkdirp: ^1.0.4
+    rimraf: ^3.0.2
+  checksum: 5ccce4b1e9d94234e303bdd93cbb23720ce52f48bfc7ffbe88554eab63af2b26d5bd8b62f3e10b6649b88a5d69e2ea48790f86de737dbbdc49e31ec050a2e64a
+  languageName: node
+  linkType: hard
+
+"@npmcli/node-gyp@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@npmcli/node-gyp@npm:3.0.0"
+  checksum: fe3802b813eecb4ade7ad77c9396cb56721664275faab027e3bd8a5e15adfbbe39e2ecc19f7885feb3cfa009b96632741cc81caf7850ba74440c6a2eee7b4ffc
+  languageName: node
+  linkType: hard
+
+"@npmcli/promise-spawn@npm:^6.0.0, @npmcli/promise-spawn@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@npmcli/promise-spawn@npm:6.0.1"
+  dependencies:
+    which: ^3.0.0
+  checksum: c4bfdf2e85a0556ba4c0b1013118593f36ed1000906569ea5962a7808807ca78362208404d951cc8d3b4163818e50c349c6d7065785378fb09234e0b3b3406e3
+  languageName: node
+  linkType: hard
+
+"@npmcli/run-script@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@npmcli/run-script@npm:6.0.0"
+  dependencies:
+    "@npmcli/node-gyp": ^3.0.0
+    "@npmcli/promise-spawn": ^6.0.0
+    node-gyp: ^9.0.0
+    read-package-json-fast: ^3.0.0
+    which: ^3.0.0
+  checksum: 9fc387f7c405ae4948921764b8b970c12ae07df22bacc242b0f68709c99a83b9d12f411ebd7e60c85a933e2d7be42c70e243ebd71a8d3f6e783e1aab5ccbb2f5
   languageName: node
   linkType: hard
 
@@ -3454,25 +3531,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-api@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-api@npm:4.0.3-pre.379"
+"@openmrs/esm-api@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-api@npm:4.0.3-pre.392"
   dependencies:
     "@types/fhir": 0.0.31
     lodash-es: ^4.17.21
   peerDependencies:
     "@openmrs/esm-config": 4.x
     "@openmrs/esm-error-handling": 4.x
-  checksum: 924277ef427d0a19a2b749eee7557e8f9c46a2bfbf9073c075f3415a52087c95baa540915a41bf543dd6923e3053dba8523c4aa9a295b88de18637e00dc7411e
+  checksum: 958ced8c0959fadf6a1cffd56a1a281c4a7d442befadf95e4eeb11da66d758addfcd1422cf02beca44514b9cf47a9960de854576bcf23e8af02b51b424892023
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-app-shell@npm:4.0.3-pre.379"
+"@openmrs/esm-app-shell@npm:4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-app-shell@npm:4.0.3-pre.392"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-framework": 4.0.3-pre.379
+    "@openmrs/esm-framework": 4.0.3-pre.392
     dayjs: ^1.10.4
     dexie: ^3.0.3
     i18next: ^19.6.0
@@ -3491,7 +3568,7 @@ __metadata:
     workbox-routing: ^6.1.5
     workbox-strategies: ^6.1.5
     workbox-window: ^6.1.5
-  checksum: 75473da1d85d6bff14287b5ef486b61c848f4a48e4a2f331a957616c767790324270d595c6a62a707af5d44aca33cb0e48a775af9e2fc116861fa38eee4e1bbb
+  checksum: 501faf3c017b2d6a7c90cb45a843f631e7118d87777cb335a8a498077323fe62c7af7221f03c8dc8acd314b664c16d786ac420799d0cd4fda6e7910dfd885dd9
   languageName: node
   linkType: hard
 
@@ -3512,20 +3589,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-breadcrumbs@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-breadcrumbs@npm:4.0.3-pre.379"
+"@openmrs/esm-breadcrumbs@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-breadcrumbs@npm:4.0.3-pre.392"
   dependencies:
     path-to-regexp: 6.1.0
   peerDependencies:
     "@openmrs/esm-state": 4.x
-  checksum: 14495995433c88da05d8790f541eeaed70fe2f4172344fabb7921cfbaaf0ed2f7c39c8c59f7bd8c9ba21591322f440b605d77a2f384c09258c8e82c9703459e5
+  checksum: c9346eb3b13aa7262d25e9b9c24797699bf9ef605dbc2f6cb32313b673e7c505c16c5d072f7ef49b9893bc3d11f28934734bee7a6ae20761be8a22ec094aa74f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-config@npm:4.0.3-pre.379"
+"@openmrs/esm-config@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-config@npm:4.0.3-pre.392"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
@@ -3533,22 +3610,22 @@ __metadata:
     "@openmrs/esm-state": 4.x
     single-spa: 5.x
     systemjs: 6.x
-  checksum: 636c97e23ca9208d6b3ffa575c4503ef1d947dc30e054d7a52b82110daacf49999dec3950b32f250d864f1d9c1fd2438d7826872777bcaecf2c69c78eb042e4f
+  checksum: 295516e70c0a326604b1870a0f28fcb3e0e2c62f0980945ee2d40cb7784cc45603cb15e7d75468a51a61cbeb1b7aa33738c5f5d080022948f15fc3e2e8c76516
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-error-handling@npm:4.0.3-pre.379"
+"@openmrs/esm-error-handling@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-error-handling@npm:4.0.3-pre.392"
   peerDependencies:
     "@openmrs/esm-globals": 4.x
-  checksum: 099f876b0daf4723d79a067f312b5b338b5faaa659534cfe9381bd33789a3063599cab7a071b21cbd23a0c2263acb4b758171cc929c5cba381e3991bd851b6a8
+  checksum: ecf9b1d38af987b4451f06b9e3e491cd601e5566d647a74bbf79f2cecbe0612262cf3518eee3afce57d4eaed9368aeb41e2dbc0412de4badde26ae9e8b7e3c54
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-extensions@npm:4.0.3-pre.379"
+"@openmrs/esm-extensions@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-extensions@npm:4.0.3-pre.392"
   dependencies:
     lodash-es: ^4.17.21
   peerDependencies:
@@ -3556,42 +3633,42 @@ __metadata:
     "@openmrs/esm-config": 4.x
     "@openmrs/esm-state": 4.x
     single-spa: 5.x
-  checksum: 8c0e4f999ed1d05932d2c35c5ed9993b18997682434fd9370267b469b52a0b1e245b2eeaff3df075d1d006cf9107bafbd2213134a03bb2197c20ce66137568a5
+  checksum: fa2cf406f584a63792772399df756bd21eaec889f157a590eec0cb5a7f7343f5875ee3a5574bb895e11dd8c1e1b4a6ae563718bd230830ca60de21961b669696
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:4.0.3-pre.379, @openmrs/esm-framework@npm:next":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-framework@npm:4.0.3-pre.379"
+"@openmrs/esm-framework@npm:4.0.3-pre.392, @openmrs/esm-framework@npm:next":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-framework@npm:4.0.3-pre.392"
   dependencies:
-    "@openmrs/esm-api": ^4.0.3-pre.379
-    "@openmrs/esm-breadcrumbs": ^4.0.3-pre.379
-    "@openmrs/esm-config": ^4.0.3-pre.379
-    "@openmrs/esm-error-handling": ^4.0.3-pre.379
-    "@openmrs/esm-extensions": ^4.0.3-pre.379
-    "@openmrs/esm-globals": ^4.0.3-pre.379
-    "@openmrs/esm-offline": ^4.0.3-pre.379
-    "@openmrs/esm-react-utils": ^4.0.3-pre.379
-    "@openmrs/esm-state": ^4.0.3-pre.379
-    "@openmrs/esm-styleguide": ^4.0.3-pre.379
-    "@openmrs/esm-utils": ^4.0.3-pre.379
+    "@openmrs/esm-api": ^4.0.3-pre.392
+    "@openmrs/esm-breadcrumbs": ^4.0.3-pre.392
+    "@openmrs/esm-config": ^4.0.3-pre.392
+    "@openmrs/esm-error-handling": ^4.0.3-pre.392
+    "@openmrs/esm-extensions": ^4.0.3-pre.392
+    "@openmrs/esm-globals": ^4.0.3-pre.392
+    "@openmrs/esm-offline": ^4.0.3-pre.392
+    "@openmrs/esm-react-utils": ^4.0.3-pre.392
+    "@openmrs/esm-state": ^4.0.3-pre.392
+    "@openmrs/esm-styleguide": ^4.0.3-pre.392
+    "@openmrs/esm-utils": ^4.0.3-pre.392
     dayjs: ^1.10.7
-  checksum: 27d343c1a1951b640f591d2a1d566087c8dc66d417a529d0cbe2523d2591dab18559248d0c8059a59199238ba1f8968d329b2db72d6374fc1c57a048cb357c4f
+  checksum: a75d4b637564a23f2224f1e01b1b6f3352aad4eb13b23263747c6babba594931de21785ab6aac3bd27e22eb58cfcaf0fdc7cbd249160b3c9f96d1e0e416932db
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-globals@npm:4.0.3-pre.379"
+"@openmrs/esm-globals@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-globals@npm:4.0.3-pre.392"
   peerDependencies:
     single-spa: 5.x
-  checksum: ca1c4e022398affa05b1cf48936d7969968a2ba1f8dde37876d2f2862189805cb52624c8b14f8f0cf8ff90b2d024d404a70a2ffae1bcf81cd51ccae440c056c8
+  checksum: 4fcaa6e3f171ae65ca9f8d45779170d557d2476afa5469b82ce5b0aabab9057151a5605a1ce086dc10db062e7f93afc476d7cd54b668a314f6581f3b29c35881
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-offline@npm:4.0.3-pre.379"
+"@openmrs/esm-offline@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-offline@npm:4.0.3-pre.392"
   dependencies:
     dexie: ^3.0.3
     lodash-es: 4.17.21
@@ -3603,7 +3680,7 @@ __metadata:
     "@openmrs/esm-state": 4.x
     "@openmrs/esm-styleguide": 4.x
     rxjs: 6.x
-  checksum: 5a5d84efbe4f1267a5c1e7da7e1fc61ccb11aab54c8656a8da1e2c33081d75968c26a3e7cce71e31d3947db1246eb980248072ed660fdf00db647e69efd8f23d
+  checksum: 6f672ed7b6fcbb3c5f821988a0c12c3ae1c8e5bb22a9ddc11fb67a988c64dc3bdc28981508b7b3ecbda35caa31f86a98c3bc0b3982c6302fe23179bc6a7d0dd3
   languageName: node
   linkType: hard
 
@@ -3731,9 +3808,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-react-utils@npm:4.0.3-pre.379"
+"@openmrs/esm-react-utils@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-react-utils@npm:4.0.3-pre.392"
   dependencies:
     lodash-es: ^4.17.21
     single-spa-react: ^5.0.0
@@ -3749,22 +3826,22 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     react-i18next: 11.x
-  checksum: efe4c5c92711dabc08a85b9a46af7ec8bc5203d545d7341855afd7c8a7175de919341229c56b33ceb8df881f84b2284f606aa485edbd840488020693627489b1
+  checksum: 71b61fdb53c921ebbc543bd65a5590cde60679df8738106ac0b68df884e34d1e188b8921aecab28cda1dd89afd57111f9894d67d8821351422a6554bd21551b1
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-state@npm:4.0.3-pre.379"
+"@openmrs/esm-state@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-state@npm:4.0.3-pre.392"
   dependencies:
     unistore: ^3.5.2
-  checksum: 80fdc04a8675c49120b4abd02e6d978adbbda0a307eb02a323655fd6f1e22a197406db65a82e921f894fdccc2d8e6f2871f20c6f4ae6a87527293566542dc61e
+  checksum: 6e990a7b2050d8c67f68d903681cc21f83fd2a4637a13d4eee39dda084505531d05640faf7a89583c286cb534fb089837ad3c0a3cbfa5d6b8fa883c16ba64b87
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-styleguide@npm:4.0.3-pre.379"
+"@openmrs/esm-styleguide@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-styleguide@npm:4.0.3-pre.392"
   dependencies:
     "@carbon/charts": ^1.5.0
     "@carbon/react": ^1.12.0
@@ -3777,26 +3854,26 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 2276bc33491add5d1e12136c97bccafc357142168eeb9d1e9d537c785dbc0a0fe5c9e1f30dca8bac8b4bc8d1e4e0d3802a436732fec912180586d36b2183b44a
+  checksum: 69a1f32e62b0423fe4903677b3ab6b463b05674acd7de1ee223d5ca77406cb9a46f0ef235c1e0dc3670fc8effa13dc2e1eb9500a26d3060381f551dd58c3e7c5
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:^4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/esm-utils@npm:4.0.3-pre.379"
+"@openmrs/esm-utils@npm:^4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/esm-utils@npm:4.0.3-pre.392"
   dependencies:
     semver: 7.3.2
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: 4ab82d143a053253aa52645e035f95bf3c85819fb49b3154772743131e676dbc89a28b1bd5e4eeaaa1216e038ba475c754e4adce9025fe385ac6bf370cac9b32
+  checksum: 5b03cc9e34f80a179b381b0e438956b6e996464bc6d9e19d57c3e9a63953d62f7e5115032ba0a21487a7a985c37b4c9cb6aba3dd0263330f3d94d4bc20b2b48c
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:4.0.3-pre.379":
-  version: 4.0.3-pre.379
-  resolution: "@openmrs/webpack-config@npm:4.0.3-pre.379"
+"@openmrs/webpack-config@npm:4.0.3-pre.392":
+  version: 4.0.3-pre.392
+  resolution: "@openmrs/webpack-config@npm:4.0.3-pre.392"
   dependencies:
     "@babel/core": ^7.17.9
     "@babel/types": ^7.17.0
@@ -3816,7 +3893,7 @@ __metadata:
     webpack-stats-plugin: ^1.0.3
   peerDependencies:
     webpack: 5.x
-  checksum: 04bd979cce9f732ff198333f6c265053cfaefa17eabde016c7c67d908e9a88a58dc22d208cc7e724a6223324371be20b9b14035cd528e146d29e94bcb4ff9258
+  checksum: 88e7092f64e8158c2498f6406bd974167b7ec716721394327c60a5a830da602b6f065a5398ac1e2bc25897cb9117840148369ecf637efbf25236338a6d65369f
   languageName: node
   linkType: hard
 
@@ -3827,10 +3904,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@remix-run/router@npm:1.0.2"
-  checksum: bf410f9cbb31308fc306bc8c5e3a732b9ad81ddb84281e37804bdd196b6db7ddd86abc29e15c5b21883e01b37f250d0b8db7bee5f5a9af6c7c532b68280676c9
+"@remix-run/router@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@remix-run/router@npm:1.0.3"
+  checksum: 7e535f3c24bf6b0a48aff3de70ee74e5402fe93105aa9bd01f275d5d8f5a9a8a7cadec08d18cf5544d4f24bc9d7a091abc1c9d4ea8efb2893e9077f104a51459
   languageName: node
   linkType: hard
 
@@ -4275,12 +4352,12 @@ __metadata:
   linkType: hard
 
 "@types/eslint@npm:*":
-  version: 8.4.8
-  resolution: "@types/eslint@npm:8.4.8"
+  version: 8.4.9
+  resolution: "@types/eslint@npm:8.4.9"
   dependencies:
     "@types/estree": "*"
     "@types/json-schema": "*"
-  checksum: 5b4708a56adeb5c209bc5d33590499be01286a90d3c324e2aabb1812d405a622ea9dd65eb8a095b2b9eb902bc8a25afddb9832f1f634457f973c07eade86aa5e
+  checksum: 9eda34e000f1e09850f447d8d65b671f59153aa5b580aca5b95185cf42b047b9cfda86eea83a6295aa883931b769a79236ce439601be7ab4485be88ce77b69ad
   languageName: node
   linkType: hard
 
@@ -4403,12 +4480,12 @@ __metadata:
   linkType: hard
 
 "@types/jest@npm:*":
-  version: 29.2.0
-  resolution: "@types/jest@npm:29.2.0"
+  version: 29.2.1
+  resolution: "@types/jest@npm:29.2.1"
   dependencies:
     expect: ^29.0.0
     pretty-format: ^29.0.0
-  checksum: 6779e63d8d7507b116a61b2935a200e48531849fc1ac74090212759fe17716777ca6d2c3a8d927a563e9cfa474ae91d40b1688376ae80e3a08974b3c9e9691e1
+  checksum: 5610c9a44c57f6dc39cf54429ea8d04574ad4c3e3ddf9a2621882aa94a0758a42ca97a0d0aec41a8d0b149fa63bf3d077d1f07c1f1d82e3d89ad7408de211255
   languageName: node
   linkType: hard
 
@@ -4450,9 +4527,9 @@ __metadata:
   linkType: hard
 
 "@types/lodash@npm:*, @types/lodash@npm:^4.14.175":
-  version: 4.14.186
-  resolution: "@types/lodash@npm:4.14.186"
-  checksum: ee0c1368a8100bb6efb88335107473a41928fc307ff1ef4ff1278868ccddba9c04c68c36d1ffe3a0392ef4a956e1955f7de3203ec09df4f1655dd1b88485c549
+  version: 4.14.187
+  resolution: "@types/lodash@npm:4.14.187"
+  checksum: 5f8a4fe6d8a6785b8ecbd9efdc8b7d3341b873f63c5390ad0f269a517508e92c1b1d7d43e97bdfb6bba5bba9a8501b30a54f791ef4c30b854382745c75c607d4
   languageName: node
   linkType: hard
 
@@ -4485,9 +4562,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>= 8":
-  version: 18.11.7
-  resolution: "@types/node@npm:18.11.7"
-  checksum: 69d630825cf6fbf580d08d76a4d4836ef8c34ed4fe0842221ade87d275f517099cbfabe8e22397208e564bd24926db97699ab9db5c091383269a432b336665e2
+  version: 18.11.9
+  resolution: "@types/node@npm:18.11.9"
+  checksum: cc0aae109e9b7adefc32eecb838d6fad931663bb06484b5e9cbbbf74865c721b03d16fd8d74ad90e31dbe093d956a7c2c306ba5429ba0c00f3f7505103d7a496
   languageName: node
   linkType: hard
 
@@ -5430,11 +5507,11 @@ __metadata:
   linkType: hard
 
 "aria-query@npm:^5.0.0":
-  version: 5.1.2
-  resolution: "aria-query@npm:5.1.2"
+  version: 5.1.3
+  resolution: "aria-query@npm:5.1.3"
   dependencies:
     deep-equal: ^2.0.5
-  checksum: c160c66ad4f1d38f9921dacb181ca8f769191befa6510c99b80a82951d122df54f6d55d6bfe38ecd8e76afa9aca3e3e28a39cfb4474da7b23101bd9347b6391f
+  checksum: 929ff95f02857b650fb4cbcd2f41072eee2f46159a6605ea03bf63aa572e35ffdff43d69e815ddc462e16e07de8faba3978afc2813650b4448ee18c9895d982b
   languageName: node
   linkType: hard
 
@@ -5699,9 +5776,9 @@ __metadata:
   linkType: hard
 
 "axe-core@npm:^4.4.3":
-  version: 4.5.0
-  resolution: "axe-core@npm:4.5.0"
-  checksum: 05b5fa52a8ed8498215cec4a43253d115cc2b43616e840768e05b1b00d6789e7480e5b29159920a45a9504489423836b2fe65a49a67b54cbc5d53b1b37245750
+  version: 4.5.1
+  resolution: "axe-core@npm:4.5.1"
+  checksum: db90c6b41483e9c3452393933072fe0b8c2221e6d9b96ae0e6a03a4ce1e4c35bec539c92e9b6fcd63c4acf6678ad3c3ca7f5ab1d884210d157867cc54acd4f6a
   languageName: node
   linkType: hard
 
@@ -6318,7 +6395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.0.0, browserslist@npm:^4.14.5, browserslist@npm:^4.16.6, browserslist@npm:^4.20.3, browserslist@npm:^4.21.3, browserslist@npm:^4.21.4":
+"browserslist@npm:^4.0.0, browserslist@npm:^4.14.5, browserslist@npm:^4.16.6, browserslist@npm:^4.21.3, browserslist@npm:^4.21.4":
   version: 4.21.4
   resolution: "browserslist@npm:4.21.4"
   dependencies:
@@ -6390,6 +6467,15 @@ __metadata:
   version: 1.0.3
   resolution: "builtins@npm:1.0.3"
   checksum: 47ce94f7eee0e644969da1f1a28e5f29bd2e48b25b2bbb61164c345881086e29464ccb1fb88dbc155ea26e8b1f5fc8a923b26c8c1ed0935b67b644d410674513
+  languageName: node
+  linkType: hard
+
+"builtins@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "builtins@npm:5.0.1"
+  dependencies:
+    semver: ^7.0.0
+  checksum: 66d204657fe36522822a95b288943ad11b58f5eaede235b11d8c4edaa28ce4800087d44a2681524c340494aadb120a0068011acabe99d30e8f11a7d826d83515
   languageName: node
   linkType: hard
 
@@ -6470,6 +6556,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cacache@npm:^17.0.0":
+  version: 17.0.1
+  resolution: "cacache@npm:17.0.1"
+  dependencies:
+    "@npmcli/fs": ^3.0.0
+    "@npmcli/move-file": ^3.0.0
+    fs-minipass: ^2.1.0
+    glob: ^8.0.1
+    lru-cache: ^7.7.1
+    minipass: ^3.1.6
+    minipass-collect: ^1.0.2
+    minipass-flush: ^1.0.5
+    minipass-pipeline: ^1.2.4
+    p-map: ^4.0.0
+    promise-inflight: ^1.0.1
+    ssri: ^10.0.0
+    tar: ^6.1.11
+    unique-filename: ^3.0.0
+  checksum: 91b6349e7bcdb5210d79966f92985738be5fbbcecf87ac58ff7d48aed1c51d65e9c32ed5835b2d28343d352fb72e5f73cf5f25ad4e89fa036009ac6a40e6b9f1
+  languageName: node
+  linkType: hard
+
 "cache-base@npm:^1.0.1":
   version: 1.0.1
   resolution: "cache-base@npm:1.0.1"
@@ -6498,9 +6606,9 @@ __metadata:
   linkType: hard
 
 "call-me-maybe@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "call-me-maybe@npm:1.0.1"
-  checksum: d19e9d6ac2c6a83fb1215718b64c5e233f688ebebb603bdfe4af59cde952df1f2b648530fab555bf290ea910d69d7d9665ebc916e871e0e194f47c2e48e4886b
+  version: 1.0.2
+  resolution: "call-me-maybe@npm:1.0.2"
+  checksum: 42ff2d0bed5b207e3f0122589162eaaa47ba618f79ad2382fe0ba14d9e49fbf901099a6227440acc5946f86a4953e8aa2d242b330b0a5de4d090bb18f8935cae
   languageName: node
   linkType: hard
 
@@ -6619,9 +6727,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001426":
-  version: 1.0.30001426
-  resolution: "caniuse-lite@npm:1.0.30001426"
-  checksum: e8b9c14ee33410d95b27da619f50648f373a7be712748970643f25d95fa80687b4755ba365f34a7a1cea00f9137193943aa6e742eedf0a4d7857f83809f49435
+  version: 1.0.30001429
+  resolution: "caniuse-lite@npm:1.0.30001429"
+  checksum: d1658080248ef5ef0f5157423b2766026e6aa45642ce3b2cc74859b6a54e39881dd902397a2368324ed30ed0cd40250f11a4a4f3773453cd57b88db5e5e5c76a
   languageName: node
   linkType: hard
 
@@ -7546,7 +7654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-declaration-sorter@npm:^6.3.0":
+"css-declaration-sorter@npm:^6.3.1":
   version: 6.3.1
   resolution: "css-declaration-sorter@npm:6.3.1"
   peerDependencies:
@@ -7634,24 +7742,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano-preset-default@npm:^5.2.12":
-  version: 5.2.12
-  resolution: "cssnano-preset-default@npm:5.2.12"
+"cssnano-preset-default@npm:^5.2.13":
+  version: 5.2.13
+  resolution: "cssnano-preset-default@npm:5.2.13"
   dependencies:
-    css-declaration-sorter: ^6.3.0
+    css-declaration-sorter: ^6.3.1
     cssnano-utils: ^3.1.0
     postcss-calc: ^8.2.3
     postcss-colormin: ^5.3.0
-    postcss-convert-values: ^5.1.2
+    postcss-convert-values: ^5.1.3
     postcss-discard-comments: ^5.1.2
     postcss-discard-duplicates: ^5.1.0
     postcss-discard-empty: ^5.1.1
     postcss-discard-overridden: ^5.1.0
-    postcss-merge-longhand: ^5.1.6
-    postcss-merge-rules: ^5.1.2
+    postcss-merge-longhand: ^5.1.7
+    postcss-merge-rules: ^5.1.3
     postcss-minify-font-values: ^5.1.0
     postcss-minify-gradients: ^5.1.1
-    postcss-minify-params: ^5.1.3
+    postcss-minify-params: ^5.1.4
     postcss-minify-selectors: ^5.2.1
     postcss-normalize-charset: ^5.1.0
     postcss-normalize-display-values: ^5.1.0
@@ -7659,17 +7767,17 @@ __metadata:
     postcss-normalize-repeat-style: ^5.1.1
     postcss-normalize-string: ^5.1.0
     postcss-normalize-timing-functions: ^5.1.0
-    postcss-normalize-unicode: ^5.1.0
+    postcss-normalize-unicode: ^5.1.1
     postcss-normalize-url: ^5.1.0
     postcss-normalize-whitespace: ^5.1.1
     postcss-ordered-values: ^5.1.3
-    postcss-reduce-initial: ^5.1.0
+    postcss-reduce-initial: ^5.1.1
     postcss-reduce-transforms: ^5.1.0
     postcss-svgo: ^5.1.0
     postcss-unique-selectors: ^5.1.1
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 3d6c05e7719f05c577c3123dc8f823ddc055ec5402ee8184cea1832c209a87ab11aa2aa2cba3e6f4ae6e144c1f3f5122fad1bc7c3086bc3441770f2733e03f58
+  checksum: f773de44f67f71e7301e1f4b4664b894c3a48bba4dadc16c559acd0b14ceafed228bdc76fe19d500b0ded9394732377069daadff2184465fa369f8dfd72d47e2
   languageName: node
   linkType: hard
 
@@ -7683,15 +7791,15 @@ __metadata:
   linkType: hard
 
 "cssnano@npm:^5.0.16":
-  version: 5.1.13
-  resolution: "cssnano@npm:5.1.13"
+  version: 5.1.14
+  resolution: "cssnano@npm:5.1.14"
   dependencies:
-    cssnano-preset-default: ^5.2.12
+    cssnano-preset-default: ^5.2.13
     lilconfig: ^2.0.3
     yaml: ^1.10.2
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 3af0810c98626794e3386e690cd633c73ce472cb138f1011b69956de5071920ddce9d45f857018bb72cd2c3ed19674d65edade591110a6d5acd7c3109ef5d5d6
+  checksum: 73463c723c5e598b37b8b4d2f014145bd72133e6581349a1b154904e0830e58de17afb1e801ed3ea3b18e386883964ce4d0299e43d4dc37d339214a956c6697f
   languageName: node
   linkType: hard
 
@@ -8237,12 +8345,12 @@ __metadata:
   linkType: hard
 
 "decamelize-keys@npm:^1.0.0, decamelize-keys@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "decamelize-keys@npm:1.1.0"
+  version: 1.1.1
+  resolution: "decamelize-keys@npm:1.1.1"
   dependencies:
     decamelize: ^1.1.0
     map-obj: ^1.0.0
-  checksum: 8bc5d32e035a072f5dffc1f1f3d26ca7ab1fb44a9cade34c97ab6cd1e62c81a87e718101e96de07d78cecda20a3fdb955df958e46671ccad01bb8dcf0de2e298
+  checksum: fc645fe20b7bda2680bbf9481a3477257a7f9304b1691036092b97ab04c0ab53e3bf9fcc2d2ae382536568e402ec41fb11e1d4c3836a9abe2d813dd9ef4311e0
   languageName: node
   linkType: hard
 
@@ -10739,6 +10847,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hosted-git-info@npm:^6.0.0":
+  version: 6.1.1
+  resolution: "hosted-git-info@npm:6.1.1"
+  dependencies:
+    lru-cache: ^7.5.1
+  checksum: fcd3ca2eaa05f3201425ccbb8aa47f88cdda4a3a6d79453f8e269f7171356278bd1db08f059d8439eb5eaa91c6a8a20800fc49cca6e9e4e899b202a332d5ba6b
+  languageName: node
+  linkType: hard
+
 "hpack.js@npm:^2.1.6":
   version: 2.1.6
   resolution: "hpack.js@npm:2.1.6"
@@ -11123,6 +11240,15 @@ __metadata:
   dependencies:
     minimatch: ^3.0.4
   checksum: 9e9c5ef6c3e0ed7ef5d797991abb554dbb7e60d5fedf6cf05c7129819689eba2b462f625c6e3561e0fc79841904eb829565513eeeab1b44f4fbec4d3146b1a8d
+  languageName: node
+  linkType: hard
+
+"ignore-walk@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "ignore-walk@npm:6.0.0"
+  dependencies:
+    minimatch: ^5.0.1
+  checksum: b94da5517922d65a721f95caa8a884bb8672e80a29691cc3402a4db1eb77f61165dc5c499d8c8efe5e3d9874ff3e9ab05734234ad929b28ba219cf73197ea98c
   languageName: node
   linkType: hard
 
@@ -11525,7 +11651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.5.0, is-core-module@npm:^2.9.0":
+"is-core-module@npm:^2.5.0, is-core-module@npm:^2.8.1, is-core-module@npm:^2.9.0":
   version: 2.11.0
   resolution: "is-core-module@npm:2.11.0"
   dependencies:
@@ -12813,6 +12939,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-parse-even-better-errors@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "json-parse-even-better-errors@npm:3.0.0"
+  checksum: f1970b5220c7fa23d888565510752c3d5e863f93668a202fcaa719739fa41485dfc6a1db212f702ebd3c873851cc067aebc2917e3f79763cae2fdb95046f38f3
+  languageName: node
+  linkType: hard
+
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
@@ -12889,7 +13022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonparse@npm:^1.2.0":
+"jsonparse@npm:^1.2.0, jsonparse@npm:^1.3.1":
   version: 1.3.1
   resolution: "jsonparse@npm:1.3.1"
   checksum: 6514a7be4674ebf407afca0eda3ba284b69b07f9958a8d3113ef1005f7ec610860c312be067e450c569aab8b89635e332cee3696789c750692bb60daba627f4d
@@ -13361,7 +13494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.7.1":
+"lru-cache@npm:^7.4.4, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
   version: 7.14.0
   resolution: "lru-cache@npm:7.14.0"
   checksum: efdd329f2c1bb790b71d497c6c59272e6bc2d7dd060ba55fc136becd3dd31fc8346edb446275504d94cb60d3c8385dbf5267b79b23789e409b2bdf302d13f0d7
@@ -13452,6 +13585,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-fetch-happen@npm:^11.0.0":
+  version: 11.0.1
+  resolution: "make-fetch-happen@npm:11.0.1"
+  dependencies:
+    agentkeepalive: ^4.2.1
+    cacache: ^17.0.0
+    http-cache-semantics: ^4.1.0
+    http-proxy-agent: ^5.0.0
+    https-proxy-agent: ^5.0.0
+    is-lambda: ^1.0.1
+    lru-cache: ^7.7.1
+    minipass: ^3.1.6
+    minipass-collect: ^1.0.2
+    minipass-fetch: ^3.0.0
+    minipass-flush: ^1.0.5
+    minipass-pipeline: ^1.2.4
+    negotiator: ^0.6.3
+    promise-retry: ^2.0.1
+    socks-proxy-agent: ^7.0.0
+    ssri: ^10.0.0
+  checksum: 871083ce4b775521229efcc972f544ffcbb5f70fd8f5582edaa1b3e555de772e076babf4b044a2d48efc326d54aa151f5ea3458615ecfcfb81cb6480bcb2e1c6
+  languageName: node
+  linkType: hard
+
 "make-fetch-happen@npm:^5.0.0":
   version: 5.0.2
   resolution: "make-fetch-happen@npm:5.0.2"
@@ -13518,11 +13675,11 @@ __metadata:
   linkType: hard
 
 "marked@npm:^4.0.16":
-  version: 4.1.1
-  resolution: "marked@npm:4.1.1"
+  version: 4.2.1
+  resolution: "marked@npm:4.2.1"
   bin:
     marked: bin/marked.js
-  checksum: 717e3357952ee53de831bf0eb110ed075bebca2376c58bcdf7ee523ef540d45308ad6d51b2c933da0968832ea4386f31c142ca65443e77c098e84f6cce73e418
+  checksum: 9361bc017f707ed4233ba0cade7065269b2f835d29388bfa170090ebeadfe96f01097b5495b2514f79c1ce13042007d64cc156236cabb841a4e470af977af04d
   languageName: node
   linkType: hard
 
@@ -13562,11 +13719,11 @@ __metadata:
   linkType: hard
 
 "memfs@npm:^3.1.2, memfs@npm:^3.4.3":
-  version: 3.4.8
-  resolution: "memfs@npm:3.4.8"
+  version: 3.4.9
+  resolution: "memfs@npm:3.4.9"
   dependencies:
     fs-monkey: ^1.0.3
-  checksum: a377030712ccd8567219536606daa7694222bfe92e70c9981adb22cd088a3f2ad13884d80b700561ff64a1ce349f3c729d51232e02019f156dbc98765fe94caa
+  checksum: 575dfde73f4105db42ffc2fdcd06efb9037541de095bd4fe9fb29134a1a775dfe922839b30db632de76cb29354d79d8f82a5e4f5f588e21bc47358b6d058a9c6
   languageName: node
   linkType: hard
 
@@ -13835,12 +13992,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass-fetch@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "minipass-fetch@npm:3.0.0"
+  dependencies:
+    encoding: ^0.1.13
+    minipass: ^3.1.6
+    minipass-sized: ^1.0.3
+    minizlib: ^2.1.2
+  dependenciesMeta:
+    encoding:
+      optional: true
+  checksum: ebc876b8763d858a759bd53a04eedc85f111a9fc0ab822a4b445c5eb71f34dc3fd3442d75484df156ca57e2dea37edfc77a585c27c67be835589f212772ddb6e
+  languageName: node
+  linkType: hard
+
 "minipass-flush@npm:^1.0.5":
   version: 1.0.5
   resolution: "minipass-flush@npm:1.0.5"
   dependencies:
     minipass: ^3.0.0
   checksum: 56269a0b22bad756a08a94b1ffc36b7c9c5de0735a4dd1ab2b06c066d795cfd1f0ac44a0fcae13eece5589b908ecddc867f04c745c7009be0b566421ea0944cf
+  languageName: node
+  linkType: hard
+
+"minipass-json-stream@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minipass-json-stream@npm:1.0.1"
+  dependencies:
+    jsonparse: ^1.3.1
+    minipass: ^3.0.0
+  checksum: 791b696a27d1074c4c08dab1bf5a9f3201145c2933e428f45d880467bce12c60de4703203d2928de4b162d0ae77b0bb4b55f96cb846645800aa0eb4919b3e796
   languageName: node
   linkType: hard
 
@@ -14208,7 +14390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:latest":
+"node-gyp@npm:^9.0.0, node-gyp@npm:latest":
   version: 9.3.0
   resolution: "node-gyp@npm:9.3.0"
   dependencies:
@@ -14289,6 +14471,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"normalize-package-data@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "normalize-package-data@npm:5.0.0"
+  dependencies:
+    hosted-git-info: ^6.0.0
+    is-core-module: ^2.8.1
+    semver: ^7.3.5
+    validate-npm-package-license: ^3.0.4
+  checksum: a459f05eaf7c2b643c61234177f08e28064fde97da15800e3d3ac0404e28450d43ac46fc95fbf6407a9bf20af4c58505ad73458a912dc1517f8c1687b1d68c27
+  languageName: node
+  linkType: hard
+
 "normalize-path@npm:^2.1.1":
   version: 2.1.1
   resolution: "normalize-path@npm:2.1.1"
@@ -14337,6 +14531,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-bundled@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "npm-bundled@npm:3.0.0"
+  dependencies:
+    npm-normalize-package-bin: ^3.0.0
+  checksum: 110859c2d6dcd7941dac0932a29171cbde123060486a4b6e897aaf5e025abeb3d9ffcdfe9e9271992e6396b2986c2c534f1029a45a7c196f1257fa244305dbf8
+  languageName: node
+  linkType: hard
+
+"npm-install-checks@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "npm-install-checks@npm:6.0.0"
+  dependencies:
+    semver: ^7.1.1
+  checksum: 5476a26dccb83c24d9ffaf3d0592e8001f9804a40c6b3f441c9a1b2c8d643e90d8352c4ce27ffce72296de7f9744750d0124a6db55b68071971d4b4e74787818
+  languageName: node
+  linkType: hard
+
 "npm-lifecycle@npm:^3.1.2":
   version: 3.1.5
   resolution: "npm-lifecycle@npm:3.1.5"
@@ -14357,6 +14569,25 @@ __metadata:
   version: 1.0.1
   resolution: "npm-normalize-package-bin@npm:1.0.1"
   checksum: ae7f15155a1e3ace2653f12ddd1ee8eaa3c84452fdfbf2f1943e1de264e4b079c86645e2c55931a51a0a498cba31f70022a5219d5665fbcb221e99e58bc70122
+  languageName: node
+  linkType: hard
+
+"npm-normalize-package-bin@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "npm-normalize-package-bin@npm:3.0.0"
+  checksum: 6a34886c150b0f5302aad52a9446e5c939aa14eeb462323e75681517b36c6b9eaef83e1f5bc2d7e5154b3b752cbce81bed05e290db3f1f7edf857cbb895e35c0
+  languageName: node
+  linkType: hard
+
+"npm-package-arg@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "npm-package-arg@npm:10.0.0"
+  dependencies:
+    hosted-git-info: ^6.0.0
+    proc-log: ^3.0.0
+    semver: ^7.3.5
+    validate-npm-package-name: ^5.0.0
+  checksum: 5f35870b4786e27358c672820ab6abb9b87e214dc1795aef96f6993ea74b789b27318017650dc4da965c249ee3e66ab9dc1ac12c68e7209dd9afae1ad7e3f0b8
   languageName: node
   linkType: hard
 
@@ -14383,6 +14614,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-packlist@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "npm-packlist@npm:7.0.2"
+  dependencies:
+    ignore-walk: ^6.0.0
+  checksum: 01bdc19d46b397575de73c3bbc9171e1a15f2b5ce1a2a6944a3514628452fe1494b77180fc6fb4d750b39d3f42d1720b7496fbe0bb50cc99bf10f812cd3e85fa
+  languageName: node
+  linkType: hard
+
 "npm-pick-manifest@npm:^3.0.0":
   version: 3.0.2
   resolution: "npm-pick-manifest@npm:3.0.2"
@@ -14391,6 +14631,33 @@ __metadata:
     npm-package-arg: ^6.0.0
     semver: ^5.4.1
   checksum: 6d6cddcbe6f8cb585f3fa1778c7fbe64b1521521020a1cff1f7053aebac9ad987b58283466f1ebbd99eefc919fe0365b0e6db840b70b09cd728fa5c383e3e18d
+  languageName: node
+  linkType: hard
+
+"npm-pick-manifest@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "npm-pick-manifest@npm:8.0.1"
+  dependencies:
+    npm-install-checks: ^6.0.0
+    npm-normalize-package-bin: ^3.0.0
+    npm-package-arg: ^10.0.0
+    semver: ^7.3.5
+  checksum: b8e16f2fbcc40ba7d1405c9b566bcee32488c6709f883207f709b0715ed34e2f3f3bc5bf5cb9563d6aa23cb878102bf0011ba22cce9235caa9a0349784b48ecd
+  languageName: node
+  linkType: hard
+
+"npm-registry-fetch@npm:^14.0.0":
+  version: 14.0.2
+  resolution: "npm-registry-fetch@npm:14.0.2"
+  dependencies:
+    make-fetch-happen: ^11.0.0
+    minipass: ^3.1.6
+    minipass-fetch: ^3.0.0
+    minipass-json-stream: ^1.0.1
+    minizlib: ^2.1.2
+    npm-package-arg: ^10.0.0
+    proc-log: ^3.0.0
+  checksum: 8053307989b5c1e7fc459889115fa6ec0965c973e73717357735d18e7b0840bc739a7c0d4c40083a4d2a9de11566540f7da2a8fe5e2ff3f721e8847cd2d5d5a6
   languageName: node
   linkType: hard
 
@@ -14644,11 +14911,11 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 4.0.3-pre.379
-  resolution: "openmrs@npm:4.0.3-pre.379"
+  version: 4.0.3-pre.392
+  resolution: "openmrs@npm:4.0.3-pre.392"
   dependencies:
-    "@openmrs/esm-app-shell": 4.0.3-pre.379
-    "@openmrs/webpack-config": 4.0.3-pre.379
+    "@openmrs/esm-app-shell": 4.0.3-pre.392
+    "@openmrs/webpack-config": 4.0.3-pre.392
     autoprefixer: ^10.4.2
     axios: ^0.21.1
     browserslist-config-openmrs: ^1.0.1
@@ -14659,6 +14926,7 @@ __metadata:
     html-webpack-plugin: ^5.5.0
     inquirer: ^7.3.3
     mini-css-extract-plugin: ^2.4.5
+    pacote: ^15.0.0
     postcss: ^8.4.6
     postcss-loader: ^6.2.1
     rimraf: ^3.0.2
@@ -14673,7 +14941,7 @@ __metadata:
     yargs: 16.0.3
   bin:
     openmrs: dist/cli.js
-  checksum: 1ea4bee5b7f08b5f92ea3b765f31719381e0a653d9711e5dcfaf4b440bdd9d65ec92b7d61fe0b83cb6db1e9b7ac9af1f6ecbd8e326346c3ae07b58e8bc33bcf4
+  checksum: 85c68926e8800df7629310f6d464be34484944076749575f165021cf0a0e7df7d048c2c6461f012fa9a7a59c6e8d86b85022ad1f392475934b23134e30bff200
   languageName: node
   linkType: hard
 
@@ -14894,6 +15162,33 @@ __metadata:
   dependencies:
     p-reduce: ^1.0.0
   checksum: 033f098515186780df1d465eb83d76e719e779442923def8293c00fbe222eae3577a4eedfc9a8884639dff0c083fb5819fe8c61bc7770d822331b0ae56453f3d
+  languageName: node
+  linkType: hard
+
+"pacote@npm:^15.0.0":
+  version: 15.0.6
+  resolution: "pacote@npm:15.0.6"
+  dependencies:
+    "@npmcli/git": ^4.0.0
+    "@npmcli/installed-package-contents": ^2.0.1
+    "@npmcli/promise-spawn": ^6.0.1
+    "@npmcli/run-script": ^6.0.0
+    cacache: ^17.0.0
+    fs-minipass: ^2.1.0
+    minipass: ^3.1.6
+    npm-package-arg: ^10.0.0
+    npm-packlist: ^7.0.0
+    npm-pick-manifest: ^8.0.0
+    npm-registry-fetch: ^14.0.0
+    proc-log: ^3.0.0
+    promise-retry: ^2.0.1
+    read-package-json: ^6.0.0
+    read-package-json-fast: ^3.0.0
+    ssri: ^10.0.0
+    tar: ^6.1.11
+  bin:
+    pacote: lib/bin.js
+  checksum: 780090212079efc787fc3c3b19bfcec34beeb6f24ef2ac43981c496ee24acbf1846752245740111db6cb7decf542313cb258b1339a57a7430d1b6626e4bfe1d0
   languageName: node
   linkType: hard
 
@@ -15331,15 +15626,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-convert-values@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "postcss-convert-values@npm:5.1.2"
+"postcss-convert-values@npm:^5.1.3":
+  version: 5.1.3
+  resolution: "postcss-convert-values@npm:5.1.3"
   dependencies:
-    browserslist: ^4.20.3
+    browserslist: ^4.21.4
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: b1615daf12d3425bf4edee9451de402702f41019ccfc85f7883d87438becf533b3061a5a3567865029c534147a6c90e89b4c42ae6741c768c879a68d35aea812
+  checksum: df48cdaffabf9737f9cfdc58a3dc2841cf282506a7a944f6c70236cff295d3a69f63de6e0935eeb8a9d3f504324e5b4e240abc29e21df9e35a02585d3060aeb5
   languageName: node
   linkType: hard
 
@@ -15393,29 +15688,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-merge-longhand@npm:^5.1.6":
-  version: 5.1.6
-  resolution: "postcss-merge-longhand@npm:5.1.6"
+"postcss-merge-longhand@npm:^5.1.7":
+  version: 5.1.7
+  resolution: "postcss-merge-longhand@npm:5.1.7"
   dependencies:
     postcss-value-parser: ^4.2.0
-    stylehacks: ^5.1.0
+    stylehacks: ^5.1.1
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 327b5474d9e84b8d8aed3e24444938cbf1274326d357b551b700203f03f7bcb615381b92b933770ffe35b154677205af08875373413f2c5e625c34730599707b
+  checksum: 81c3fc809f001b9b71a940148e242bdd6e2d77713d1bfffa15eb25c1f06f6648d5e57cb21645746d020a2a55ff31e1740d2b27900442913a9d53d8a01fb37e1b
   languageName: node
   linkType: hard
 
-"postcss-merge-rules@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "postcss-merge-rules@npm:5.1.2"
+"postcss-merge-rules@npm:^5.1.3":
+  version: 5.1.3
+  resolution: "postcss-merge-rules@npm:5.1.3"
   dependencies:
-    browserslist: ^4.16.6
+    browserslist: ^4.21.4
     caniuse-api: ^3.0.0
     cssnano-utils: ^3.1.0
     postcss-selector-parser: ^6.0.5
   peerDependencies:
     postcss: ^8.2.15
-  checksum: fcbc415999a35248dcce03064a5456123663507b05ff0f1de5c97b6effc68014ab0ffd5f06e71cf08d401f037932e271b7db33124c73260f3630a1441212a0c8
+  checksum: 0ddaddff98cd7f3fac2b0e716c641f529a61a8668be6d5b48d60770d0a1246126088e1d606f309b9748ff598a3794f3fd6dd5b8c3d79112f84744cab5375d4d9
   languageName: node
   linkType: hard
 
@@ -15443,16 +15738,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-minify-params@npm:^5.1.3":
-  version: 5.1.3
-  resolution: "postcss-minify-params@npm:5.1.3"
+"postcss-minify-params@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "postcss-minify-params@npm:5.1.4"
   dependencies:
-    browserslist: ^4.16.6
+    browserslist: ^4.21.4
     cssnano-utils: ^3.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 2d218f6b82474310c866b690210595a5e6a4c695f174f9100b018adb4a171bd67b1adaba26c241b3d41a4ea0f4962e0f5a77cf12ae60d9db76f80b0c7cbd6bcd
+  checksum: bd63e2cc89edcf357bb5c2a16035f6d02ef676b8cede4213b2bddd42626b3d428403849188f95576fc9f03e43ebd73a29bf61d33a581be9a510b13b7f7f100d5
   languageName: node
   linkType: hard
 
@@ -15575,15 +15870,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-normalize-unicode@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "postcss-normalize-unicode@npm:5.1.0"
+"postcss-normalize-unicode@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "postcss-normalize-unicode@npm:5.1.1"
   dependencies:
-    browserslist: ^4.16.6
+    browserslist: ^4.21.4
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 3570c90050f190811b5dbf7b4cf4f30f0b627c1ba5fbe5ad332e8b0aa7ef14b3d0aa2af1cb1074d0267aec8c9771e28866d867c8a8a0c433b6c34e50445f9c16
+  checksum: 4c24d26cc9f4b19a9397db4e71dd600dab690f1de8e14a3809e2aa1452dbc3791c208c38a6316bbc142f29e934fdf02858e68c94038c06174d78a4937e0f273c
   languageName: node
   linkType: hard
 
@@ -15622,15 +15917,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-reduce-initial@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "postcss-reduce-initial@npm:5.1.0"
+"postcss-reduce-initial@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "postcss-reduce-initial@npm:5.1.1"
   dependencies:
-    browserslist: ^4.16.6
+    browserslist: ^4.21.4
     caniuse-api: ^3.0.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 2cb10fa3fa7d7df9e4376df64d19177debd5cfe6d8fde52327d27de425eb28d5d85fa45c857cf7c0aed35d16455b6f4762b53959480f92a1dfa4b51a1d780a32
+  checksum: 1b704aba8c38103cbb5a75c6201dbf58ec2f3a978013c7f7e8957fd3bf3282f992050dec5a01bc050d031bad836e187dd6622b922ca78ab92bcd0afd21fb0b98
   languageName: node
   linkType: hard
 
@@ -15794,6 +16089,13 @@ __metadata:
   bin:
     pretty-quick: bin/pretty-quick.js
   checksum: 19f1a5484d24df1c799413ec176c9efabdebbbef297c8fcaf924bb8afb172439bdc4025822ad55223c7cb8262b2cb1ba9b9363c4785393750409605526597c7f
+  languageName: node
+  linkType: hard
+
+"proc-log@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "proc-log@npm:3.0.0"
+  checksum: 02b64e1b3919e63df06f836b98d3af002b5cd92655cab18b5746e37374bfb73e03b84fe305454614b34c25b485cc687a9eebdccf0242cda8fda2475dd2c97e02
   languageName: node
   linkType: hard
 
@@ -16157,26 +16459,26 @@ __metadata:
   linkType: hard
 
 "react-router-dom@npm:^6.3.0":
-  version: 6.4.2
-  resolution: "react-router-dom@npm:6.4.2"
+  version: 6.4.3
+  resolution: "react-router-dom@npm:6.4.3"
   dependencies:
-    "@remix-run/router": 1.0.2
-    react-router: 6.4.2
+    "@remix-run/router": 1.0.3
+    react-router: 6.4.3
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 858e6a5c4c5da56615dbf53118d576d61851157f077805dfe476b10c332329f8b1494062d75a8de6f1bdd35fbcb8a510f8e23beb2306440d2452b9f2fe4b079d
+  checksum: 67a44d8dc45761a1c88793cac73839bb657168ef61b9473eb39b186b4a3ea1472454fd96f8997dc541cb1e79a723d62f9503cbc9179b63b8f1d634ed6d2b079a
   languageName: node
   linkType: hard
 
-"react-router@npm:6.4.2":
-  version: 6.4.2
-  resolution: "react-router@npm:6.4.2"
+"react-router@npm:6.4.3":
+  version: 6.4.3
+  resolution: "react-router@npm:6.4.3"
   dependencies:
-    "@remix-run/router": 1.0.2
+    "@remix-run/router": 1.0.3
   peerDependencies:
     react: ">=16.8"
-  checksum: c229d65d9b0df88dd4e8c57bd59793e371f2c84b4cb200b77ead9f601c8fd7758f72acfffc9a2fc5cb31877af3a0e08ae24aeb75ab2b20681f3b1d33ca671552
+  checksum: b89c0495c6837b1457915c08c5acc4eb7a2e9e3fae0420faf9bfc6311ecdfe78627cc1034c0e975bccd9aeeb70d1dcc5021322779dd3053d94c47e37339d77eb
   languageName: node
   linkType: hard
 
@@ -16198,6 +16500,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"read-package-json-fast@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "read-package-json-fast@npm:3.0.1"
+  dependencies:
+    json-parse-even-better-errors: ^3.0.0
+    npm-normalize-package-bin: ^3.0.0
+  checksum: b2e249c9bba4e0f188bea06dd57a7cfe0d76e272e8de14d1d71bcee894f48f576a9884a5890786a4a97990d196b86461c8b7e43024dca00b091081effcfd7ea0
+  languageName: node
+  linkType: hard
+
 "read-package-json@npm:1 || 2, read-package-json@npm:^2.0.0, read-package-json@npm:^2.0.13":
   version: 2.1.2
   resolution: "read-package-json@npm:2.1.2"
@@ -16207,6 +16519,18 @@ __metadata:
     normalize-package-data: ^2.0.0
     npm-normalize-package-bin: ^1.0.0
   checksum: 56a2642851e9321a68e1708263944bf5ab8a2c172daf3f13f18aad32fbe2f2ba516935b068c93771d9671012aec4596962c20417aca8b5e73501bc647691337a
+  languageName: node
+  linkType: hard
+
+"read-package-json@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "read-package-json@npm:6.0.0"
+  dependencies:
+    glob: ^8.0.1
+    json-parse-even-better-errors: ^3.0.0
+    normalize-package-data: ^5.0.0
+    npm-normalize-package-bin: ^3.0.0
+  checksum: e2e4bf037918970bdafe29a20039f8f34ae6a4cc540230998f71347f2ed28eebeba5026d69587366df2a8fd5baf84c5304dca5819347b05ea3ed551b82ca1eee
   languageName: node
   linkType: hard
 
@@ -17093,7 +17417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
   version: 7.3.8
   resolution: "semver@npm:7.3.8"
   dependencies:
@@ -17698,6 +18022,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ssri@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "ssri@npm:10.0.0"
+  dependencies:
+    minipass: ^3.1.1
+  checksum: c8707ee2351bcfe5258e47b4e08ded4b2e8aec1d79853adec43bf4da6d6e071930ec72a01555f835d772892a230dc17eeb2331b7053a62fa4fd458b863a42741
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^6.0.0, ssri@npm:^6.0.1":
   version: 6.0.2
   resolution: "ssri@npm:6.0.2"
@@ -18036,15 +18369,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylehacks@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "stylehacks@npm:5.1.0"
+"stylehacks@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "stylehacks@npm:5.1.1"
   dependencies:
-    browserslist: ^4.16.6
+    browserslist: ^4.21.4
     postcss-selector-parser: ^6.0.4
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 310b3452c11fd443b0d327aa2d5b43ae7479407339204b7ad11cf2e16d33b690c1cbf47a21b737ef112411e53563f0f996c5fa3642d135c896329950a008277f
+  checksum: 11175366ef52de65bf06cefba0ddc9db286dc3a1451fd2989e74c6ea47091a02329a4bf6ce10b1a36950056927b6bbbe47c5ab3a1f4c7032df932d010fbde5a2
   languageName: node
   linkType: hard
 
@@ -18175,15 +18508,15 @@ __metadata:
   linkType: hard
 
 "table@npm:^6.0.9":
-  version: 6.8.0
-  resolution: "table@npm:6.8.0"
+  version: 6.8.1
+  resolution: "table@npm:6.8.1"
   dependencies:
     ajv: ^8.0.1
     lodash.truncate: ^4.4.2
     slice-ansi: ^4.0.0
     string-width: ^4.2.3
     strip-ansi: ^6.0.1
-  checksum: 5b07fe462ee03d2e1fac02cbb578efd2e0b55ac07e3d3db2e950aa9570ade5a4a2b8d3c15e9f25c89e4e50b646bc4269934601ee1eef4ca7968ad31960977690
+  checksum: 08249c7046125d9d0a944a6e96cfe9ec66908d6b8a9db125531be6eb05fa0de047fd5542e9d43b4f987057f00a093b276b8d3e19af162a9c40db2681058fd306
   languageName: node
   linkType: hard
 
@@ -18217,8 +18550,8 @@ __metadata:
   linkType: hard
 
 "tar@npm:^6.0.5, tar@npm:^6.1.11, tar@npm:^6.1.2":
-  version: 6.1.11
-  resolution: "tar@npm:6.1.11"
+  version: 6.1.12
+  resolution: "tar@npm:6.1.12"
   dependencies:
     chownr: ^2.0.0
     fs-minipass: ^2.0.0
@@ -18226,7 +18559,7 @@ __metadata:
     minizlib: ^2.1.1
     mkdirp: ^1.0.3
     yallist: ^4.0.0
-  checksum: a04c07bb9e2d8f46776517d4618f2406fb977a74d914ad98b264fc3db0fe8224da5bec11e5f8902c5b9bcb8ace22d95fbe3c7b36b8593b7dfc8391a25898f32f
+  checksum: 49d72e4420944e7ede2782d6b0826a6ede6cdab23c7de63470917e7a78166bc4d5b1a96279d3d79a85f1ba5a17cd37c0acbb3cbff19a07447691445b8b051c55
   languageName: node
   linkType: hard
 
@@ -18643,9 +18976,9 @@ __metadata:
   linkType: hard
 
 "tslib@npm:^2.0.3":
-  version: 2.4.0
-  resolution: "tslib@npm:2.4.0"
-  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  version: 2.4.1
+  resolution: "tslib@npm:2.4.1"
+  checksum: 19480d6e0313292bd6505d4efe096a6b31c70e21cf08b5febf4da62e95c265c8f571f7b36fcc3d1a17e068032f59c269fab3459d6cd3ed6949eafecf64315fca
   languageName: node
   linkType: hard
 
@@ -18669,58 +19002,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo-darwin-64@npm:1.6.2":
-  version: 1.6.2
-  resolution: "turbo-darwin-64@npm:1.6.2"
+"turbo-darwin-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-darwin-64@npm:1.6.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-darwin-arm64@npm:1.6.2":
-  version: 1.6.2
-  resolution: "turbo-darwin-arm64@npm:1.6.2"
+"turbo-darwin-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-darwin-arm64@npm:1.6.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-linux-64@npm:1.6.2":
-  version: 1.6.2
-  resolution: "turbo-linux-64@npm:1.6.2"
+"turbo-linux-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-linux-64@npm:1.6.3"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-linux-arm64@npm:1.6.2":
-  version: 1.6.2
-  resolution: "turbo-linux-arm64@npm:1.6.2"
+"turbo-linux-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-linux-arm64@npm:1.6.3"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-windows-64@npm:1.6.2":
-  version: 1.6.2
-  resolution: "turbo-windows-64@npm:1.6.2"
+"turbo-windows-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-windows-64@npm:1.6.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-windows-arm64@npm:1.6.2":
-  version: 1.6.2
-  resolution: "turbo-windows-arm64@npm:1.6.2"
+"turbo-windows-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-windows-arm64@npm:1.6.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "turbo@npm:^1.6.1":
-  version: 1.6.2
-  resolution: "turbo@npm:1.6.2"
+  version: 1.6.3
+  resolution: "turbo@npm:1.6.3"
   dependencies:
-    turbo-darwin-64: 1.6.2
-    turbo-darwin-arm64: 1.6.2
-    turbo-linux-64: 1.6.2
-    turbo-linux-arm64: 1.6.2
-    turbo-windows-64: 1.6.2
-    turbo-windows-arm64: 1.6.2
+    turbo-darwin-64: 1.6.3
+    turbo-darwin-arm64: 1.6.3
+    turbo-linux-64: 1.6.3
+    turbo-linux-arm64: 1.6.3
+    turbo-windows-64: 1.6.3
+    turbo-windows-arm64: 1.6.3
   dependenciesMeta:
     turbo-darwin-64:
       optional: true
@@ -18736,7 +19069,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: d32365bdd617d4ef4edbc332784ac303d77627aeb9107a6616f5d1ab7082f84da04905609c0daa39dd3a6841b2b52e46326135e98e29dab4b7f5464758d11513
+  checksum: 35195f4b7623014c25ba152c11a8cb23e51cbd75dc9266d0656692665f85b28faf3496dea8cecacf52795a917410668124186ffbdcf276325ccc3e11df9e9623
   languageName: node
   linkType: hard
 
@@ -19008,6 +19341,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unique-filename@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "unique-filename@npm:3.0.0"
+  dependencies:
+    unique-slug: ^4.0.0
+  checksum: 8e2f59b356cb2e54aab14ff98a51ac6c45781d15ceaab6d4f1c2228b780193dc70fae4463ce9e1df4479cb9d3304d7c2043a3fb905bdeca71cc7e8ce27e063df
+  languageName: node
+  linkType: hard
+
 "unique-slug@npm:^2.0.0":
   version: 2.0.2
   resolution: "unique-slug@npm:2.0.2"
@@ -19023,6 +19365,15 @@ __metadata:
   dependencies:
     imurmurhash: ^0.1.4
   checksum: 49f8d915ba7f0101801b922062ee46b7953256c93ceca74303bd8e6413ae10aa7e8216556b54dc5382895e8221d04f1efaf75f945c2e4a515b4139f77aa6640c
+  languageName: node
+  linkType: hard
+
+"unique-slug@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "unique-slug@npm:4.0.0"
+  dependencies:
+    imurmurhash: ^0.1.4
+  checksum: 0884b58365af59f89739e6f71e3feacb5b1b41f2df2d842d0757933620e6de08eff347d27e9d499b43c40476cbaf7988638d3acb2ffbcb9d35fd035591adfd15
   languageName: node
   linkType: hard
 
@@ -19252,7 +19603,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validate-npm-package-license@npm:^3.0.1, validate-npm-package-license@npm:^3.0.3":
+"validate-npm-package-license@npm:^3.0.1, validate-npm-package-license@npm:^3.0.3, validate-npm-package-license@npm:^3.0.4":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
   dependencies:
@@ -19268,6 +19619,15 @@ __metadata:
   dependencies:
     builtins: ^1.0.3
   checksum: ce4c68207abfb22c05eedb09ff97adbcedc80304a235a0844f5344f1fd5086aa80e4dbec5684d6094e26e35065277b765c1caef68bcea66b9056761eddb22967
+  languageName: node
+  linkType: hard
+
+"validate-npm-package-name@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "validate-npm-package-name@npm:5.0.0"
+  dependencies:
+    builtins: ^5.0.0
+  checksum: 5342a994986199b3c28e53a8452a14b2bb5085727691ea7aa0d284a6606b127c371e0925ae99b3f1ef7cc7d2c9de75f52eb61a3d1cc45e39bca1e3a9444cbb4e
   languageName: node
   linkType: hard
 
@@ -19628,9 +19988,9 @@ __metadata:
   linkType: hard
 
 "webpack-stats-plugin@npm:^1.0.3":
-  version: 1.1.0
-  resolution: "webpack-stats-plugin@npm:1.1.0"
-  checksum: f692f3003813122a1745607c1db78fbcdf51dca570984a591f53f8e6e4a856ebb1490c43837ad4728ca2b62aed9bdadecb79e5e04efc5bff41ff075e5d809c54
+  version: 1.1.1
+  resolution: "webpack-stats-plugin@npm:1.1.1"
+  checksum: aa553ccfb9389f2d8a2d04eb6289230bc323edb11b0cbdd676d41617dd790a7f0d0844c46b927a9465139b3edb9da2cc7a2ef664891920c052ef4fa5f2797230
   languageName: node
   linkType: hard
 
@@ -19811,6 +20171,17 @@ __metadata:
   bin:
     node-which: ./bin/node-which
   checksum: 1a5c563d3c1b52d5f893c8b61afe11abc3bab4afac492e8da5bde69d550de701cf9806235f20a47b5c8fa8a1d6a9135841de2596535e998027a54589000e66d1
+  languageName: node
+  linkType: hard
+
+"which@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "which@npm:3.0.0"
+  dependencies:
+    isexe: ^2.0.0
+  bin:
+    node-which: bin/which.js
+  checksum: fdcf3cadab414e60b86c6836e7ac9de9273561a8926f57cbc28641b602a771527239ee4d47f2689ed255666f035ba0a0d72390986cc0c4e45344491adc7d0eeb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR brings the keyboard navigation to the compact patient search and the compact patient search extension as well.

The navigation works the following way:
1. First the focus is on the input element.
2. As soon as the results load, we can surf through the results using the Arrow up and down keys. The focus shifts either to the next or the prev result depending on the arrow key pressed.
3. If the focus is on a result and the user clicks "Enter", the user will be directed to the patient chart or the `selectPatientAction` function if passed through a prop in the extension.
4. If the focus is on the first result and the user presses the arrow up key, the focus will return to the input bar.
5. If the focus is on any of the result and user presses any key other than Arrow up, down or Enter, the focus will be shifted back to the end of the input value and hence user can use the input directly.

The video below shows the working. 


## Screenshots

https://user-images.githubusercontent.com/51502471/200540492-6d49cbf3-18c7-44e1-887a-d42d7ef2c036.mov


## Related Issue

https://issues.openmrs.org/browse/O3-1575


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
