### PR TITLE
(fix) O3-1882: Update installation instructions in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This monorepo uses [yarn](https://yarnpkg.com) and [lerna](https://github.com/le
 
 To install the dependancies, run:
 ```bash
-npx lerna bootstrap
+yarn install
 ```
 
 To set up environment variables for the project, follow these steps:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR updates the README file in this repository to resolve an issue with the "npx learna bootstrap" command. Currently, running this command results in an error that reads: "Unknown Syntax Error: Unsupported option name ("--mutex")." To fix this issue, I removed the "npx learna bootstrap" command and replaced it with "yarn install" instead.
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-1882
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
