### PR TITLE
(fix) Fix left navigation routing

### DIFF
--- a/packages/esm-appointments-app/src/appointments-metrics/metrics-card.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-metrics/metrics-card.component.tsx
@@ -4,11 +4,11 @@ import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 dayjs.extend(isSameOrBefore);
 import isEmpty from 'lodash-es/isEmpty';
+import { ConfigurableLink } from '@openmrs/esm-framework';
 import { Tile, Layer } from '@carbon/react';
 import { ArrowRight } from '@carbon/react/icons';
-import { ConfigurableLink } from '@openmrs/esm-framework';
+import { basePath, spaBasePath, spaRoot } from '../constants';
 import styles from './metrics-card.scss';
-import { spaBasePath, spaRoot } from '../constants';
 
 interface MetricsCardProps {
   label: string;
@@ -48,7 +48,7 @@ const MetricsCard: React.FC<MetricsCardProps> = ({
           </div>
           {view && (
             <div className={styles.link}>
-              <ConfigurableLink className={styles.link} to={`/openmrs/spa/${metricsLink[view]}`}>
+              <ConfigurableLink className={styles.link} to={`${spaBasePath}${basePath}/${metricsLink[view]}`}>
                 <span style={{ fontSize: '0.825rem', marginRight: '0.325rem' }}>{t('view', 'View')}</span>{' '}
                 <ArrowRight size={16} className={styles.viewListBtn} />
               </ConfigurableLink>

--- a/packages/esm-appointments-app/src/appointments-metrics/metrics-header.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-metrics/metrics-header.component.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { Add, ArrowRight } from '@carbon/react/icons';
-import { Button } from '@carbon/react';
-import { launchOverlay } from '../hooks/useOverlay';
-import AppointmentServices from '../admin/appointment-services/appointment-services.component';
 import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday';
 dayjs.extend(isToday);
-import styles from './metrics-header.scss';
+import { useTranslation } from 'react-i18next';
+import { Add, ArrowRight } from '@carbon/react/icons';
+import { Button } from '@carbon/react';
 import { ConfigurableLink } from '@openmrs/esm-framework';
+import { launchOverlay } from '../hooks/useOverlay';
+import AppointmentServices from '../admin/appointment-services/appointment-services.component';
+import styles from './metrics-header.scss';
 
 const MetricsHeader: React.FC = () => {
   const { t } = useTranslation();
@@ -17,7 +17,7 @@ const MetricsHeader: React.FC = () => {
     <div className={styles.metricsContainer}>
       <span className={styles.metricsTitle}>{t('appointmentMetrics', 'Appointment metrics')}</span>
       <div className={styles.metricsContent}>
-        <ConfigurableLink className={styles.link} to={`/openmrs/spa/calendar`}>
+        <ConfigurableLink className={styles.link} to={`\${openmrsSpaBase}/appointments/calendar`}>
           <span style={{ fontSize: '0.825rem', marginRight: '0.325rem' }}>{t('calendar', 'Calendar')}</span>{' '}
           <ArrowRight size={16} className={styles.viewListBtn} />
         </ConfigurableLink>

--- a/packages/esm-appointments-app/src/createDashboardLink.tsx
+++ b/packages/esm-appointments-app/src/createDashboardLink.tsx
@@ -13,7 +13,7 @@ function DashboardExtension({ dashboardLinkConfig }: { dashboardLinkConfig: Dash
   const spaBasePath = `${window.spaBase}/home`;
 
   const navLink = useMemo(() => {
-    const pathArray = location.pathname.split('/');
+    const pathArray = location.pathname.split('/home');
     const lastElement = pathArray[pathArray.length - 1];
     return decodeURIComponent(lastElement);
   }, [location.pathname]);
@@ -21,7 +21,7 @@ function DashboardExtension({ dashboardLinkConfig }: { dashboardLinkConfig: Dash
   return (
     <ConfigurableLink
       to={`${spaBasePath}/${name}`}
-      className={`cds--side-nav__link ${name === navLink && 'active-left-nav-link'}`}>
+      className={`cds--side-nav__link ${navLink.match(name) && 'active-left-nav-link'}`}>
       {title}
     </ConfigurableLink>
   );

--- a/packages/esm-outpatient-app/src/createDashboardLink.tsx
+++ b/packages/esm-outpatient-app/src/createDashboardLink.tsx
@@ -13,7 +13,7 @@ function DashboardExtension({ dashboardLinkConfig }: { dashboardLinkConfig: Dash
   const spaBasePath = `${window.spaBase}/home`;
 
   const navLink = useMemo(() => {
-    const pathArray = location.pathname.split('/');
+    const pathArray = location.pathname.split('/home');
     const lastElement = pathArray[pathArray.length - 1];
     return decodeURIComponent(lastElement);
   }, [location.pathname]);
@@ -21,7 +21,7 @@ function DashboardExtension({ dashboardLinkConfig }: { dashboardLinkConfig: Dash
   return (
     <ConfigurableLink
       to={`${spaBasePath}/${name}`}
-      className={`cds--side-nav__link ${name === navLink && 'active-left-nav-link'}`}>
+      className={`cds--side-nav__link ${navLink.match(name) && 'active-left-nav-link'}`}>
       {title}
     </ConfigurableLink>
   );

--- a/packages/esm-patient-list-app/src/createDashboardLink.tsx
+++ b/packages/esm-patient-list-app/src/createDashboardLink.tsx
@@ -13,7 +13,7 @@ function DashboardExtension({ dashboardLinkConfig }: { dashboardLinkConfig: Dash
   const spaBasePath = `${window.spaBase}/home`;
 
   const navLink = useMemo(() => {
-    const pathArray = location.pathname.split('/');
+    const pathArray = location.pathname.split('/home');
     const lastElement = pathArray[pathArray.length - 1];
     return decodeURIComponent(lastElement);
   }, [location.pathname]);
@@ -21,7 +21,7 @@ function DashboardExtension({ dashboardLinkConfig }: { dashboardLinkConfig: Dash
   return (
     <ConfigurableLink
       to={`${spaBasePath}/${name}`}
-      className={`cds--side-nav__link ${name === navLink && 'active-left-nav-link'}`}>
+      className={`cds--side-nav__link ${navLink.match(name) && 'active-left-nav-link'}`}>
       {title}
     </ConfigurableLink>
   );

--- a/packages/esm-patient-list-app/src/patient-list-list/patient-list-table.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-list/patient-list-table.component.tsx
@@ -114,7 +114,7 @@ const PatientListTable: React.FC<PatientListTableProps> = ({
                           <TableCell className={styles.tableCell} key={cell.id}>
                             <ConfigurableLink
                               className={styles.link}
-                              to={`\${openmrsSpaBase}/patient-list/${patientLists[index]?.id}`}>
+                              to={`\${openmrsSpaBase}/home/patient-lists/${patientLists[index]?.id}`}>
                               {cell.value}
                             </ConfigurableLink>
                           </TableCell>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Fixes some aspects of the left navigation menu routing experience on the home page. Specifically, this PR:

- Fixes a bunch of nested routes so they're scoped behind the `/home` route.
- Ensures that when nested routes in a dashboard are navigated to, that dashboard retains its active styling if it's the active URL.

## Video


https://user-images.githubusercontent.com/8509731/229604035-47bdbb0e-d302-4cd8-b93b-83e4a87cd7ea.mp4


