### PR TITLE
(fix) Bug fix on launching overlay when queue is not empty

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -350,7 +350,25 @@ function ActiveVisitsTable() {
         </div>
         <div className={styles.headerContainer}>
           <span className={styles.heading}>{t('patientsCurrentlyInQueue', 'Patients currently in queue')}</span>
-          <div className={styles.headerButtons}></div>
+          <div className={styles.headerButtons}>
+            <ExtensionSlot
+              extensionSlotName="patient-search-button-slot"
+              state={{
+                buttonText: t('addPatientToQueue', 'Add patient to queue'),
+                overlayHeader: t('addPatientToQueue', 'Add patient to queue'),
+                buttonProps: {
+                  kind: 'secondary',
+                  renderIcon: (props) => <Add size={16} {...props} />,
+                  size: 'sm',
+                },
+                selectPatientAction: (selectedPatientUuid) => {
+                  setShowOverlay(true);
+                  setView(SearchTypes.SCHEDULED_VISITS);
+                  setViewState({ selectedPatientUuid });
+                },
+              }}
+            />
+          </div>
         </div>
         <DataTable
           data-floating-menu-container
@@ -385,18 +403,6 @@ function ActiveVisitsTable() {
                       size="sm"
                     />
                   </Layer>
-                  <Button
-                    size="sm"
-                    kind="secondary"
-                    className={styles.addPatientToListBtn}
-                    renderIcon={(props) => <Add size={16} {...props} />}
-                    onClick={() => {
-                      setShowOverlay(true);
-                      setView('');
-                    }}
-                    iconDescription={t('addPatientToQueue', 'Add patient to queue')}>
-                    {t('addPatientToQueue', 'Add patient to queue')}
-                  </Button>
                   <ClearQueueEntries visitQueueEntries={visitQueueEntries} />
                 </TableToolbarContent>
               </TableToolbar>
@@ -481,7 +487,7 @@ function ActiveVisitsTable() {
             view={view}
             closePanel={() => setShowOverlay(false)}
             viewState={{
-              selectedPatientUuid: '',
+              selectedPatientUuid: viewState.selectedPatientUuid,
             }}
           />
         )}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Bug fix on opening service queue overlay, does not launch search but visit form

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
https://user-images.githubusercontent.com/19533785/213694361-4c4a10a6-3726-420d-afa2-99500f785337.mp4

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
