### PR TITLE
(chore) O3-1720: Changing the 'searchByAddressLevel' to false

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -264,7 +264,7 @@ export const esmPatientRegistrationSchema = {
           _type: Type.Boolean,
           _description:
             "Whether to fill the addresses by levels, i.e. County => subCounty, the current field is dependent on it's previous field.",
-          _default: true,
+          _default: false,
         },
         useAddressHierarchyLabel: {
           _type: Type.Object,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR changes the 'searchAddressByLevel' to false in the address hierarchy, since it blocks the users to fill addresses which is not present in this [file](https://github.com/openmrs/openmrs-distro-referenceapplication/blob/main/distro/configuration/addresshierarchy/addresshierarchy.csv)

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

https://issues.openmrs.org/browse/O3-1720

## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
