### PR TITLE
(feat) Add mutate public queue screen entries on serving and calling clients in queue

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -61,7 +61,6 @@ import {
   updateSelectedServiceUuid,
   useSelectedServiceName,
   useSelectedQueueLocationUuid,
-  useSelectedProviderRoomTimestamp,
   useIsPermanentProviderQueueRoom,
 } from '../helpers/helpers';
 import { buildStatusString, formatWaitTime, getTagType, timeDiffInMinutes } from '../helpers/functions';

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.resource.ts
@@ -420,3 +420,20 @@ export async function generateVisitQueueNumber(
     },
   );
 }
+
+export function serveQueueEntry(servicePointName: string, ticketNumber: string, status: string) {
+  const abortController = new AbortController();
+
+  return openmrsFetch(`/ws/rest/v1/queueutil/assignticket`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    signal: abortController.signal,
+    body: {
+      servicePointName,
+      ticketNumber,
+      status,
+    },
+  });
+}

--- a/packages/esm-outpatient-app/src/active-visits/change-status-dialog.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/change-status-dialog.component.tsx
@@ -73,7 +73,7 @@ const ChangeStatus: React.FC<ChangeStatusDialogProps> = ({ queueEntry, closeModa
             });
             closeModal();
             mutate();
-            navigate({ to: `${window.spaBase}/home` });
+            navigate({ to: `${window.spaBase}/home/service-queues` });
           }
         },
         (error) => {

--- a/packages/esm-outpatient-app/src/queue-entry-table-components/transition-entry.component.tsx
+++ b/packages/esm-outpatient-app/src/queue-entry-table-components/transition-entry.component.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback } from 'react';
 import { Notification } from '@carbon/react/icons';
-import { MappedVisitQueueEntry } from '../active-visits/active-visits-table.resource';
+import { MappedVisitQueueEntry, serveQueueEntry } from '../active-visits/active-visits-table.resource';
 import { useTranslation } from 'react-i18next';
-import { showModal } from '@openmrs/esm-framework';
+import { showModal, showNotification } from '@openmrs/esm-framework';
 import { Button } from '@carbon/react';
 import styles from './transition-entry.scss';
+import { mutate } from 'swr';
 interface TransitionMenuProps {
   queueEntry: MappedVisitQueueEntry;
   closeModal: () => void;
@@ -13,6 +14,21 @@ const TransitionMenu: React.FC<TransitionMenuProps> = ({ queueEntry, closeModal 
   const { t } = useTranslation();
 
   const launchTransitionPriorityModal = useCallback(() => {
+    serveQueueEntry(queueEntry?.service, queueEntry?.visitQueueNumber, 'calling').then(
+      ({ status }) => {
+        if (status === 200) {
+          mutate(`/ws/rest/v1/queueutil/assignticket`);
+        }
+      },
+      (error) => {
+        showNotification({
+          title: t('errorPostingToScreen', 'Error posting to screen'),
+          kind: 'error',
+          critical: true,
+          description: error?.message,
+        });
+      },
+    );
     const dispose = showModal('transition-queue-entry-status-modal', {
       closeModal: () => dispose(),
       queueEntry,

--- a/packages/esm-outpatient-app/src/queue-screen/useActiveTickets.tsx
+++ b/packages/esm-outpatient-app/src/queue-screen/useActiveTickets.tsx
@@ -2,12 +2,12 @@ import { openmrsFetch } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 
 export const useActiveTickets = () => {
-  const { data, isLoading, error } = useSWR<{ data: Record<string, { status: string; ticketNumber: string }> }>(
+  const { data, isLoading, error, mutate } = useSWR<{ data: Record<string, { status: string; ticketNumber: string }> }>(
     '/ws/rest/v1/queueutil/active-tickets',
     openmrsFetch,
     { refreshInterval: 3000 },
   );
   const activeTickets =
     Array.from(Object.entries(data?.data ?? {}).map(([key, value]) => ({ room: key, ...value }))) ?? [];
-  return { activeTickets, isLoading, error };
+  return { activeTickets, isLoading, error, mutate };
 };

--- a/packages/esm-outpatient-app/src/transition-queue-entry/transition-queue-entry-dialog.component.tsx
+++ b/packages/esm-outpatient-app/src/transition-queue-entry/transition-queue-entry-dialog.component.tsx
@@ -16,6 +16,7 @@ import {
 } from '@openmrs/esm-framework';
 import {
   MappedVisitQueueEntry,
+  serveQueueEntry,
   updateQueueEntry,
   useVisitQueueEntries,
 } from '../active-visits/active-visits-table.resource';
@@ -66,15 +67,19 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
     ).then(
       ({ status }) => {
         if (status === 201) {
-          showToast({
-            critical: true,
-            title: t('success', 'Success'),
-            kind: 'success',
-            description: t('patientAttendingService', 'Patient attending service'),
+          serveQueueEntry(queueEntry?.service, queueEntry?.visitQueueNumber, 'serving').then(({ status }) => {
+            if (status === 200) {
+              showToast({
+                critical: true,
+                title: t('success', 'Success'),
+                kind: 'success',
+                description: t('patientAttendingService', 'Patient attending service'),
+              });
+              closeModal();
+              mutate();
+              navigate({ to: `\${openmrsSpaBase}/patient/${queueEntry?.patientUuid}/chart` });
+            }
           });
-          closeModal();
-          mutate();
-          navigate({ to: `\${openmrsSpaBase}/patient/${queueEntry?.patientUuid}/chart` });
         }
       },
       (error) => {

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -70,6 +70,7 @@
   "errorAddingQueueRoom": "Error adding queue room",
   "errorClearingQueues": "Error clearing queues",
   "errorFetchingAppoinments": "Error fetching appointments",
+  "errorPostingToScreen": "Error posting to screen",
   "facility": "Facility",
   "female": "Female",
   "femaleLabelText": "Female",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Added mutate public queue screen entries on serving and calling clients in queue

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
https://www.loom.com/share/21cf893cbe0445d196bd656e368b000c

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
