### PR TITLE
(test) Fix tests failing due to inconsistent whitespace

### DIFF
--- a/packages/esm-outpatient-app/src/queue-patient-linelists/queue-linelist-base-table.test.tsx
+++ b/packages/esm-outpatient-app/src/queue-patient-linelists/queue-linelist-base-table.test.tsx
@@ -87,10 +87,10 @@ describe('QueuePatientBaseTable: ', () => {
     });
 
     const expectedTableRows = [
-      /john wilson 08 — Oct — 1632, 12:00 AM M 35 walkin 0700000000/,
-      /charles babbage 13 — Jul — 1635, 12:00 AM M 35 walkIn 0700000001/,
-      /neil amstrong 21 — May — 1633, 12:00 AM M 35 walkIn 0700000002/,
-      /elon musketeer 27 — Jan — 1636, 12:00 AM M 35 walkIn 0700000000/,
+      /john wilson 08 — Oct — 1632, 12:00\s+AM M 35 walkin 0700000000/,
+      /charles babbage 13 — Jul — 1635, 12:00\s+AM M 35 walkIn 0700000001/,
+      /neil amstrong 21 — May — 1633, 12:00\s+AM M 35 walkIn 0700000002/,
+      /elon musketeer 27 — Jan — 1636, 12:00\s+AM M 35 walkIn 0700000000/,
     ];
 
     expectedTableRows.forEach((row) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Following on from https://github.com/openmrs/openmrs-esm-patient-chart/pull/934, this PR fixes an unusual regression on my system involving the formatDateTime helper function. More specifically, an assertion that checked for the existence of whitespace between a timestamp and the meridian indicator (i.e. AM / PM) fails to recognize literal whitespace and expects non-breaking whitespace instead. 

It's entirely likely that this regression is due to some weird quirk on my setup but nonetheless, the fix I've provided is compatible with setups experiencing this issue as well as those that are not.

## Screenshots

> Test failure

<img width="642" alt="Screenshot 2023-01-12 at 14 03 10" src="https://user-images.githubusercontent.com/8509731/212050519-4358e351-840a-48cf-9197-68206db301ae.png">

> A row with the expected content clearly exists:

<img width="632" alt="Screenshot 2023-01-12 at 14 03 37" src="https://user-images.githubusercontent.com/8509731/212050655-2bc075d5-2094-46cf-8c31-6f397ea1eb9f.png">

