### PR TITLE
(fix) Show service and add patient to queue button when queue is empty

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -424,11 +424,48 @@ function ActiveVisitsTable() {
 
   return (
     <div className={styles.container}>
-      <div className={styles.headerContainer}>
-        <div className={!isDesktop(layout) ? styles.tabletHeading : styles.desktopHeading}>
-          <h4>{t('patientsCurrentlyInQueue', 'Patients currently in queue')}</h4>
-        </div>
-      </div>
+      {useQueueTableTabs === false ? (
+        <>
+          <div className={styles.headerBtnContainer}>
+            <Button
+              size="sm"
+              kind="ghost"
+              renderIcon={(props) => <ArrowRight size={16} {...props} />}
+              onClick={(selectedPatientUuid) => {
+                setShowOverlay(true);
+                setView(SearchTypes.QUEUE_SERVICE_FORM);
+                setViewState({ selectedPatientUuid });
+              }}
+              iconDescription={t('addNewQueue', 'Add new queue')}>
+              {t('addNewService', 'Add new service')}
+            </Button>
+          </div>
+          <div className={styles.headerContainer}>
+            <div className={!isDesktop(layout) ? styles.tabletHeading : styles.desktopHeading}>
+              <h4>{t('patientsCurrentlyInQueue', 'Patients currently in queue')}</h4>
+            </div>
+            <div className={styles.headerButtons}>
+              <ExtensionSlot
+                extensionSlotName="patient-search-button-slot"
+                state={{
+                  buttonText: t('addPatientToQueue', 'Add patient to queue'),
+                  overlayHeader: t('addPatientToQueue', 'Add patient to queue'),
+                  buttonProps: {
+                    kind: 'secondary',
+                    renderIcon: (props) => <Add size={16} {...props} />,
+                    size: 'sm',
+                  },
+                  selectPatientAction: (selectedPatientUuid) => {
+                    setShowOverlay(true);
+                    setView(SearchTypes.SCHEDULED_VISITS);
+                    setViewState({ selectedPatientUuid });
+                  },
+                }}
+              />
+            </div>
+          </div>
+        </>
+      ) : null}
       <div className={styles.tileContainer}>
         <Tile className={styles.tile}>
           <p className={styles.content}>{t('noPatientsToDisplay', 'No patients to display')}</p>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Show service and add patient to queue button when queue is empty

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="810" alt="test1" src="https://user-images.githubusercontent.com/19533785/214818216-1c6a5fd5-6c05-408c-a442-421937814949.PNG">
<img width="800" alt="test2" src="https://user-images.githubusercontent.com/19533785/214818228-ffae10f0-f067-4a36-8022-5ab990cf8227.PNG">


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
