### PR TITLE
O3-1964: Disable the cross browser testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   testOnPR:
     if: ${{ github.event_name == 'pull_request' }}
-    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -43,7 +42,7 @@ jobs:
         run: yarn start --sources 'packages/esm-*-app/'&
 
       - name: Run E2E tests
-        run: yarn playwright test --project=chromium
+        run: yarn playwright test
 
       - name: Upload Report
         uses: actions/upload-artifact@v3
@@ -81,7 +80,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --with-deps
 
       - name: Run db and web containers
         run: |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx,css,scss}\" \"e2e/**/*.ts\"",
     "test": "cross-env TZ=UTC jest --config jest.config.json --verbose false --passWithNoTests",
     "test-watch": "cross-env TZ=UTC jest --watch --config jest.config.json",
-    "test-e2e": "playwright test --project=chromium",
+    "test-e2e": "playwright test",
     "coverage": "yarn test --coverage",
     "postinstall": "husky install",
     "extract-translations": "lerna run extract-translations -- --config ../../tools/i18next-parser.config.js"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,18 +27,6 @@ const config: PlaywrightTestConfig = {
         ...devices['Desktop Chrome'],
       },
     },
-    {
-      name: 'firefox',
-      use: {
-        ...devices['Desktop Firefox'],
-      },
-    },
-    {
-      name: 'webkit',
-      use: {
-        ...devices['Desktop Safari'],
-      },
-    },
   ],
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

As per the [discussion](https://talk.openmrs.org/t/e2e-tests-on-firefox-is-failing/38944) regarding the E2E tests failure in Firefox. The whole cross browser testing is removed. 


## Screenshots

*None.*


## Related Issue

https://issues.openmrs.org/browse/O3-1964


## Other

*None.*

