### PR TITLE
(fix) KH-139: Fixed navigation display for sections

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/section/section-wrapper.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/section-wrapper.component.tsx
@@ -23,7 +23,7 @@ export const SectionWrapper = ({ sectionDefinition, index }: SectionWrapperProps
    * t('relationshipsSection', 'Relationships')
    */
   return (
-    <div id={sectionDefinition.id}>
+    <div id={sectionDefinition.id} style={{ scrollMarginTop: '100px' }}>
       <h3 className={styles.productiveHeading02} style={{ color: '#161616' }}>
         {index + 1}. {t(`${sectionDefinition.id}Section`, sectionDefinition.name)}
       </h3>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR fixes navigation display of sections using side quick scroll.

## Screenshots

https://user-images.githubusercontent.com/54466041/231099079-f360de89-3bd8-4045-96df-f21756c4c840.mov

## Related Issue

- https://issues.openmrs.org/browse/KH-139


