### PR TITLE
(fix) O3-1668 & O3-1724: Fixed the re-focus to search input when entering different fields 

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
@@ -65,13 +65,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
     inputRef.current.focus();
   }, [inputRef]);
 
-  const focussedResult = useArrowNavigation(
-    inputRef,
-    patients?.length ?? 0,
-    handlePatientSelection,
-    handleFocusToInput,
-    -1,
-  );
+  const focussedResult = useArrowNavigation(patients?.length ?? 0, handlePatientSelection, handleFocusToInput, -1);
 
   useEffect(() => {
     if (bannerContainerRef.current && focussedResult > -1) {

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -58,13 +58,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
     },
     [config.search, selectPatientAction, patients, handleCloseSearchResults],
   );
-  const focussedResult = useArrowNavigation(
-    inputRef,
-    patients?.length ?? 0,
-    handlePatientSelection,
-    handleFocusToInput,
-    -1,
-  );
+  const focussedResult = useArrowNavigation(patients?.length ?? 0, handlePatientSelection, handleFocusToInput, -1);
 
   useEffect(() => {
     if (bannerContainerRef.current && focussedResult > -1) {

--- a/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
+++ b/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
@@ -24,6 +24,8 @@ const useArrowNavigation = (
       } else if (focussedResult !== -1) {
         // This condition will be met when scrolling through the list, the user presses another
         // key, then the user should be focussed to the input.
+        // The focus to input should only be called when the user is scrolling through the list
+        // Hence the if condition
         resetFocusCallback();
         setFocussedResult(initalFocussedResult);
       }

--- a/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
+++ b/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 
 const useArrowNavigation = (
-  inputRef: React.MutableRefObject<HTMLInputElement>,
   totalResults: number,
   enterCallback: (evt: any, index: number) => void,
   resetFocusCallback: () => void,
@@ -30,15 +29,7 @@ const useArrowNavigation = (
         setFocussedResult(initalFocussedResult);
       }
     },
-    [
-      setFocussedResult,
-      totalResults,
-      focussedResult,
-      enterCallback,
-      initalFocussedResult,
-      inputRef,
-      resetFocusCallback,
-    ],
+    [setFocussedResult, totalResults, focussedResult, enterCallback, initalFocussedResult, resetFocusCallback],
   );
 
   useEffect(() => {

--- a/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
+++ b/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
@@ -12,12 +12,16 @@ const useArrowNavigation = (
   const handleKeyPress = useCallback(
     (e) => {
       if (e.key === 'ArrowUp') {
-        setFocussedResult((prev) => Math.max(-1, prev - 1));
+        const newFocussedResult = Math.max(-1, focussedResult - 1);
+        setFocussedResult(newFocussedResult);
+        if (newFocussedResult === -1) {
+          resetFocusCallback();
+        }
       } else if (e.key === 'ArrowDown') {
         setFocussedResult((prev) => Math.min(totalResults - 1, prev + 1));
       } else if (e.key === 'Enter' && focussedResult > -1) {
         enterCallback(e, focussedResult);
-      } else if (document.activeElement !== inputRef.current) {
+      } else if (focussedResult !== -1) {
         resetFocusCallback();
         setFocussedResult(initalFocussedResult);
       }

--- a/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
+++ b/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
@@ -22,6 +22,8 @@ const useArrowNavigation = (
       } else if (e.key === 'Enter' && focussedResult > -1) {
         enterCallback(e, focussedResult);
       } else if (focussedResult !== -1) {
+        // This condition will be met when scrolling through the list, the user presses another
+        // key, then the user should be focussed to the input.
         resetFocusCallback();
         setFocussedResult(initalFocussedResult);
       }

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
@@ -46,7 +46,7 @@ const PatientSearchComponent: React.FC<PatientSearchComponentProps> = ({
 
   useEffect(() => {
     goTo(1);
-  }, [query]);
+  }, [query, goTo]);
 
   const handlePatientSelection = useCallback(
     (evt, patientUuid: string) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR introduces the fix to the re-focus to the patient search input when filling other input fields on the same page.

## Screenshots

### Issue
https://user-images.githubusercontent.com/51502471/216061238-d3862c6c-13fd-4377-bf30-5405a8b4c732.mov

## Related Issue
https://issues.openmrs.org/browse/O3-1668
https://issues.openmrs.org/browse/O3-1724

## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
