### PR TITLE
(fix) Side rail and bottom nav UI fixes

### DIFF
--- a/packages/esm-patient-list-app/src/index.ts
+++ b/packages/esm-patient-list-app/src/index.ts
@@ -66,7 +66,7 @@ function setupOpenMRS() {
       },
       {
         name: 'patient-list-action-menu',
-        slot: 'action-menu-items-slot',
+        slot: 'action-menu-non-chart-items-slot',
         load: getAsyncLifecycle(() => import('./patient-list-action-button.component'), {
           featureName: 'patient-list-action-menu-item',
           moduleName,

--- a/packages/esm-patient-list-app/src/patient-list-action-button.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-action-button.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
-import { ListBulleted } from '@carbon/react/icons';
+import { Events } from '@carbon/react/icons';
 import { navigate, useLayoutType } from '@openmrs/esm-framework';
 import styles from './patient-list-action-button.scss';
 
@@ -14,21 +14,24 @@ const PatientListActionButton: React.FC = () => {
   if (layout === 'tablet') {
     return (
       <Button kind="ghost" className={styles.container} role="button" tabIndex={0} onClick={navigateToPatientList}>
-        <ListBulleted size={20} />
-        <span>{t('patientList', 'Patient list')}</span>
+        <Events size={16} />
+        <span>{t('patientLists', 'Patient lists')}</span>
       </Button>
     );
   }
+
   return (
     <Button
       className={styles.container}
       onClick={navigateToPatientList}
       kind="ghost"
-      renderIcon={(props) => <ListBulleted {...props} />}
+      renderIcon={(props) => <Events size={20} {...props} />}
       hasIconOnly
-      iconDescription={t('patientList', 'Patient list')}
-      tooltipAlignment="end"
-      tooltipPosition="bottom"
+      iconDescription={t('patientLists', 'Patient lists')}
+      enterDelayMs={1000}
+      tooltipAlignment="center"
+      tooltipPosition="left"
+      size="sm"
     />
   );
 };

--- a/packages/esm-patient-list-app/src/patient-list-action-button.scss
+++ b/packages/esm-patient-list-app/src/patient-list-action-button.scss
@@ -59,5 +59,9 @@
       color: $interactive-01;
       @include type.type-style('heading-compact-01');
     }
+
+    svg {
+      fill: $interactive-01;
+    }
   }
 }

--- a/packages/esm-patient-list-app/translations/en.json
+++ b/packages/esm-patient-list-app/translations/en.json
@@ -31,7 +31,6 @@
   "noPatientListFound": "No patient list found",
   "offlinePatients": "Offline patients",
   "openPatientList": "Add to list",
-  "patientList": "Patient list",
   "patientListAppMenuLink": "Patient Lists",
   "patientLists": "Patient Lists",
   "patients": "patients",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Provides a bunch of style fixes that get the side rail and the bottom nav in line with the available [designs](https://zeroheight.com/23a080e38/p/948cf1-siderail-and-bottom-nav/t/403f5f). More specifically, this change set gets the patient list action button in line with the rest of the action buttons.

## Video

https://user-images.githubusercontent.com/8509731/219490229-3cdd3a74-b877-4ad4-9c1f-efc7df966fa4.mp4