### PR TITLE
(fix) O3-1839: Address field resetting values on patient registration form

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -78,21 +78,8 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
       if (!addressTemplateXml) {
         return;
       }
-      const { addressFieldValues, addressValidationSchema } = parseAddressTemplateXml(addressTemplateXml);
+      const { addressValidationSchema } = parseAddressTemplateXml(addressTemplateXml);
       setValidationSchema((validationSchema) => validationSchema.concat(addressValidationSchema));
-      // `=== false` is here on purpose (`inEditMode` can be null).
-      // We *only* want to set initial address field values when *creating* a patient.
-      // We must wait until after loading for this info.
-      if (inEditMode === false) {
-        for (const { name, defaultValue } of addressFieldValues) {
-          if (!initialAddressFieldValues[name]) {
-            initialAddressFieldValues[name] = defaultValue;
-          }
-        }
-        fieldDefinition?.map((field) => (initialAddressFieldValues[field.id] = ''));
-
-        setInitialFormValues({ ...initialFormValues, ...initialAddressFieldValues });
-      }
     }
   }, [inEditMode, addressTemplate, initialAddressFieldValues]);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes the resetting of patient registration form when address fields are loaded. 

The fix is to remove setting the address field's initial values when address fields are loaded. Address fields are fetched from the backend and hence it takes time to come on the form.

Setting the initial value is taken care by the address component itself, and there's no requirement of setting the fields in the patient registration component.

## Screenshots

*None.*


## Related Issue

https://issues.openmrs.org/browse/O3-1839

## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
