### PR TITLE
03-1632:Fix Search fields in the application to have an orange outline

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
@@ -7,11 +7,11 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  border: 1px solid $ui-04;
+  border: 1px solid #fdae1b;
 }
 
 .patientSearchInput {
-  border: none;
+  border: 1px solid #fdae1b;
 }
 
 .patientSearchInput input:focus {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
As per the designs in the Zeplin, we have an orange outline for search fields. By default, the search shows the default Carbon outline for the Search fields. We needed to change this according to zeplin style

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

![Screenshot from 2023-02-07 20-07-26-1](https://user-images.githubusercontent.com/78595738/217460367-4b98a1bd-a3f0-4376-a8b6-b3a7702f1115.png)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-1632

<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
