### PR TITLE
(feat) KH-131: Allowing user have more than 11 months in estimated months

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
@@ -64,7 +64,7 @@ export const DobField: React.FC = () => {
     }
   };
 
-  const calculateBirthdate = () => {
+  const updateBirthdate = () => {
     const months = +monthsEstimateMeta.value % 12;
     const years = +yearsEstimateMeta.value + Math.floor(monthsEstimateMeta.value / 12);
     setFieldValue('yearsEstimated', years);
@@ -113,7 +113,7 @@ export const DobField: React.FC = () => {
             min={0}
             required
             {...yearsEstimated}
-            onBlur={calculateBirthdate}
+            onBlur={updateBirthdate}
           />
           <TextInput
             id="monthsEstimated"
@@ -128,7 +128,7 @@ export const DobField: React.FC = () => {
             min={0}
             {...monthsEstimated}
             required={!yearsEstimateMeta.value}
-            onBlur={calculateBirthdate}
+            onBlur={updateBirthdate}
           />
         </div>
       )}

--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
@@ -38,7 +38,7 @@ export const DobField: React.FC = () => {
   const onToggle = (e) => {
     setFieldValue('birthdateEstimated', e.name === 'unknown');
     setFieldValue('birthdate', '');
-    setFieldValue('yearsEstimated', '');
+    setFieldValue('yearsEstimated', 0);
     setFieldValue('monthsEstimated', '');
   };
 
@@ -58,10 +58,18 @@ export const DobField: React.FC = () => {
   const onEstimatedMonthsChange = (e) => {
     const months = +e.target.value;
 
-    if (!isNaN(months) && months <= 11 && months >= 0) {
+    if (!isNaN(months)) {
       setFieldValue('monthsEstimated', months);
       setFieldValue('birthdate', calcBirthdate(yearsEstimateMeta.value, months, dateOfBirth));
     }
+  };
+
+  const calculateBirthdate = () => {
+    const months = +monthsEstimateMeta.value % 12;
+    const years = +yearsEstimateMeta.value + Math.floor(monthsEstimateMeta.value / 12);
+    setFieldValue('yearsEstimated', years);
+    setFieldValue('monthsEstimated', months > 0 ? months : '');
+    setFieldValue('birthdate', calcBirthdate(years, months, dateOfBirth));
   };
 
   return (
@@ -104,6 +112,8 @@ export const DobField: React.FC = () => {
             value={yearsEstimated.value}
             min={0}
             required
+            {...yearsEstimated}
+            onBlur={calculateBirthdate}
           />
           <TextInput
             id="monthsEstimated"
@@ -116,6 +126,9 @@ export const DobField: React.FC = () => {
             invalidText={monthsEstimateMeta.error && t(monthsEstimateMeta.error)}
             value={monthsEstimated.value}
             min={0}
+            {...monthsEstimated}
+            required={!yearsEstimateMeta.value}
+            onBlur={calculateBirthdate}
           />
         </div>
       )}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR allows user to enter more than 11 months in the estimated months field, for ease to paediatricians, who usually record age in months.

If the months entered > 11, then the changes will be:
years -> current years + int(months/12)
months -> months%12

Say, if the entered years and months are 0 years and 5 months, it will be 0 years and 5 months.
Say, if the entered years and months are 0 years and 20 months, it will be 1 years and 8 months.
Say, if the entered years and months are 1 years and 20 months, it will be 2 years and 8 months. (Most unlikely).

Also, if the entered years are 0, then the months field becomes required.

## Screenshots

https://user-images.githubusercontent.com/51502471/230329921-a6505365-d704-4bff-8d71-5d794adafafe.mov





## Related Issue
https://issues.openmrs.org/browse/KH-131


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
