### PR TITLE
(fix) O3-2008: Set 'showHeading' default value to false

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -140,7 +140,7 @@ export const esmPatientRegistrationSchema = {
       showHeading: {
         _type: Type.Boolean,
         _description: 'Whether to show a heading above the person attribute field.',
-        _default: true,
+        _default: false,
       },
       label: {
         _type: Type.String,
@@ -188,7 +188,7 @@ export const esmPatientRegistrationSchema = {
         id: 'phone',
         type: 'person attribute',
         uuid: '14d4f066-15f5-102d-96e4-000c29c2a5d7',
-        showHeading: true,
+        showHeading: false,
         validation: {
           matches: '',
         },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
In the package _esm-patient-registration-app_ the property `showHeading` in `fieldDefinitions` has the default value of true. These caused the default creation of a title per question. 


## Screenshots
Previous behavior

<img width="776" alt="image" src="https://user-images.githubusercontent.com/106243905/228879412-f64c7350-b14f-4b00-b894-473a45b3008f.png">

Current behavior

<img width="755" alt="image" src="https://user-images.githubusercontent.com/106243905/228879644-ee23cf34-6350-45ed-862a-122349f04ecc.png">



## Related Issue
[O3-2008](https://issues.openmrs.org/browse/O3-2008)

