### PR TITLE
(fix) O3-1948: Use the correct labels for the address section 

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.component.tsx
@@ -108,7 +108,7 @@ export const AddressHierarchy: React.FC = () => {
                   key={`combo_input_${index}`}
                   textFieldName={attributes.name}
                   name={`address.${attributes.name}`}
-                  labelText={t(attributes.label)}
+                  labelText={t(attributes.name)}
                   id={attributes.name}
                   setSelectedValue={setSelectedValue}
                   selected={selected}
@@ -117,7 +117,7 @@ export const AddressHierarchy: React.FC = () => {
                 <Input
                   key={`combo_input_${index}`}
                   name={`address.${attributes.name}`}
-                  labelText={t(attributes.label)}
+                  labelText={t(attributes.name)}
                   id={attributes.name}
                   setSelectedValue={setSelectedValue}
                   selected={selected}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

The address section of the patient registration form shows the wrong labels for the input fields. Updated it to show the attribute name. 

## Screenshots

<img width="793" alt="image" src="https://user-images.githubusercontent.com/43912578/223941457-2ff045e5-c901-48e8-904a-73bb1d4b4216.png">


## Related Issue

https://issues.openmrs.org/browse/O3-1948


## Other

*None.*

