### PR TITLE
(feat) Add activeTicket screen to display people on the queue

### DIFF
--- a/packages/esm-outpatient-app/src/home.component.tsx
+++ b/packages/esm-outpatient-app/src/home.component.tsx
@@ -4,13 +4,19 @@ import ActiveVisitsTabs from './active-visits/active-visits-tab.component';
 import ClinicMetrics from './patient-queue-metrics/clinic-metrics.component';
 import { ConfigObject, useConfig } from '@openmrs/esm-framework';
 import PatientQueueHeader from './patient-queue-header/patient-queue-header.component';
+import QueueScreen from './queue-screen/queue-screen.component';
 
 interface HomeProps {}
 
-const Home: React.FC<HomeProps> = () => {
+const Home: React.FC<HomeProps> = (props) => {
   const config = useConfig() as ConfigObject;
   const useQueueTableTabs = config.showQueueTableTab;
+  const pathName = window.location.pathname;
+  const activeTicketScreen = pathName.substring(pathName.lastIndexOf('/') + 1);
 
+  if (activeTicketScreen === 'screen') {
+    return <QueueScreen />;
+  }
   return (
     <div>
       <PatientQueueHeader />

--- a/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.component.tsx
@@ -48,7 +48,7 @@ const PatientQueueHeader: React.FC<{ title?: string }> = ({ title }) => {
             <label className={styles.view}>{t('view', 'View')}:</label>
             <Dropdown
               id="typeOfCare"
-              label={currentQueueLocationName}
+              label={currentQueueLocationName ?? ''}
               items={[{ display: `${t('all', 'All')}` }, ...queueLocations]}
               itemToString={(item) => (item ? item.name : '')}
               type="inline"

--- a/packages/esm-outpatient-app/src/queue-screen/queue-screen.component.tsx
+++ b/packages/esm-outpatient-app/src/queue-screen/queue-screen.component.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect } from 'react';
+import {
+  DataTable,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableHeader,
+  TableBody,
+  TableCell,
+  DataTableSkeleton,
+} from '@carbon/react';
+import { useTranslation } from 'react-i18next';
+import { useActiveTickets } from './useActiveTickets';
+import PatientQueueHeader from '../patient-queue-header/patient-queue-header.component';
+import styles from './queue-screen.scss';
+
+interface QueueScreenProps {}
+
+const QueueScreen: React.FC<QueueScreenProps> = () => {
+  const { t } = useTranslation();
+  const { activeTickets, isLoading, error } = useActiveTickets();
+
+  if (isLoading) {
+    return <DataTableSkeleton row={5} className={styles.queueScreen} role="progressbar" />;
+  }
+
+  if (error) {
+    return <div>Error</div>;
+  }
+
+  const headerData = [
+    {
+      header: t('room', 'Room'),
+      key: 'room',
+    },
+    {
+      header: t('ticketNumber', 'Ticket Number'),
+      key: 'ticketNumber',
+    },
+    {
+      header: t('status', 'Status'),
+      key: 'status',
+    },
+  ];
+
+  const rowData = activeTickets.map((ticket, index) => ({
+    id: `${index}}`,
+    room: ticket.room,
+    ticketNumber: ticket.ticketNumber,
+    status: ticket.status,
+  }));
+
+  return (
+    <div>
+      <PatientQueueHeader />
+      <div className={styles.queueScreen}>
+        <DataTable rows={rowData} headers={headerData} isSortable>
+          {({ rows, headers, getHeaderProps, getTableProps }) => (
+            <TableContainer title={t('activeTickets', 'Active tickets')}>
+              <Table {...getTableProps()} size="lg" useZebraStyles>
+                <TableHead>
+                  <TableRow>
+                    {headers.map((header) => (
+                      <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
+                    ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((row) => (
+                    <TableRow key={row.id}>
+                      {row.cells.map((cell) => (
+                        <TableCell key={cell.id}>{cell.value}</TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </DataTable>
+      </div>
+    </div>
+  );
+};
+
+export default QueueScreen;

--- a/packages/esm-outpatient-app/src/queue-screen/queue-screen.scss
+++ b/packages/esm-outpatient-app/src/queue-screen/queue-screen.scss
@@ -1,0 +1,3 @@
+.queueScreen {
+  margin: 1rem;
+}

--- a/packages/esm-outpatient-app/src/queue-screen/queue-screen.test.tsx
+++ b/packages/esm-outpatient-app/src/queue-screen/queue-screen.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useActiveTickets } from './useActiveTickets';
+import QueueScreen from './queue-screen.component';
+
+jest.mock('./useActiveTickets');
+
+describe('QueueScreen component', () => {
+  test('renders loading skeleton when data is loading', () => {
+    const mockedUseActiveTickets = useActiveTickets as jest.MockedFunction<typeof useActiveTickets>;
+    mockedUseActiveTickets.mockReturnValue({ isLoading: true, activeTickets: [], error: undefined });
+    render(<QueueScreen />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  test('renders error message when there is an error fetching data', () => {
+    const mockedUseActiveTickets = useActiveTickets as jest.MockedFunction<typeof useActiveTickets>;
+    mockedUseActiveTickets.mockReturnValue({ error: new Error('Error'), isLoading: false, activeTickets: [] });
+    render(<QueueScreen />);
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+
+  test('renders table with active tickets when data is loaded', () => {
+    const mockedUseActiveTickets = useActiveTickets as jest.MockedFunction<typeof useActiveTickets>;
+    mockedUseActiveTickets.mockReturnValue({
+      activeTickets: [
+        {
+          room: 'Room A',
+          ticketNumber: '123',
+          status: 'Pending',
+        },
+      ],
+      isLoading: false,
+      error: undefined,
+    });
+    render(<QueueScreen />);
+    expect(screen.getByText('Room')).toBeInTheDocument();
+    expect(screen.getByText('Ticket Number')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Room A')).toBeInTheDocument();
+    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+});

--- a/packages/esm-outpatient-app/src/queue-screen/useActiveTickets.tsx
+++ b/packages/esm-outpatient-app/src/queue-screen/useActiveTickets.tsx
@@ -1,0 +1,13 @@
+import { openmrsFetch } from '@openmrs/esm-framework';
+import useSWR from 'swr';
+
+export const useActiveTickets = () => {
+  const { data, isLoading, error } = useSWR<{ data: Record<string, { status: string; ticketNumber: string }> }>(
+    '/ws/rest/v1/queueutil/active-tickets',
+    openmrsFetch,
+    { refreshInterval: 3000 },
+  );
+  const activeTickets =
+    Array.from(Object.entries(data?.data ?? {}).map(([key, value]) => ({ room: key, ...value }))) ?? [];
+  return { activeTickets, isLoading, error };
+};

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -1,5 +1,6 @@
 {
   "actions": "Actions",
+  "activeTickets": "Active tickets",
   "activeVisits": "Active Visits",
   "activeVisitsNotInQueue": "Active visits not in queue",
   "add": "Add",
@@ -187,6 +188,7 @@
   "requeue": "Requeue",
   "retainLocation": "",
   "returnDate": "Return date",
+  "room": "Room",
   "rRate": "R. Rate",
   "save": "Save",
   "scheduledAppointmentsList": "Scheduled appointments patient list",
@@ -226,6 +228,7 @@
   "success": "Success",
   "tcaDate": "Tca date",
   "temperature": "Temperature",
+  "ticketNumber": "Ticket Number",
   "time": "Time",
   "tirageNotYetCompleted": "Triage has not yet been completed",
   "today": "Today",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

A screen to be display for the patient in a facility so that they are able to view how the queue is progressing


## Screenshots
![Kapture 2023-04-04 at 10 37 15](https://user-images.githubusercontent.com/28008754/229721714-55d3f6dc-a3a6-4062-8172-d4b7b958848f.gif)


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
