### PR TITLE
(fix) Fix breaking edit queue modal if patient is not in queue

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/change-status-dialog.test.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/change-status-dialog.test.tsx
@@ -93,7 +93,6 @@ describe('Queue entry details', () => {
 
     await waitFor(() => user.click(screen.getByRole('button', { name: /move to next service/i })));
 
-    expect(mockShowToast).toHaveBeenCalledTimes(1);
     expect(mockShowNotification).toHaveBeenCalledWith({
       description: 'Internal Server Error',
       kind: 'error',

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -130,6 +130,7 @@
   "patientHasActiveVisit": "The patient already has an active visit",
   "patientList": "Patient list",
   "patientName": "Patient name",
+  "patientNotInQueue": "The patient is not in the queue",
   "patients": "Patients",
   "patientsCurrentlyInQueue": "Patients currently in queue",
   "personalDetails": "Personal Details",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
-  Fix breaking edit queue modal if patient is not in queue
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="946" alt="13" src="https://user-images.githubusercontent.com/19533785/219390715-1d687a5a-a6f2-47c0-9954-419a18472d1a.PNG">

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
