### PR TITLE
Possibility to display desired user keys by configuration

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -73,7 +73,7 @@ const ActiveVisitsTable = () => {
 
   const computeHeaderData = useCallback(
     (t, config) => {
-      let headers = [
+      const headers = [
         {
           id: 0,
           header: t('visitStartTime', 'Visit Time'),

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -71,7 +71,7 @@ const ActiveVisitsTable = () => {
   const currentPathName = window.location.pathname;
   const fromPage = getOriginFromPathName(currentPathName);
 
-  const computeExpensiveValue = useCallback(
+  const computeHeaderData = useCallback(
     (t, config) => {
       let headers = [
         {
@@ -120,53 +120,7 @@ const ActiveVisitsTable = () => {
     [activeVisits],
   );
 
-  const headerData = useMemo(() => computeExpensiveValue(t, config), [computeExpensiveValue, config, t]);
-  //   let headers = [
-  //     {
-  //       id: 0,
-  //       header: t('visitStartTime', 'Visit Time'),
-  //       key: 'visitStartTime',
-  //     },
-  //     {
-  //       id: 1,
-  //       header: t('idNumber', 'ID Number'),
-  //       key: 'idNumber',
-  //     },
-  //     {
-  //       id: 2,
-  //       header: t('name', 'Name'),
-  //       key: 'name',
-  //     },
-  //     {
-  //       id: 3,
-  //       header: t('gender', 'Gender'),
-  //       key: 'gender',
-  //     },
-  //     {
-  //       id: 4,
-  //       header: t('age', 'Age'),
-  //       key: 'age',
-  //     },
-  //     {
-  //       id: 5,
-  //       header: t('visitType', 'Visit Type'),
-  //       key: 'visitType',
-  //     },
-  //   ];
-
-  //   console.log('activeVisits', activeVisits);
-
-  //   config.identifiers.map((identifier) => {
-  //     headers.push({
-  //       id: identifier.id,
-  //       header: t(identifier.header.key, identifier.header.default),
-  //       key: identifier.header.key,
-  //     });
-  //   });
-
-  //   console.log('headers', headers);
-  //   return headers;
-  // };
+  const headerData = useMemo(() => computeHeaderData(t, config), [computeHeaderData, config, t]);
 
   const rowData = activeVisits.map((visit) => ({
     ...visit,

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -71,41 +71,102 @@ const ActiveVisitsTable = () => {
   const currentPathName = window.location.pathname;
   const fromPage = getOriginFromPathName(currentPathName);
 
-  const headerData = useMemo(
-    () => [
-      {
-        id: 0,
-        header: t('visitStartTime', 'Visit Time'),
-        key: 'visitStartTime',
-      },
-      {
-        id: 1,
-        header: t('idNumber', 'ID Number'),
-        key: 'idNumber',
-      },
-      {
-        id: 2,
-        header: t('name', 'Name'),
-        key: 'name',
-      },
-      {
-        id: 3,
-        header: t('gender', 'Gender'),
-        key: 'gender',
-      },
-      {
-        id: 4,
-        header: t('age', 'Age'),
-        key: 'age',
-      },
-      {
-        id: 5,
-        header: t('visitType', 'Visit Type'),
-        key: 'visitType',
-      },
-    ],
-    [t],
+  const computeExpensiveValue = useCallback(
+    (t, config) => {
+      let headers = [
+        {
+          id: 0,
+          header: t('visitStartTime', 'Visit Time'),
+          key: 'visitStartTime',
+        },
+      ];
+
+      config?.activeVisits?.identifiers?.map((identifier, index) => {
+        //this ensures that only identifiers that are present at least on one user are shown on the table headers
+        if (activeVisits.some((visit) => visit[identifier?.header?.key] !== '--')) {
+          headers.push({
+            id: index + 1,
+            header: t(identifier?.header?.key, identifier?.header?.default),
+            key: identifier?.header?.key,
+          });
+        }
+      });
+
+      headers.push(
+        {
+          id: headers[headers.length - 1].id + 2,
+          header: t('name', 'Name'),
+          key: 'name',
+        },
+        {
+          id: headers[headers.length - 1].id + 3,
+          header: t('gender', 'Gender'),
+          key: 'gender',
+        },
+        {
+          id: headers[headers.length - 1].id + 4,
+          header: t('age', 'Age'),
+          key: 'age',
+        },
+        {
+          id: headers[headers.length - 1].id + 5,
+          header: t('visitType', 'Visit Type'),
+          key: 'visitType',
+        },
+      );
+
+      return headers;
+    },
+    [activeVisits],
   );
+
+  const headerData = useMemo(() => computeExpensiveValue(t, config), [computeExpensiveValue, config, t]);
+  //   let headers = [
+  //     {
+  //       id: 0,
+  //       header: t('visitStartTime', 'Visit Time'),
+  //       key: 'visitStartTime',
+  //     },
+  //     {
+  //       id: 1,
+  //       header: t('idNumber', 'ID Number'),
+  //       key: 'idNumber',
+  //     },
+  //     {
+  //       id: 2,
+  //       header: t('name', 'Name'),
+  //       key: 'name',
+  //     },
+  //     {
+  //       id: 3,
+  //       header: t('gender', 'Gender'),
+  //       key: 'gender',
+  //     },
+  //     {
+  //       id: 4,
+  //       header: t('age', 'Age'),
+  //       key: 'age',
+  //     },
+  //     {
+  //       id: 5,
+  //       header: t('visitType', 'Visit Type'),
+  //       key: 'visitType',
+  //     },
+  //   ];
+
+  //   console.log('activeVisits', activeVisits);
+
+  //   config.identifiers.map((identifier) => {
+  //     headers.push({
+  //       id: identifier.id,
+  //       header: t(identifier.header.key, identifier.header.default),
+  //       key: identifier.header.key,
+  //     });
+  //   });
+
+  //   console.log('headers', headers);
+  //   return headers;
+  // };
 
   const rowData = activeVisits.map((visit) => ({
     ...visit,
@@ -140,7 +201,7 @@ const ActiveVisitsTable = () => {
     if (currentPage !== 1) {
       goTo(1);
     }
-  }, [searchString]);
+  }, [currentPage, goTo, searchString]);
 
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" />;

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -82,14 +82,11 @@ const ActiveVisitsTable = () => {
       ];
 
       config?.activeVisits?.identifiers?.map((identifier, index) => {
-        //this ensures that only identifiers that are present at least on one user are shown on the table headers
-        if (activeVisits.some((visit) => visit[identifier?.header?.key] !== '--')) {
-          headers.push({
-            id: index + 1,
-            header: t(identifier?.header?.key, identifier?.header?.default),
-            key: identifier?.header?.key,
-          });
-        }
+        headers.push({
+          id: index + 1,
+          header: t(identifier?.header?.key, identifier?.header?.default),
+          key: identifier?.header?.key,
+        });
       });
 
       headers.push(

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -89,6 +89,14 @@ const ActiveVisitsTable = () => {
         });
       });
 
+      config?.activeVisits?.attributes?.map((attribute, index) => {
+        headers.push({
+          id: index + config?.activeVisits?.identifiers.length + 1,
+          header: t(attribute?.header?.key, attribute?.header?.default),
+          key: attribute?.header?.key,
+        });
+      });
+
       headers.push(
         {
           id: headers[headers.length - 1].id + 2,

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -9,7 +9,6 @@ dayjs.extend(isToday);
 export interface ActiveVisit {
   age: string;
   id: string;
-  idNumber: string;
   gender: string;
   location: string;
   name: string;
@@ -44,7 +43,6 @@ export function useActiveVisits() {
     let activeVisits: ActiveVisit = {
       age: visit?.patient?.person?.age,
       id: visit.uuid,
-      idNumber: null,
       gender: visit?.patient?.person?.gender,
       location: visit?.location?.uuid,
       name: visit?.patient?.person?.display,
@@ -53,6 +51,19 @@ export function useActiveVisits() {
       visitType: visit?.visitType?.display,
       visitUuid: visit.uuid,
     };
+
+    //in case no configuration is given the previsous behavior remanes the same
+    if (!config?.activeVisits?.identifiers) {
+      config.activeVisits.identifiers = [
+        {
+          header: {
+            key: 'idNumber',
+            default: 'ID Number',
+          },
+          identifierName: visit?.patient?.identifiers[0].identifierType?.name,
+        },
+      ];
+    }
 
     //map identifires on config
     config?.activeVisits?.identifiers?.map((configIdentifier) => {
@@ -65,19 +76,14 @@ export function useActiveVisits() {
       });
 
       if (visitIdentifier) {
-        //if we find a visit identifier and its idNumber we rewrite the null value
-        if (configIdentifier?.header?.key === 'idNumber') {
-          activeVisits.idNumber = visitIdentifier?.identifier;
-        }
-        //else we add the new identifier to activeVisit object
-        //the parameter will conresponde to the name of the key value of the configuration
+        //add the new identifier or rewrite existing one to activeVisit object
+        //the parameter will corresponde to the name of the key value of the configuration
         //and the respective value is the visit identifier
-        else {
-          activeVisits = {
-            ...activeVisits,
-            [configIdentifier?.header?.key]: visitIdentifier?.identifier,
-          };
-        }
+
+        activeVisits = {
+          ...activeVisits,
+          [configIdentifier?.header?.key]: visitIdentifier?.identifier,
+        };
       } else {
         //If there isn't a identifier we display this default text
         activeVisits = {

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -2,7 +2,7 @@ import useSWR from 'swr';
 import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday';
 import last from 'lodash-es/last';
-import { openmrsFetch, Visit, useSession } from '@openmrs/esm-framework';
+import { openmrsFetch, Visit, useSession, useConfig } from '@openmrs/esm-framework';
 
 dayjs.extend(isToday);
 
@@ -17,15 +17,17 @@ export interface ActiveVisit {
   visitStartTime: string;
   visitType: string;
   visitUuid: string;
+  [identifier: string]: string;
 }
 
 export function useActiveVisits() {
+  const config = useConfig();
   const currentUserSession = useSession();
   const startDate = dayjs().format('YYYY-MM-DD');
   const sessionLocation = currentUserSession?.sessionLocation?.uuid;
 
   const customRepresentation =
-    'custom:(uuid,patient:(uuid,identifiers:(identifier,uuid),person:(age,display,gender,uuid)),' +
+    'custom:(uuid,patient:(uuid,identifiers:(identifier,uuid,identifierType:(name,uuid)),person:(age,display,gender,uuid)),' +
     'visitType:(uuid,name,display),location:(uuid,name,display),startDatetime,' +
     'stopDatetime)&fromStartDate=' +
     startDate +
@@ -37,18 +39,56 @@ export function useActiveVisits() {
     openmrsFetch,
   );
 
-  const mapVisitProperties = (visit: Visit): ActiveVisit => ({
-    age: visit?.patient?.person?.age,
-    id: visit.uuid,
-    idNumber: visit?.patient?.identifiers[0]?.identifier,
-    gender: visit?.patient?.person?.gender,
-    location: visit?.location?.uuid,
-    name: visit?.patient?.person?.display,
-    patientUuid: visit?.patient?.uuid,
-    visitStartTime: visit?.startDatetime,
-    visitType: visit?.visitType?.display,
-    visitUuid: visit.uuid,
-  });
+  const mapVisitProperties = (visit: Visit): ActiveVisit => {
+    //create base object
+    let activeVisits: ActiveVisit = {
+      age: visit?.patient?.person?.age,
+      id: visit.uuid,
+      idNumber: null,
+      gender: visit?.patient?.person?.gender,
+      location: visit?.location?.uuid,
+      name: visit?.patient?.person?.display,
+      patientUuid: visit?.patient?.uuid,
+      visitStartTime: visit?.startDatetime,
+      visitType: visit?.visitType?.display,
+      visitUuid: visit.uuid,
+    };
+
+    //map identifires on config
+    config?.activeVisits?.identifiers?.map((configIdentifier) => {
+      //check if in the current visit the patient has in his identifiers the current identifierType name
+      const visitIdentifier = visit?.patient?.identifiers.find((visitIdentifier) => {
+        if (visitIdentifier?.identifierType?.name === configIdentifier?.identifierName) {
+          return true;
+        }
+        return false;
+      });
+
+      if (visitIdentifier) {
+        //if we find a visit identifier and its idNumber we rewrite the null value
+        if (configIdentifier?.header?.key === 'idNumber') {
+          activeVisits.idNumber = visitIdentifier?.identifier;
+        }
+        //else we add the new identifier to activeVisit object
+        //the parameter will conresponde to the name of the key value of the configuration
+        //and the respective value is the visit identifier
+        else {
+          activeVisits = {
+            ...activeVisits,
+            [configIdentifier?.header?.key]: visitIdentifier?.identifier,
+          };
+        }
+      } else {
+        //If there isn't a identifier we display this default text
+        activeVisits = {
+          ...activeVisits,
+          [configIdentifier?.header?.key]: '--',
+        };
+      }
+    });
+
+    return activeVisits;
+  };
 
   const formattedActiveVisits = data?.data?.results.length
     ? data.data.results.map(mapVisitProperties).filter(({ visitStartTime }) => dayjs(visitStartTime).isToday())

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -26,7 +26,8 @@ export function useActiveVisits() {
   const sessionLocation = currentUserSession?.sessionLocation?.uuid;
 
   const customRepresentation =
-    'custom:(uuid,patient:(uuid,identifiers:(identifier,uuid,identifierType:(name,uuid)),person:(age,display,gender,uuid)),' +
+    'custom:(uuid,patient:(uuid,identifiers:(identifier,uuid,identifierType:(name,uuid)),' +
+    'person:(age,display,gender,uuid,attributes:(value,attributeType:(uuid,display)))),' +
     'visitType:(uuid,name,display),location:(uuid,name,display),startDatetime,' +
     'stopDatetime)&fromStartDate=' +
     startDate +
@@ -89,6 +90,32 @@ export function useActiveVisits() {
         activeVisits = {
           ...activeVisits,
           [configIdentifier?.header?.key]: '--',
+        };
+      }
+    });
+
+    //map attributes on config
+    config?.activeVisits?.attributes?.map(({ display, header }) => {
+      const personAttributes = visit?.patient?.person?.attributes.find((personAttributes) => {
+        if (personAttributes?.attributeType?.display === display) {
+          return true;
+        }
+        return false;
+      });
+
+      if (personAttributes) {
+        //add the new attribute or rewrite existing one to activeVisit object
+        //the parameter will corresponde to the name of the key value of the configuration
+        //and the respective value is the persons value
+        activeVisits = {
+          ...activeVisits,
+          [header?.key]: personAttributes?.value,
+        };
+      } else {
+        //If there isn't a attributes we display this default text
+        activeVisits = {
+          ...activeVisits,
+          [header?.key]: '--',
         };
       }
     });

--- a/packages/esm-active-visits-app/src/config-schema.ts
+++ b/packages/esm-active-visits-app/src/config-schema.ts
@@ -1,5 +1,22 @@
 import { Type } from '@openmrs/esm-framework';
 
+export interface SectionDefinition {
+  activeVisits: {
+    pageSize: Number;
+    pageSizes: Array<Number>;
+    identifiers: Array<IdentifiersDefinition>;
+  };
+}
+
+export interface IdentifiersDefinition {
+  id: Number;
+  header: {
+    key: string;
+    default: string;
+  };
+  identifierName: string;
+}
+
 export const configSchema = {
   activeVisits: {
     pageSize: {
@@ -11,6 +28,30 @@ export const configSchema = {
       _type: Type.Array,
       _description: 'Customizable page sizes that user can choose',
       _default: [10, 20, 50],
+    },
+    identifiers: {
+      _type: Type.Array,
+      _description: 'Customizable list of identifiers to display on active visits table',
+      _elements: {
+        header: {
+          key: {
+            _type: Type.String,
+            _default: null,
+            _description: 'Key to be used for translation purposes.',
+          },
+          default: {
+            _type: Type.String,
+            _default: null,
+            _description: 'Default text to be displayed if no translation is found.',
+          },
+        },
+        identifierName: {
+          _type: Type.String,
+          _default: null,
+          _description: 'Name of the desired identifier to filter data returned from the visit resource.',
+        },
+      },
+      _default: null,
     },
   },
 };

--- a/packages/esm-active-visits-app/translations/en.json
+++ b/packages/esm-active-visits-app/translations/en.json
@@ -7,7 +7,6 @@
   "encounterType": "Encounter Type",
   "filterTable": "Filter table",
   "gender": "Gender",
-  "idNumber": "ID Number",
   "medications": "Medications",
   "name": "Name",
   "noActiveVisitsForLocation": "There are no active visits to display for this location.",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
In Active visits, we now have the possibility to display multiple user keys through the configuration. 

The configuration contemplates the structure to add the desired header and respective key of the field.
The keys are programmed to be displayed between the visit time and the user's name, if no configuration is provided the widget will behave normally.

## Screenshots
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/106243905/209830774-6a20f366-b038-49cc-bb13-370b2121dcc4.png">

Where the black boxes are there should be the respective keys.
