### PR TITLE
(feat) Explicitly set slot order of home page widgets

### DIFF
--- a/packages/esm-active-visits-app/src/index.ts
+++ b/packages/esm-active-visits-app/src/index.ts
@@ -28,8 +28,9 @@ function setupOpenMRS() {
   return {
     extensions: [
       {
-        id: 'active-visits-widget',
+        name: 'active-visits-widget',
         slot: 'homepage-widgets-slot',
+        order: 0,
         load: getAsyncLifecycle(() => import('./active-visits-widget/active-visits.component'), options),
       },
       {

--- a/packages/esm-appointments-app/src/index.ts
+++ b/packages/esm-appointments-app/src/index.ts
@@ -39,8 +39,9 @@ function setupOpenMRS() {
   return {
     extensions: [
       {
-        id: 'home-appointments',
+        name: 'home-appointments',
         slot: 'homepage-widgets-slot',
+        order: 1,
         load: getAsyncLifecycle(() => import('./home-appointments'), options),
       },
       {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Presently, when loading the home page, there is no guarantee about the order of widgets.  

This PR explicitly sets the slot order of widgets in the `homepage-widgets-slot`, guaranteeing that the `Active visits` widget gets rendered on top of the `Today's appointments` widget.