### PR TITLE
(feat) Delay display of menu item tooltips by 500ms

### DIFF
--- a/packages/esm-patient-registration-app/src/add-patient-link.tsx
+++ b/packages/esm-patient-registration-app/src/add-patient-link.tsx
@@ -11,6 +11,7 @@ export default function Root() {
     <HeaderGlobalAction
       aria-label="Add Patient"
       aria-labelledby="Add Patient"
+      enterDelayMs={500}
       name="AddPatientIcon"
       onClick={addPatient}
       className={styles.slotStyles}>

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -81,6 +81,7 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
           aria-label={t('searchPatient', 'Search Patient')}
           aria-labelledby="Search Patient"
           className={`${showSearchInput ? styles.activeSearchIconButton : styles.searchIconButton}`}
+          enterDelayMs={500}
           name="SearchPatientIcon"
           onClick={handleGlobalAction}>
           {showSearchInput ? <Close size={20} /> : <Search size={20} />}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Ups the `HeaderGlobalAction` component's `enterDelayMs` prop's value from 100ms to 500ms. This delay is sufficient for the tooltips not to overlap when a user hovers over menu items in the navigation bar.

## Related Issue

https://issues.openmrs.org/browse/O3-1585

Slack discussion https://openmrs.slack.com/archives/CKS32D55G/p1667573248471719.
