### PR TITLE
(feat) KH-136: Increased the address hierarchy search dropdown's height

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-search.scss
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-search.scss
@@ -7,11 +7,10 @@
 }
 
 .suggestions {
-  position: relative;
   border-top-width: 0;
   list-style: none;
   margin-top: 0;
-  max-height: 143px;
+  max-height: 20rem;
   overflow-y: auto;
   padding-left: 0;
   width: 100%;
@@ -20,6 +19,7 @@
   background-color: #fff;
   margin-bottom: 20px;
   z-index: 99;
+  border: 1px solid $ui-03;
 }
 
 .suggestions li {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary
This PR increases the address hierarchy's search dropdown's height from 143px to 320px, and also gave a border to make it distinguishable from other UI components. 

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/51502471/230013543-78a6bb79-2a66-49dd-b81c-aeab2b79f0d2.png)

### After
![image](https://user-images.githubusercontent.com/51502471/230013485-efcf47fd-4429-4c43-84a6-7d5829a41b98.png)



## Related Issue
https://issues.openmrs.org/browse/KH-136


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
