### PR TITLE
(fix): O3-1939: Fix e2e tests workflow by updating the start command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Run dev server
-        run: yarn start &
+        run: yarn start --sources 'packages/esm-*-app/'&
 
       - name: Run E2E tests
         run: yarn playwright test --project=chromium
@@ -75,7 +75,7 @@ jobs:
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:9000/openmrs/login.htm)" != "200" ]]; do sleep 10; done
 
       - name: Run dev server
-        run: yarn start --backend "http://localhost:9000" &
+        run: yarn start --sources 'packages/esm-*-app/' --backend "http://localhost:9000" &
 
       - name: Run E2E tests
         run: yarn playwright test

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ yarn test
 To run E2E tests, make sure the dev server is running by using:
 
 ```sh
-yarn start
+yarn start --sources 'packages/esm-*-app/'
 ```
 
 Then, in a separate terminal, run:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,7 +10,7 @@ Please ensure that you have followed the basic installation guide in the
 Once everything is set up, make sure the dev server is running by using:
 
 ```sh
-yarn start
+yarn start --sources 'packages/esm-*-app/'
 ```
 Then, in a separate terminal, run:
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
following changes in the logic of starting this app, [https://github.com/openmrs/openmrs-esm-patient-management/pull/574](https://github.com/openmrs/openmrs-esm-patient-management/pull/574,) removed argument "sources 'packages/esm-*-app/'" which fails the starting of the app while running tests. this should be added as a parameter to `yarn start` while running e2e tests

cc @vasharma05 @jayasanka-sack 
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-1939
*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
