### PR TITLE
(feat) Remove extraneous clinic metrics loading state

### DIFF
--- a/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -1,10 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Dropdown, DataTableSkeleton } from '@carbon/react';
-import { useMetrics, useAppointmentMetrics, useServiceMetricsCount, useServices } from './queue-metrics.resource';
+import { Dropdown } from '@carbon/react';
 import MetricsCard from './metrics-card.component';
 import MetricsHeader from './metrics-header.component';
-import styles from './clinic-metrics.scss';
 import {
   updateSelectedServiceName,
   updateSelectedServiceUuid,
@@ -12,8 +10,10 @@ import {
   useSelectedServiceUuid,
   useSelectedQueueLocationUuid,
 } from '../helpers/helpers';
-import { useVisitQueueEntries } from '../active-visits/active-visits-table.resource';
 import { useActiveVisits, useAverageWaitTime } from './clinic-metrics.resource';
+import { useServiceMetricsCount, useServices } from './queue-metrics.resource';
+import { useVisitQueueEntries } from '../active-visits/active-visits-table.resource';
+import styles from './clinic-metrics.scss';
 
 export interface Service {
   uuid: string;
@@ -23,34 +23,27 @@ export interface Service {
 function ClinicMetrics() {
   const { t } = useTranslation();
 
-  const { metrics, isLoading } = useMetrics();
   const currentQueueLocation = useSelectedQueueLocationUuid();
   const { allServices } = useServices(currentQueueLocation);
   const currentServiceUuid = useSelectedServiceUuid();
   const currentServiceName = useSelectedServiceName();
   const { serviceCount } = useServiceMetricsCount(currentServiceName, currentQueueLocation);
-  const [initialSelectedItem, setInitialSelectItem] = useState(true);
+  const [initialSelectedItem, setInitialSelectItem] = useState(() => {
+    if (currentServiceName && currentServiceUuid) {
+      return false;
+    } else if (currentServiceName === t('all', 'All')) {
+      return true;
+    }
+  });
   const { visitQueueEntriesCount } = useVisitQueueEntries(currentServiceName, currentQueueLocation);
   const { activeVisitsCount, isLoading: loading } = useActiveVisits();
   const { waitTime } = useAverageWaitTime(currentServiceUuid, '');
-
-  useEffect(() => {
-    if (currentServiceName && currentServiceUuid) {
-      setInitialSelectItem(false);
-    } else if (currentServiceName === t('all', 'All')) {
-      setInitialSelectItem(true);
-    }
-  }, [allServices, currentServiceName, serviceCount, currentServiceUuid, t]);
 
   const handleServiceChange = ({ selectedItem }) => {
     updateSelectedServiceUuid(selectedItem.uuid);
     updateSelectedServiceName(selectedItem.display);
     setInitialSelectItem(false);
   };
-
-  if (isLoading) {
-    return <DataTableSkeleton role="progressbar" />;
-  }
 
   return (
     <>

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/queue-metrics.resource.ts
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/queue-metrics.resource.ts
@@ -4,18 +4,6 @@ import { openmrsFetch } from '@openmrs/esm-framework';
 import { Appointment, QueueServiceInfo } from '../types';
 import { startOfDay } from '../constants';
 
-export function useMetrics() {
-  const metrics = { scheduled_appointments: 100, average_wait_time: 28, patients_waiting_for_service: 182 };
-  const { data, error, isLoading } = useSWR<{ data: { results: {} } }, Error>(`/ws/rest/v1/queue?`, openmrsFetch);
-
-  return {
-    // Returns placeholder mock data, soon to be replaced with actual data from the backend
-    metrics: metrics,
-    isError: error,
-    isLoading,
-  };
-}
-
 export function useServices(location: string) {
   const apiUrl = `/ws/rest/v1/queue?location=${location}`;
   const { data, isLoading } = useSWRImmutable<{ data: { results: Array<QueueServiceInfo> } }, Error>(
@@ -33,6 +21,7 @@ export function useServices(location: string) {
 export function useServiceMetricsCount(service: string, location: string) {
   const status = 'Waiting';
   const apiUrl = `/ws/rest/v1/queue-entry-metrics?service=${service}&status=${status}&location=${location}`;
+
   const { data } = useSWRImmutable<
     {
       data: {
@@ -40,7 +29,7 @@ export function useServiceMetricsCount(service: string, location: string) {
       };
     },
     Error
-  >(apiUrl, openmrsFetch);
+  >(service ? apiUrl : null, openmrsFetch);
 
   return {
     serviceCount: data ? data?.data?.count : 0,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Fixes an issue where the clinic metrics UI kept re-rendering due to a dependency on the `useMetrics` hook which was relying on mocked data. 