### PR TITLE
(fix) O3-1492: Remove dangerous global selectors from stylesheets

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/patient-search.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/patient-search.scss
@@ -2,11 +2,6 @@
 @use '@carbon/styles/scss/type';
 @import '../root.scss';
 
-// FIX: This is not ideal
-:global(.cds--side-nav) {
-  z-index: 0;
-}
-
 .searchResultsContainer {
   width: 100%;
   background-color: $ui-02;

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
@@ -82,13 +82,13 @@
   color: $interactive-01;
 }
 
-:global(.cds--tooltip--definition .cds--tooltip__trigger) {
-  border-bottom: none;
-}
-
 .buttonCol {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-end;
+
+  :global(.cds--tooltip--definition .cds--tooltip__trigger) {
+    border-bottom: none;
+  }
 }

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.scss
@@ -2,10 +2,6 @@
 @use '@carbon/styles/scss/type';
 @import '../root.scss';
 
-:global(.cds--side-nav) {
-  z-index: 0;
-}
-
 .searchResultsDesktop {
   height: calc(100vh - 4rem);
   display: flex;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary
This PR removes some global style rules or at least scopes them within a class so they're self-contained to the components they affect and don't pollute the global scope. In this case, the style override for `.cds--side-nav` ought to exist in the esm-core style guide [overrides](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/_overrides.scss) file.

## Related Issue
https://issues.openmrs.org/browse/O3-1492