### PR TITLE
(fix) KH-134: Unable to deselect a selected identifier from the identifier configuration overlay

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/id/identifier-selection-overlay.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/id/identifier-selection-overlay.tsx
@@ -98,7 +98,7 @@ const PatientIdentifierOverlay: React.FC<PatientIdentifierOverlayProps> = ({ clo
               id={identifierType.uuid}
               value={identifierType.uuid}
               labelText={identifierType.name}
-              onChange={(checked) => handleCheckingIdentifier(identifierType, checked)}
+              onChange={(e, { checked }) => handleCheckingIdentifier(identifierType, checked)}
               checked={!!patientIdentifier}
               disabled={isDisabled || (isOffline && isDisabledOffline)}
             />


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes recording the `checked` boolean value for the checkboxes, which got missed in the migration from V10 -> V11.


## Screenshots

https://user-images.githubusercontent.com/51502471/230342885-5726b1bb-b190-4fbb-96dd-096c5f99ce40.mov


## Related Issue
https://issues.openmrs.org/browse/KH-134


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
