### PR TITLE
(fix) O3-1929: Increase the timeout in GitHub e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   testOnPR:
     if: ${{ github.event_name == 'pull_request' }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-        
+
       - name: Install dependencies
         run: yarn
 
@@ -55,28 +55,28 @@ jobs:
       - name: Copy test environment variables
         run: cp example.env .env
 
-      - name: Setup node 
+      - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: 16
-     
+
       - name: Install dependencies
         run: yarn
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      
+
       - name: Run db and web containers
         run: |
           cd e2e/support
           docker-compose up -d
-    
+
       - name: Wait for OpenMRS instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:9000/openmrs/login.htm)" != "200" ]]; do sleep 10; done
-      
+
       - name: Run dev server
         run: yarn start --backend "http://localhost:9000" &
-    
+
       - name: Run E2E tests
         run: yarn playwright test
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Increase the timeout in github e2e tests
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-1929
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
