### PR TITLE
(fix) O3-1994: Change dev server port of testOnPush job to 8180

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Copy test environment variables
-        run: cp example.env .env
+        run: |
+          cp example.env .env
+          sed -i 's/8080/8180/g' .env
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -93,7 +95,7 @@ jobs:
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:9000/openmrs/login.htm)" != "200" ]]; do sleep 10; done
 
       - name: Run dev server
-        run: yarn start --sources 'packages/esm-*-app/' --backend "http://localhost:9000" &
+        run: yarn start --sources 'packages/esm-*-app/' --backend "http://localhost:9000" --port 8180 & # Refer to O3-1994
 
       - name: Run E2E tests
         run: yarn playwright test


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
The 8084 port of the currently used github-action ubuntu runner is already allocated for a different service in default. So it fails to run the esm-patient-lists app on testOnPush workflow. Therefore, The base port was changed to 8180
<!--
Required.
Please describe what problems your PR addresses.
-->

## Screenshots
<img width="693" alt="image" src="https://user-images.githubusercontent.com/27498587/231124973-ff779e1c-4110-4582-b8d7-b979cfde4804.png">

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-1994
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other
*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
