### PR TITLE
Add tab instead of link for missed appointments

### DIFF
--- a/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointment-forms/appointments-form.component.tsx
@@ -205,6 +205,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment, patientU
           setIsSubmitting(false);
           mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${appointmentStartDate}&status=Scheduled`);
           mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${appointmentStartDate}&status=CheckedIn`);
+          mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${appointmentStartDate}&status=Missed`);
           mutate(`/ws/rest/v1/appointment/all?forDate=${appointmentStartDate}`);
           closeOverlay();
         }

--- a/packages/esm-appointments-app/src/appointments-tabs/missed-appointment.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-tabs/missed-appointment.component.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAppointments } from './appointments-table.resource';
+import AppointmentsBaseTable from './appointments-base-table.component';
+import { AppointmentTypes } from '../types';
+
+interface MissedAppointmentsProps {
+  status: string;
+}
+
+const MissedAppointments: React.FC<MissedAppointmentsProps> = ({ status }) => {
+  const { t } = useTranslation();
+  const { appointments, isLoading } = useAppointments();
+
+  return (
+    <div>
+      <AppointmentsBaseTable appointments={appointments} isLoading={isLoading} tableHeading={AppointmentTypes.MISSED} />
+    </div>
+  );
+};
+
+export default MissedAppointments;

--- a/packages/esm-appointments-app/src/appointments/appointment-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-list.component.tsx
@@ -13,12 +13,14 @@ import dayjs from 'dayjs';
 import UnScheduledAppointments from '../appointments-tabs/unscheduled-appointments.component';
 import PendingAppointments from '../appointments-tabs/pending-appointments.component';
 import { useAppointments } from '../appointments-tabs/appointments-table.resource';
+import MissedAppointments from '../appointments-tabs/missed-appointment.component';
 
 enum AppointmentTypes {
   SCHEDULED = 'Scheduled',
   COMPLETED = 'Completed',
   CANCELLED = 'Cancelled',
   CHECKEDIN = 'CheckedIn',
+  MISSED = 'Missed',
 }
 
 const AppointmentList: React.FC = () => {
@@ -66,6 +68,7 @@ const AppointmentList: React.FC = () => {
           <Tab>{t('unScheduled', 'UnScheduled')}</Tab>
           <Tab>{t('completed', 'Completed')}</Tab>
           <Tab disabled={!isToday}>{t('checkedIn', 'CheckedIn')}</Tab>
+          <Tab>{t('missed', 'Missed')}</Tab>
           <Tab>{t('pending', 'Pending')}</Tab>
           <Button
             className={styles.calendarButton}
@@ -88,6 +91,7 @@ const AppointmentList: React.FC = () => {
           {isToday && (
             <TabPanel style={{ padding: 0 }}>{<CheckInAppointments status={AppointmentTypes.CHECKEDIN} />}</TabPanel>
           )}
+          <TabPanel style={{ padding: 0 }}>{<MissedAppointments status={AppointmentTypes.MISSED} />}</TabPanel>
           <TabPanel style={{ padding: 0 }}>
             <PendingAppointments />
           </TabPanel>


### PR DESCRIPTION

![missed](https://user-images.githubusercontent.com/8075969/202273471-4f5d31c1-5241-4c5e-a56c-fb33b9fbba30.png)
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Add tab instead of link for missed appointments
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
