### PR TITLE
Use translations for left pane section links when available

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -171,7 +171,7 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
                 {sections.map((section) => (
                   <div className={`${styles.space05} ${styles.touchTarget}`} key={section.name}>
                     <Link className={styles.linkName} onClick={() => scrollIntoView(section.id)}>
-                      <XAxis size={16} /> {section.name}
+                      <XAxis size={16} /> {t(`${section.id}Section`, section.name)}
                     </Link>
                   </div>
                 ))}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Use translations, when available, for left pane section links. With this change, translations can be provided via cfg by translation overrides. The used key for the translation is the one that's already in place here: https://github.com/openmrs/openmrs-esm-patient-management/blob/f4940529fa192b3490bb8ce58058c4166fa0bf99/packages/esm-patient-registration-app/src/patient-registration/section/section-wrapper.component.tsx#L28


## Screenshots

![image](https://user-images.githubusercontent.com/68599335/226933810-10955677-3726-40c5-b473-507216717c47.png)