### PR TITLE
(test) O3-1813: Fix testOnPush job in our CI e2e suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
 
+      - name: Run dev server
+        run: yarn start &
+
       - name: Run E2E tests
         run: yarn playwright test --project=chromium
 
@@ -72,7 +75,7 @@ jobs:
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:9000/openmrs/login.htm)" != "200" ]]; do sleep 10; done
       
       - name: Run dev server
-        run: yarn start --backend "http://localhost:9000"
+        run: yarn start --backend "http://localhost:9000" &
     
       - name: Run E2E tests
         run: yarn playwright test

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,12 +14,6 @@ const config: PlaywrightTestConfig = {
   retries: process.env.CI ? 2 : 1,
   reporter: 'html',
   globalSetup: require.resolve('./e2e/core/global-setup'),
-  webServer: {
-    command: 'yarn start',
-    url: process.env.E2E_UI_BASE_URL,
-    timeout: 120 * 1000,
-    reuseExistingServer: !process.env.CI,
-  },
   use: {
     baseURL: process.env.E2E_UI_BASE_URL,
     storageState: 'e2e/storageState.json',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Removed the `webServer` configuration from the playwright test configuration
Update the workflow to run the dev servers in detached mode

## Screenshots

**Tested the testOnPR job:**
<img width="1678" alt="Screenshot 2023-01-24 at 22 26 04" src="https://user-images.githubusercontent.com/27498587/214359280-cb09223b-22e1-4173-bfa6-13d829e03f8c.png">


**Tested the testOnPush job:**
<img width="1678" alt="Screenshot 2023-01-24 at 22 25 10" src="https://user-images.githubusercontent.com/27498587/214359415-e971c20f-6671-4096-81a0-63bb6fa3d4d8.png">


## Related Issue
https://issues.openmrs.org/browse/O3-1813


## Other
The docker openmrs instance usually takes around 16 minutes to start.
