### PR TITLE
(fix) O3-1872: Fix the translation interpolation issue in the empty text illustration

### DIFF
--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -55,7 +55,7 @@
   "editAppointment": "Edit Appointment",
   "editAppointments": "Edit Appointment",
   "emergency": "Emergency",
-  "emptyStateText": "There are no {displayText.toLowerCase()} to display",
+  "emptyStateText": "There are no {{displayText}} to display",
   "encounters": "Encounters",
   "encounterType": "Encounter type",
   "endTime": "End Time",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Fixed the syntax issue in the `en.json` translation file

## Screenshots

<img width="1412" alt="image" src="https://user-images.githubusercontent.com/43912578/219276117-a42a0a8b-1dc6-463a-a86e-2d09b93d4b16.png">

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/43912578/219276155-e66f5aba-d0c7-4317-98ce-2e52ac6697ae.png">

## Related Issue

https://issues.openmrs.org/browse/O3-1872


