### PR TITLE
feat: add ability to view specified identifier Types on compact patient search

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
@@ -59,3 +59,12 @@
 .middot {
   margin: 0 spacing.$spacing-03;
 }
+
+.configuredTag {
+  margin: spacing.$spacing-01;
+}
+
+.configuredLabel {
+  @include type.type-style('label-01');
+  color: $ui-05;
+}

--- a/packages/esm-patient-search-app/src/config-schema.ts
+++ b/packages/esm-patient-search-app/src/config-schema.ts
@@ -31,4 +31,20 @@ export const configSchema = {
       'e3d177ee-04ad-11ed-828d-0242ac1e0002',
     ],
   },
+  defaultIdentifierTypes: {
+    _type: Type.Array,
+    _element: {
+      _type: Type.String,
+    },
+    _description: 'The identifier types to be display on all patient search result page',
+    _default: ['b4d66522-11fc-45c7-83e3-39a1af21ae0d', 'f85081e2-b4be-4e48-b3a4-7994b69bb101'],
+  },
+  defaultIdentifier: {
+    _type: Type.String,
+    _elements: {
+      _type: Type.String,
+    },
+    _description: 'Identifier to be shown in the event defaultIdentifierTypes does is empty',
+    _default: 'OpenMRS ID',
+  },
 };

--- a/packages/esm-patient-search-app/src/types/index.ts
+++ b/packages/esm-patient-search-app/src/types/index.ts
@@ -1,7 +1,7 @@
-import { FetchResponse } from '@openmrs/esm-framework';
+import { FetchResponse, OpenmrsResource } from '@openmrs/esm-framework';
 export interface SearchedPatient {
   uuid: string;
-  identifiers: Array<{ identifier: string }>;
+  identifiers: Array<Identifier>;
   person: {
     addresses: Array<Address>;
     age: number;
@@ -17,6 +17,14 @@ export interface SearchedPatient {
     };
   };
   attributes: Array<{ value: string; attributeType: { uuid: string; display: string } }>;
+}
+
+export interface Identifier {
+  display: string;
+  identifier: string;
+  identifierType: OpenmrsResource;
+  location: OpenmrsResource;
+  uuid: string;
 }
 export interface Address {
   preferred: boolean;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Add ability to configure which identifiers users can view when performing patient search on compact patient search results. This is a result of user feedback not keen on seeing all identifier information


## Screenshots
![Peek 2023-02-10 13-57](https://user-images.githubusercontent.com/28008754/218076560-e4dda471-c34a-4735-b14b-58579c5e3fde.gif)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
