### PR TITLE
(fix) O3-1922: Display patient list `name` in the breadcrumbs menu instead of a UUID

### DIFF
--- a/packages/esm-patient-list-app/src/api/api-remote.ts
+++ b/packages/esm-patient-list-app/src/api/api-remote.ts
@@ -163,14 +163,16 @@ export async function deletePatientList(cohortUuid: string, ac = new AbortContro
   );
 }
 
-export async function getPatientListName(patientListUuid: string, ac = new AbortController()) {
+export async function getPatientListName(patientListUuid: string) {
+  const abortController = new AbortController();
+
   try {
     const url = `${cohortUrl}/cohort/${patientListUuid}?`;
     const { data } = await openmrsFetch<OpenmrsCohort>(url, {
-      signal: ac.signal,
+      signal: abortController.signal,
     });
-    return data.name;
+    return data?.name;
   } catch (error) {
-    throw error;
+    console.error('Error resolving patient list name: ', error);
   }
 }

--- a/packages/esm-patient-list-app/src/api/api-remote.ts
+++ b/packages/esm-patient-list-app/src/api/api-remote.ts
@@ -165,14 +165,9 @@ export async function deletePatientList(cohortUuid: string, ac = new AbortContro
 }
 
 export async function getPatientListName(patientListUuid: string, ac = new AbortController()) {
-  const url = `${cohortUrl}/cohort/${patientListUuid}?v=custom:(name,uuid)`;
-  const {
-    data: { results, error },
-  } = await openmrsFetch<CohortResponse<PatientList>>(url, {
+  const url = `${cohortUrl}/cohort/${patientListUuid}?`;
+  const { data } = await openmrsFetch<OpenmrsCohort>(url, {
     signal: ac.signal,
   });
-  if (error) {
-    throw error;
-  }
-  return results;
+  return data.name;
 }

--- a/packages/esm-patient-list-app/src/api/api-remote.ts
+++ b/packages/esm-patient-list-app/src/api/api-remote.ts
@@ -164,9 +164,13 @@ export async function deletePatientList(cohortUuid: string, ac = new AbortContro
 }
 
 export async function getPatientListName(patientListUuid: string, ac = new AbortController()) {
-  const url = `${cohortUrl}/cohort/${patientListUuid}?`;
-  const { data } = await openmrsFetch<OpenmrsCohort>(url, {
-    signal: ac.signal,
-  });
-  return data.name;
+  try {
+    const url = `${cohortUrl}/cohort/${patientListUuid}?`;
+    const { data } = await openmrsFetch<OpenmrsCohort>(url, {
+      signal: ac.signal,
+    });
+    return data.name;
+  } catch (error) {
+    throw error;
+  }
 }

--- a/packages/esm-patient-list-app/src/api/api-remote.ts
+++ b/packages/esm-patient-list-app/src/api/api-remote.ts
@@ -6,7 +6,6 @@ import {
   OpenmrsCohort,
   OpenmrsCohortMember,
   OpenmrsCohortRef,
-  PatientList,
   PatientListFilter,
   PatientListMember,
   PatientListUpdate,

--- a/packages/esm-patient-list-app/src/api/api-remote.ts
+++ b/packages/esm-patient-list-app/src/api/api-remote.ts
@@ -6,6 +6,7 @@ import {
   OpenmrsCohort,
   OpenmrsCohortMember,
   OpenmrsCohortRef,
+  PatientList,
   PatientListFilter,
   PatientListMember,
   PatientListUpdate,
@@ -161,4 +162,17 @@ export async function deletePatientList(cohortUuid: string, ac = new AbortContro
     },
     ac,
   );
+}
+
+export async function getPatientListName(patientListUuid: string, ac = new AbortController()) {
+  const url = `${cohortUrl}/cohort/${patientListUuid}?v=custom:(name,uuid)`;
+  const {
+    data: { results, error },
+  } = await openmrsFetch<CohortResponse<PatientList>>(url, {
+    signal: ac.signal,
+  });
+  if (error) {
+    throw error;
+  }
+  return results;
 }

--- a/packages/esm-patient-list-app/src/index.ts
+++ b/packages/esm-patient-list-app/src/index.ts
@@ -27,13 +27,7 @@ function setupOpenMRS() {
   const spaBasePath = `${window.spaBase}/${route}`;
 
   async function getName(x: string) {
-    const name = await getPatientListName(x)
-      .then((results) => results.find((r) => r.id === x).display)
-      .catch((err) => {
-        if (err) {
-          return 'err';
-        }
-      });
+    const name = await getPatientListName(x);
     return name;
   }
 

--- a/packages/esm-patient-list-app/src/index.ts
+++ b/packages/esm-patient-list-app/src/index.ts
@@ -27,8 +27,14 @@ function setupOpenMRS() {
   const spaBasePath = `${window.spaBase}/${route}`;
 
   async function getName(x: string) {
-    const name = await getPatientListName(x);
-    return name;
+    const cachedName = localStorage.getItem(x);
+    if (cachedName) {
+      return cachedName;
+    } else {
+      const name = await getPatientListName(x);
+      localStorage.setItem(x, name);
+      return name;
+    }
   }
 
   setupOffline();

--- a/packages/esm-patient-list-app/src/index.ts
+++ b/packages/esm-patient-list-app/src/index.ts
@@ -27,8 +27,12 @@ function setupOpenMRS() {
   const spaBasePath = `${window.spaBase}/${route}`;
 
   async function getName(x: string) {
-    const name = await getPatientListName(x);
-    return name;
+    try {
+      const name = await getPatientListName(x);
+      return name;
+    } catch (error) {
+      return error.message;
+    }
   }
 
   setupOffline();

--- a/packages/esm-patient-list-app/src/index.ts
+++ b/packages/esm-patient-list-app/src/index.ts
@@ -26,13 +26,8 @@ function setupOpenMRS() {
   const route = `patient-list`;
   const spaBasePath = `${window.spaBase}/${route}`;
 
-  async function getName(x: string) {
-    try {
-      const name = await getPatientListName(x);
-      return name;
-    } catch (error) {
-      return error.message;
-    }
+  async function getListName(patientListUuid: string): Promise<string> {
+    return (await getPatientListName(patientListUuid)) ?? '--';
   }
 
   setupOffline();
@@ -46,7 +41,7 @@ function setupOpenMRS() {
     },
     {
       path: `${spaBasePath}/:uuid?`,
-      title: ([x]) => getName(`${x}`),
+      title: ([patientListUuid]) => getListName(patientListUuid),
       parent: spaBasePath,
     },
   ]);

--- a/packages/esm-patient-list-app/src/index.ts
+++ b/packages/esm-patient-list-app/src/index.ts
@@ -1,4 +1,5 @@
 import { defineConfigSchema, getAsyncLifecycle, registerBreadcrumbs } from '@openmrs/esm-framework';
+import { getPatientListName } from './api/api-remote';
 import { setupOffline } from './offline';
 
 declare var __VERSION__: string;
@@ -25,6 +26,17 @@ function setupOpenMRS() {
   const route = `patient-list`;
   const spaBasePath = `${window.spaBase}/${route}`;
 
+  async function getName(x: string) {
+    const name = await getPatientListName(`${x}`)
+      .then((results) => results.find((r) => r.id === x).display)
+      .catch((err) => {
+        if (err) {
+          return 'err';
+        }
+      });
+    return name;
+  }
+
   setupOffline();
   defineConfigSchema(moduleName, {});
 
@@ -36,7 +48,7 @@ function setupOpenMRS() {
     },
     {
       path: `${spaBasePath}/:uuid?`,
-      title: ([x]) => `${x}`,
+      title: ([x]) => getName(`${x}`),
       parent: spaBasePath,
     },
   ]);

--- a/packages/esm-patient-list-app/src/index.ts
+++ b/packages/esm-patient-list-app/src/index.ts
@@ -27,7 +27,7 @@ function setupOpenMRS() {
   const spaBasePath = `${window.spaBase}/${route}`;
 
   async function getName(x: string) {
-    const name = await getPatientListName(`${x}`)
+    const name = await getPatientListName(x)
       .then((results) => results.find((r) => r.id === x).display)
       .catch((err) => {
         if (err) {

--- a/packages/esm-patient-list-app/src/index.ts
+++ b/packages/esm-patient-list-app/src/index.ts
@@ -27,14 +27,8 @@ function setupOpenMRS() {
   const spaBasePath = `${window.spaBase}/${route}`;
 
   async function getName(x: string) {
-    const cachedName = localStorage.getItem(x);
-    if (cachedName) {
-      return cachedName;
-    } else {
-      const name = await getPatientListName(x);
-      localStorage.setItem(x, name);
-      return name;
-    }
+    const name = await getPatientListName(x);
+    return name;
   }
 
   setupOffline();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
  The breadcrumbs should display the patient list name instead of the list uuid as it is currently. 

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
  - https://issues.openmrs.org/browse/O3-1922

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other
Previously, I was experiencing an issue when the name section in the breadcrumb system was stuck in the loading state as shown below. I added some error handling and displayed the "err" if there is an error.  Can't really tell what am doing wrong.
[Screencast from 2023-03-07 17-57-29.webm](https://user-images.githubusercontent.com/104269786/223490383-b02612e3-1e24-4a35-aea8-9b1d926fa611.webm)

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
