### PR TITLE
(fix) O3-1918: Coded person attributes not saved when saving a patient

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.component.tsx
@@ -4,6 +4,8 @@ import { Input } from '../../input/basic-input/input/input.component';
 import { PersonAttributeTypeResponse } from '../../patient-registration-types';
 import { useConceptAnswers } from '../field.resource';
 import styles from './../field.scss';
+import { useTranslation } from 'react-i18next';
+import { Field } from 'formik';
 
 export interface CodedPersonAttributeFieldProps {
   personAttributeType: PersonAttributeTypeResponse;
@@ -17,27 +19,45 @@ export function CodedPersonAttributeField({
   label,
 }: CodedPersonAttributeFieldProps) {
   const { data: conceptAnswers, isLoading: isLoadingConceptAnswers } = useConceptAnswers(answerConceptSetUuid);
+  const { t } = useTranslation();
+  const fieldName = `attributes.${personAttributeType.uuid}`;
 
   return (
     <div className={`${styles.customField} ${styles.halfWidthInDesktopView}`}>
       {!isLoadingConceptAnswers && conceptAnswers?.length ? (
         <Layer>
-          <Select
-            id={`person-attribute-${personAttributeType.uuid}`}
-            name={`attributes.${personAttributeType.uuid}`}
-            labelText={label ?? personAttributeType?.display}>
-            <SelectItem value="" text="" />
-            {conceptAnswers.map((answer) => (
-              <SelectItem key={answer.uuid} value={answer.uuid} text={answer.display} />
-            ))}
-          </Select>
+          <Field name={fieldName}>
+            {({ field, form: { touched, errors }, meta }) => {
+              return (
+                <Select
+                  id={`person-attribute-${personAttributeType.uuid}`}
+                  labelText={label ?? personAttributeType?.display}
+                  invalid={errors[fieldName] && touched[fieldName]}
+                  {...field}>
+                  <SelectItem value={null} text={t('selectAnOption', 'Select an option')} />
+                  {conceptAnswers.map((answer) => (
+                    <SelectItem key={answer.uuid} value={answer.uuid} text={answer.display} />
+                  ))}
+                </Select>
+              );
+            }}
+          </Field>
         </Layer>
       ) : (
-        <Input
-          id={`person-attribute-${personAttributeType.uuid}`}
-          labelText={label ?? personAttributeType?.display}
-          name={`attributes.${personAttributeType.uuid}`}
-        />
+        <Layer>
+          <Field name={fieldName}>
+            {({ field, form: { touched, errors }, meta }) => {
+              return (
+                <Input
+                  id={`person-attribute-${personAttributeType.uuid}`}
+                  labelText={label ?? personAttributeType?.display}
+                  invalid={errors[fieldName] && touched[fieldName]}
+                  {...field}
+                />
+              );
+            }}
+          </Field>
+        </Layer>
       )}
     </div>
   );

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
@@ -97,7 +97,10 @@ export function useInitialFormValues(patientUuid: string): [FormValues, Dispatch
     if (!isLoadingAttributes && attributes) {
       let personAttributes = {};
       attributes.forEach((attribute) => {
-        personAttributes[attribute.attributeType.uuid] = attribute.value;
+        personAttributes[attribute.attributeType.uuid] =
+          attribute.attributeType.format === 'org.openmrs.Concept' && typeof attribute.value === 'object'
+            ? attribute.value?.uuid
+            : attribute.value;
       });
       setInitialFormValues((initialFormValues) => ({
         ...initialFormValues,
@@ -199,7 +202,9 @@ export function useInitialPatientIdentifiers(patientUuid: string): {
 function useInitialPersonAttributes(personUuid: string) {
   const shouldFetch = !!personUuid;
   const { data, error, isLoading } = useSWR<FetchResponse<{ results: Array<PersonAttributeResponse> }>, Error>(
-    shouldFetch ? `/ws/rest/v1/person/${personUuid}/attribute` : null,
+    shouldFetch
+      ? `/ws/rest/v1/person/${personUuid}/attribute?v=custom:(uuid,display,attributeType:(uuid,display,format),value)`
+      : null,
     openmrsFetch,
   );
   const result = useMemo(() => {

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-types.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-types.tsx
@@ -235,10 +235,16 @@ export interface PersonAttributeTypeResponse {
 export interface PersonAttributeResponse {
   display: string;
   uuid: string;
-  value: string;
+  value:
+    | string
+    | {
+        uuid: string;
+        display: string;
+      };
   attributeType: {
     display: string;
     uuid: string;
+    format: 'org.openmrs.Concept' | string;
   };
 }
 

--- a/packages/esm-patient-registration-app/translations/en.json
+++ b/packages/esm-patient-registration-app/translations/en.json
@@ -79,6 +79,7 @@
   "resetIdentifierTooltip": "Reset",
   "restoreRelationshipActionButton": "Undo",
   "searchAddress": "Search address",
+  "selectAnOption": "Select an option",
   "sexFieldLabelText": "Sex",
   "stateProvince": "State",
   "stroke": "Stroke",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
The coded person attributes were not being saved with a patient when saving the patient, and hence when editing a patient, they were not reflected in the form either. This PR introduces the fix to save and to fetch the coded person attributes when saving and editing a patient respectively.


## Screenshots
*None.*


## Related Issue
https://issues.openmrs.org/projects/O3/issues/O3-1918
Thread [here](https://openmrs.slack.com/archives/CHP5QAE5R/p1677001375170889)
Reported by @kazlaw


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
