### PR TITLE
Revert "(fix) O3-1883: Converted phone and email fields into configuration defined fields"

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -77,7 +77,7 @@ export const builtInSections: Array<SectionDefinition> = [
     name: 'Basic Info',
     fields: ['name', 'gender', 'dob', 'id'],
   },
-  { id: 'contact', name: 'Contact Details', fields: ['address', 'phone', 'email'] },
+  { id: 'contact', name: 'Contact Details', fields: ['address', 'phone & email'] },
   { id: 'death', name: 'Death Info', fields: [] },
   { id: 'relationships', name: 'Relationships', fields: [] },
 ];
@@ -177,24 +177,7 @@ export const esmPatientRegistrationSchema = {
         _description: 'For coded questions only. Provide ability to add custom concept answers.',
       },
     },
-    _default: [
-      {
-        id: 'phone',
-        type: 'person attribute',
-        uuid: '14d4f066-15f5-102d-96e4-000c29c2a5d7',
-        validation: {
-          matches: '',
-        },
-      },
-      {
-        id: 'email',
-        type: 'person attribute',
-        uuid: 'a2c222fa-b9ca-11ed-8850-0242ac190003',
-        validation: {
-          matches: '',
-        },
-      },
-    ],
+    _default: [],
     _description:
       'Definitions for custom fields that can be used in sectionDefinitions. Can also be used to override built-in fields.',
   },

--- a/packages/esm-patient-registration-app/src/patient-registration/field/email/email-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/email/email-field.component.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Input } from '../../input/basic-input/input/input.component';
+import { useTranslation } from 'react-i18next';
+import { PhoneField } from '../phone/phone-field.component';
+import styles from '../field.scss';
+
+export const PhoneEmailField: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <h4 className={styles.productiveHeading02Light}>{t('phoneEmailLabelText', 'Phone, Email')}</h4>
+      <div className={styles.grid}>
+        <PhoneField />
+        <Input
+          id="email"
+          // This UUID will be fixed for all the distributions in OPENMRS
+          name="attributes.ac7d7773-fe9f-11ec-8b9b-0242ac1b0002"
+          labelText={t('emailLabelText', 'Email')}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/esm-patient-registration-app/src/patient-registration/field/email/email-field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/email/email-field.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
+import { PhoneEmailField } from './email-field.component';
+import { Formik, Form } from 'formik';
+
+describe('email field', () => {
+  it('should render email field with label Email', async () => {
+    const { findByLabelText } = render(
+      <Formik initialValues={{}} onSubmit={null}>
+        <Form>
+          <PhoneEmailField />
+        </Form>
+      </Formik>,
+    );
+
+    const email = await findByLabelText('Email (optional)');
+    expect(email).toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PhoneEmailField } from './email/email-field.component';
 import { NameField } from './name/name-field.component';
 import { GenderField } from './gender/gender-field.component';
 import { Identifiers } from './id/id-field.component';
@@ -38,6 +39,8 @@ export function Field({ name }: FieldProps) {
       return <AddressHierarchy />;
     case 'id':
       return <Identifiers />;
+    case 'phone & email':
+      return <PhoneEmailField />;
     default:
       return <CustomField name={name} />;
   }

--- a/packages/esm-patient-registration-app/src/patient-registration/field/phone/phone-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/phone/phone-field.component.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Input } from '../../input/basic-input/input/input.component';
+import { useTranslation } from 'react-i18next';
+
+export const PhoneField: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <Input
+        id="phone"
+        //This UUID will be fixed for all the distributions of OPENMRS.
+        name="attributes.14d4f066-15f5-102d-96e4-000c29c2a5d7"
+        labelText={t('phoneNumberInputLabelText', 'Phone number')}
+        light
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
Reverts openmrs/openmrs-esm-patient-management#582

This PR is being reverted because the UUID of the email field has again changed from `a2c222fa-b9ca-11ed-8850-0242ac19000` to `88b95cfa-beae-11ed-8aa6-0242c0a8f002`. 

Next course of action will be to remove the email field from the field configurations till the UUID issue is resolved.
Thanks!