### PR TITLE
(fix) Remove redundant styling for search fields

### DIFF
--- a/packages/esm-outpatient-app/src/patient-search/basic-search.scss
+++ b/packages/esm-outpatient-app/src/patient-search/basic-search.scss
@@ -12,13 +12,6 @@
   flex-grow: 1;
 }
 
-.searchInput {
-  input:focus {
-    outline: none;
-    border: spacing.$spacing-01 solid var(--omrs-color-brand-orange);
-  }
-}
-
 .tileContainer {
   :global(.omrs-breakpoint-gt-tablet) & {
     margin: 0 1.5rem 0;

--- a/packages/esm-patient-search-app/src/compact-patient-search-extension/compact-patient-search.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search-extension/compact-patient-search.scss
@@ -29,7 +29,3 @@
 .patientSearchInput {
   border: none;
 }
-
-.patientSearchInput input:focus {
-  outline: 1px solid 1px solid colors.$orange-40;
-}

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
@@ -13,7 +13,3 @@
 .patientSearchInput {
   border: none;
 }
-
-.patientSearchInput input:focus {
-  outline: 1px solid 1px solid colors.$orange-40;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Custom styling for search fields on focus is no longer required following https://github.com/openmrs/openmrs-esm-core/pull/607. This PR removes existing custom styling.