### PR TITLE
(fix) Fix the search bar UI shown in overlay menus

### DIFF
--- a/packages/esm-appointments-app/src/patient-search/patient-search.scss
+++ b/packages/esm-appointments-app/src/patient-search/patient-search.scss
@@ -9,9 +9,7 @@
 [data-extension-id='patient-search-bar'] {
   & > div {
     width: 100%;
-    & form {
-      margin: 0.0125rem;
-    }
+
     & input {
       background-color: $ui-02;
       border-bottom: none;

--- a/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
@@ -84,6 +84,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
     <div className={styles.patientSearchBar}>
       <form onSubmit={handleSubmit} className={styles.searchArea}>
         <Search
+          autoFocus
           className={styles.patientSearchInput}
           closeButtonLabelText={t('clearSearch', 'Clear')}
           labelText=""

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
@@ -7,7 +7,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  border: 1px solid $ui-04;
 }
 
 .patientSearchInput {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Fixes the appearance of the search box in the appointments and service queues apps as follows:

- Removes extraneous margin and borders around the input. 
- Autofocuses the input when an overlay gets launched. 

## Screenshots

<img width="557" alt="Screenshot 2023-03-16 at 9 41 39 AM" src="https://user-images.githubusercontent.com/8509731/225538056-ffda2650-0c08-442c-98ca-83e0754d8df1.png">

