### PR TITLE
(fix) O3-1965: Load the current cohortType on "Edit patient list" form

### DIFF
--- a/packages/esm-patient-list-app/src/api/hooks.ts
+++ b/packages/esm-patient-list-app/src/api/hooks.ts
@@ -30,7 +30,7 @@ export function useAllPatientListsWhichDoNotIncludeGivenPatient(patientUuid: str
 }
 
 export function usePatientListDetails(patientListUuid: string) {
-  const url = `${cohortUrl}/cohort/${patientListUuid}?v=custom:(uuid,name,description,display,size,attributes,startDate,endDate)`;
+  const url = `${cohortUrl}/cohort/${patientListUuid}?v=custom:(uuid,name,description,display,size,attributes,startDate,endDate,cohortType)`;
 
   const { data, error, isLoading, mutate } = useSWR<FetchResponse<OpenmrsCohort>, Error>(
     patientListUuid ? url : null,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
The edit-patient-list form doesn't load the patient list type (cohortType) automatically. The current patient list type should be the default value on the drop-down menu.
This problem occurs because our endpoint doesn't automatically get the cohortType in the payload. We are currently using a custom representation, so the cohortType field should be added to the list of the required fields.
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
![image](https://user-images.githubusercontent.com/73557402/225721152-f310d5e0-bd30-45ed-b5ad-d55984fc00ab.png)


![image](https://user-images.githubusercontent.com/73557402/225724232-b0158b36-e8bc-43a8-9517-e5b12795e71e.png)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-1965

<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
