### PR TITLE
(fix)03-1860:Add appropriate permissions to view and edit/ configure …

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.component.tsx
@@ -98,7 +98,13 @@ export const Identifiers: React.FC = () => {
         });
       }
     }
-  }, [identifierTypes, setFieldValue, initializeIdentifier, defaultPatientIdentifierTypes, values.identifiers]);
+  }, [
+    identifierTypes,
+    setFieldValue,
+    defaultPatientIdentifierTypes,
+    values.identifiers,
+    initialFormValues.identifiers,
+  ]);
 
   if (isLoading) {
     return (
@@ -113,7 +119,7 @@ export const Identifiers: React.FC = () => {
 
   return (
     <div className={styles.halfWidthInDesktopView}>
-      <UserHasAccess privilege="coreapps.systemAdministration">
+      <UserHasAccess privilege={['Get Identifier Types', 'Add Patient Identifiers']}>
         <div className={styles.identifierLabelText}>
           <h4 className={styles.productiveHeading02Light}>{t('idFieldLabelText', 'Identifiers')}</h4>
           <Button

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
@@ -49,7 +49,7 @@ export const IdentifierInput: React.FC<IdentifierInputProps> = ({ patientIdentif
       selectedSource: null,
       autoGeneration: false,
     } as PatientIdentifierValue);
-  }, [initialValue, setHideInputField]);
+  }, [fieldName, initialValue, patientIdentifier, setFieldValue]);
 
   const handleEdit = () => {
     setHideInputField(false);
@@ -60,10 +60,10 @@ export const IdentifierInput: React.FC<IdentifierInputProps> = ({ patientIdentif
   };
 
   const handleDelete = () => {
-    /* 
-    If there is an initialValue to the identifier, a confirmation modal seeking 
-    confirmation to delete the identifier should be shown, else in the other case, 
-    we can directly delete the identifier. 
+    /*
+    If there is an initialValue to the identifier, a confirmation modal seeking
+    confirmation to delete the identifier should be shown, else in the other case,
+    we can directly delete the identifier.
     */
 
     if (initialValue) {
@@ -111,27 +111,31 @@ export const IdentifierInput: React.FC<IdentifierInputProps> = ({ patientIdentif
       )}
       <div>
         {!patientIdentifier.required && patientIdentifier.initialValue && hideInputField && (
-          <Button
-            kind="ghost"
-            onClick={handleEdit}
-            iconDescription={t('editIdentifierTooltip', 'Edit')}
-            disabled={disabled}
-            hasIconOnly>
-            <Edit size={16} />
-          </Button>
+          <UserHasAccess privilege="Edit Patient Identifiers">
+            <Button
+              kind="ghost"
+              onClick={handleEdit}
+              iconDescription={t('editIdentifierTooltip', 'Edit')}
+              disabled={disabled}
+              hasIconOnly>
+              <Edit size={16} />
+            </Button>
+          </UserHasAccess>
         )}
         {initialValue && initialValue !== identifierValue && (
-          <Button
-            kind="ghost"
-            onClick={handleReset}
-            iconDescription={t('resetIdentifierTooltip', 'Reset')}
-            disabled={disabled}
-            hasIconOnly>
-            <Reset size={16} />
-          </Button>
+          <UserHasAccess privilege="Edit Patient Identifiers">
+            <Button
+              kind="ghost"
+              onClick={handleReset}
+              iconDescription={t('resetIdentifierTooltip', 'Reset')}
+              disabled={disabled}
+              hasIconOnly>
+              <Reset size={16} />
+            </Button>
+          </UserHasAccess>
         )}
         {!patientIdentifier.required && !defaultPatientIdentifierTypesMap[patientIdentifier.identifierTypeUuid] && (
-          <UserHasAccess privilege="coreapps.systemAdministration">
+          <UserHasAccess privilege="Delete Patient Identifiers">
             <Button
               kind="danger--ghost"
               onClick={handleDelete}


### PR DESCRIPTION
…identifiers on patient registration

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Currently, only the system administrator is allowed to configure identifiers on the patient registration.
If you go to the patient registration form, you see a configure button. Clicking the Configure buttons opens an overlay.
![image](https://user-images.githubusercontent.com/78595738/227448773-48b6b913-efdb-42de-a481-19c8cbb76d9e.png)
As you can see, this allows adding identifiers to the patient's form. Hence the appropriate privileges for opening the configuring overlay are coreapps.addPatientIdentifier

When you come to edit a patient, you can see the edit buttons and delete buttons:
![image](https://user-images.githubusercontent.com/78595738/227449022-01e7ade4-5695-45fe-a46e-a84c83ffd7fc.png)
Hence we need to place the appropriate privelege checks at appropriate places.

The appropriate permissions are: 

Add Patient Identifiers
Delete Patient Identifers
Edit Patient Identifiers
Get Patient Identifiers

<!--
Required.
Please describe what problems your PR addresses.
-->




## Related Issue
https://issues.openmrs.org/browse/O3-1860
*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


