### PR TITLE
(enhancement): Add ability to use configurable labels on address hierarchy inputs

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.component.tsx
@@ -71,6 +71,7 @@ export const AddressHierarchy: React.FC = () => {
         id: name,
         name,
         value,
+        label,
       };
     });
     setAddressLayout(propertiesObj);
@@ -101,11 +102,7 @@ export const AddressHierarchy: React.FC = () => {
                   key={`combo_input_${index}`}
                   textFieldName={attributes.name}
                   name={`address.${attributes.name}`}
-                  labelText={
-                    isEmpty(config.fieldConfigurations.address.useAddressHierarchy.useAddressHierarchyLabel)
-                      ? t(attributes.name)
-                      : config.fieldConfigurations.address.useAddressHierarchy.useAddressHierarchyLabel[attributes.name]
-                  }
+                  labelText={t(attributes.label)}
                   id={attributes.name}
                   setSelectedValue={setSelectedValue}
                   selected={selected}
@@ -114,7 +111,7 @@ export const AddressHierarchy: React.FC = () => {
                 <Input
                   key={`combo_input_${index}`}
                   name={`address.${attributes.name}`}
-                  labelText={t(attributes.name)}
+                  labelText={t(attributes.label)}
                   id={attributes.name}
                   setSelectedValue={setSelectedValue}
                   selected={selected}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Add the ability to use config provided label on the Address hierarchy as shown in the screenshot


## Screenshots
![Screenshot 2023-01-31 at 4 04 11 PM](https://user-images.githubusercontent.com/28008754/215767579-700bdddb-d94b-4184-8394-121f48f5feae.png)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
