### PR TITLE
(chore) Leverage remote caching in bundle size workflow

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -8,10 +8,24 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      TURBO_API: 'http://127.0.0.1:9080'
+      TURBO_TOKEN: ${{ secrets.TURBO_SERVER_TOKEN }}
+      TURBO_TEAM: ${{ github.repository_owner }}
 
     steps:
       - uses: actions/checkout@v3
-      - uses: preactjs/compressed-size-action@v2
+
+      - name: Setup a local cache server for Turborepo
+        uses: felixmosh/turborepo-gh-artifacts@v2
         with:
-          build-script: "turbo run build --color"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ env.TURBO_TOKEN }}
+
+      - name: Compute bundle size report
+        uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           minimum-change-threshold: 10000 # 10 KB
+          build-script: "turbo run build --color --concurrency=5"
+


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Leverages remote caching in the bundle size workflow via the `turborepo-gh-artifacts` GitHub action. This PR also specifies a max concurrency value for the build job. These tweaks should result in runs faster by at least a minute or more.