### PR TITLE
(chore) Cache dependencies in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,5 @@
 name: E2E Tests
+
 on:
   push:
     branches:
@@ -24,8 +25,16 @@ jobs:
         with:
           node-version: 16
 
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      
       - name: Install dependencies
-        run: yarn
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
 
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
@@ -60,8 +69,16 @@ jobs:
         with:
           node-version: 16
 
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
       - name: Install dependencies
-        run: yarn
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Sets up dependency caching in the e2e workflow. Currently, it takes:

- Nearly 3 minutes to install dependencies when running the `testOnPush` job 
- Around 2 mins 20 seconds to install dependencies when running the `testOnPR` job. 

Caching dependencies brings this down to almost 10 seconds, per the latest action runs.

This PR also switches the dependency installation command from `yarn` to `yarn install --immutable`.