### PR TITLE
Adds breadcrumbs to appointments calendar

### DIFF
--- a/packages/esm-appointments-app/src/appointments-calendar/appointments-calendar-list-view.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-calendar/appointments-calendar-list-view.component.tsx
@@ -13,7 +13,7 @@ import {
 } from '@carbon/react';
 import { ArrowRight, Filter } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
-import { formatDate, formatTime } from '@openmrs/esm-framework';
+import { ExtensionSlot, formatDate, formatTime } from '@openmrs/esm-framework';
 import AppointmentsHeader from '../appointments-header/appointments-header.component';
 import styles from './appointments-calendar-list-view.scss';
 import EmptyState from '../empty-state/empty-state.component';
@@ -49,6 +49,7 @@ const AppointmentsCalendarListView: React.FC<AppointmentsCalendarListViewProps> 
   return (
     <div>
       <AppointmentsHeader title={t('clinicalAppointments', 'Clinical Appointments')} />
+      <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
       <div className={styles.calendarTitle}>
         <h3 className={styles.productiveHeading02}>{t('calendar', 'Calendar')}</h3>
         <Button renderIcon={ArrowRight} kind="ghost">

--- a/packages/esm-appointments-app/src/index.ts
+++ b/packages/esm-appointments-app/src/index.ts
@@ -1,4 +1,4 @@
-import { defineConfigSchema, getAsyncLifecycle, getSyncLifecycle } from '@openmrs/esm-framework';
+import { defineConfigSchema, getAsyncLifecycle, getSyncLifecycle, registerBreadcrumbs } from '@openmrs/esm-framework';
 import { configSchema } from './config-schema';
 import { createDashboardLink } from './createDashboardLink';
 import { clinicalAppointmentsDashboardMeta } from './dashboard.meta';
@@ -22,6 +22,19 @@ function setupOpenMRS() {
   };
 
   defineConfigSchema(moduleName, configSchema);
+
+  registerBreadcrumbs([
+    {
+      path: `${window.spaBase}/appointments`,
+      title: 'Appointments',
+      parent: `${window.spaBase}/home`,
+    },
+    {
+      path: `${window.spaBase}/appointments/calendar`,
+      title: 'Calendar',
+      parent: `${window.spaBase}/appointments`,
+    },
+  ]);
 
   return {
     pages: [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Currently the calendar screen in appointments has no way of navigating backwards to the main appointments screen. The only options would be pressing the back button on the browser. 

This PR adds breadcrumbs for easier navigation.

## Screenshots
<img width="1792" alt="Screenshot 2022-12-01 at 15 59 00" src="https://user-images.githubusercontent.com/15266028/205059001-89931d24-0d4a-46a4-8db9-4e722b26e7ea.png">

