### PR TITLE
(Cleanup) O3-1594: Closing patient chart always returns to home page

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -43,14 +43,12 @@ interface PaginationData {
 }
 interface NameLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
-  from: string;
 }
 
-const PatientNameLink: React.FC<NameLinkProps> = ({ from, to, children }) => {
+const PatientNameLink: React.FC<NameLinkProps> = ({ to, children }) => {
   const handleNameClick = (event: MouseEvent, to: string) => {
     event.preventDefault();
     navigate({ to });
-    localStorage.setItem('fromPage', from);
   };
   return (
     <a onClick={(e) => handleNameClick(e, to)} href={interpolateUrl(to)}>
@@ -69,7 +67,6 @@ const ActiveVisitsTable = () => {
   const [searchString, setSearchString] = useState('');
 
   const currentPathName = window.location.pathname;
-  const fromPage = getOriginFromPathName(currentPathName);
 
   const headerData = useMemo(
     () => [
@@ -190,7 +187,6 @@ const ActiveVisitsTable = () => {
                           <TableCell key={cell.id}>
                             {cell.info.header === 'name' ? (
                               <PatientNameLink
-                                from={fromPage}
                                 to={`\${openmrsSpaBase}/patient/${paginatedActiveVisits?.[index]?.patientUuid}/chart/`}>
                                 {cell.value}
                               </PatientNameLink>

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -44,11 +44,8 @@ import {
 import {
   useVisitQueueEntries,
   useServices,
-  QueueService,
-  QueueStatus,
   MappedVisitQueueEntry,
   MappedQueuePriority,
-  getOriginFromPathName,
 } from './active-visits-table.resource';
 import CurrentVisit from '../current-visit/current-visit-summary.component';
 import PatientSearch from '../patient-search/patient-search.component';
@@ -57,12 +54,7 @@ import styles from './active-visits-table.scss';
 import first from 'lodash-es/first';
 import { SearchTypes } from '../types';
 import ClearQueueEntries from '../clear-queue-entries-dialog/clear-queue-entries.component';
-import {
-  updateSelectedServiceName,
-  updateSelectedServiceUuid,
-  useSelectedServiceName,
-  useSelectedServiceUuid,
-} from '../helpers/helpers';
+import { updateSelectedServiceName, updateSelectedServiceUuid, useSelectedServiceName } from '../helpers/helpers';
 
 type FilterProps = {
   rowIds: Array<string>;
@@ -74,14 +66,12 @@ type FilterProps = {
 
 interface NameLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
-  from: string;
 }
 
-const PatientNameLink: React.FC<NameLinkProps> = ({ from, to, children }) => {
+const PatientNameLink: React.FC<NameLinkProps> = ({ to, children }) => {
   const handleNameClick = (event: MouseEvent, to: string) => {
     event.preventDefault();
     navigate({ to });
-    localStorage.setItem('fromPage', from);
   };
 
   return (
@@ -176,7 +166,6 @@ function ActiveVisitsTable() {
   const layout = useLayoutType();
 
   const currentPathName: string = window.location.pathname;
-  const fromPage: string = getOriginFromPathName(currentPathName);
 
   useEffect(() => {
     if (!userLocation && session?.sessionLocation !== null) {
@@ -260,9 +249,7 @@ function ActiveVisitsTable() {
       ...entry,
       name: {
         content: (
-          <PatientNameLink to={`\${openmrsSpaBase}/patient/${entry.patientUuid}/chart`} from={fromPage}>
-            {entry.name}
-          </PatientNameLink>
+          <PatientNameLink to={`\${openmrsSpaBase}/patient/${entry.patientUuid}/chart`}>{entry.name}</PatientNameLink>
         ),
       },
       priority: {

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
@@ -232,11 +232,6 @@ export function useVisitQueueEntries(currServiceName: string): UseVisitQueueEntr
   };
 }
 
-export const getOriginFromPathName = (pathname = '') => {
-  const from = pathname.split('/');
-  return last(from);
-};
-
 export async function updateQueueEntry(
   visitUuid: string,
   previousQueueUuid: string,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR is a cleanup for the ticket O3-1594, since the `fromPage` was added for the active visits table only, but with the work in https://github.com/openmrs/openmrs-esm-core/pull/579 and https://github.com/openmrs/openmrs-esm-patient-chart/pull/897, this is done in a more efficient way.


## Screenshots

*None.*

## Related Issue
https://issues.openmrs.org/browse/O3-1594

## Other

Dependent on https://github.com/openmrs/openmrs-esm-core/pull/579 and https://github.com/openmrs/openmrs-esm-patient-chart/pull/897