### PR TITLE
(fix) O3-1930: Add timeout in edit patient e2e test

### DIFF
--- a/e2e/specs/patientEdit.spec.ts
+++ b/e2e/specs/patientEdit.spec.ts
@@ -15,7 +15,7 @@ test('should be able to edit a patient', async ({ page, api }) => {
 
   await patientEditPage.goto(patient.uuid);
 
-  await expect(patientEditPage.givenNameInput()).not.toHaveValue('');
+  await expect(patientEditPage.givenNameInput()).not.toHaveValue('', { timeout: 1000000 });
 
   // TODO: Add email field after fixing O3-1883 (https://issues.openmrs.org/browse/O3-1883)
   const formValues: PatientRegistrationFormValues = {

--- a/e2e/specs/patientEdit.spec.ts
+++ b/e2e/specs/patientEdit.spec.ts
@@ -15,7 +15,7 @@ test('should be able to edit a patient', async ({ page, api }) => {
 
   await patientEditPage.goto(patient.uuid);
 
-  await expect(patientEditPage.givenNameInput()).not.toHaveValue('', { timeout: 1000000 });
+  await expect(patientEditPage.givenNameInput()).not.toHaveValue('', { timeout: 2 * 60 * 1000 });
 
   // TODO: Add email field after fixing O3-1883 (https://issues.openmrs.org/browse/O3-1883)
   const formValues: PatientRegistrationFormValues = {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Added a timeout in edit patient e2e test because that test was flaky
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-1930
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
