### PR TITLE
(fix) Fixed empty location in change queue status dialog

### DIFF
--- a/packages/esm-outpatient-app/src/active-visits/change-status-dialog.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/change-status-dialog.component.tsx
@@ -130,6 +130,7 @@ const ChangeStatus: React.FC<ChangeStatusDialogProps> = ({ queueEntry, closeModa
                   setSelectedQueueLocation(event.target.value);
                   setEditLocation(true);
                 }}>
+                {!selectedQueueLocation ? <SelectItem text={t('selectOption', 'Select an option')} value="" /> : null}
                 {queueLocations?.length > 0 &&
                   queueLocations.map((location) => (
                     <SelectItem key={location.id} text={location.name} value={location.id}>

--- a/packages/esm-outpatient-app/translations/en.json
+++ b/packages/esm-outpatient-app/translations/en.json
@@ -202,6 +202,7 @@
   "secondaryHelperText": "Type the patient's name or unique ID number",
   "selectFacility": "Select a facility",
   "selectLocation": "Select a location",
+  "selectOption": "Select an option",
   "selectProgramType": "Select program type",
   "selectQueueLocation": "Select a queue location",
   "selectRoom": "Select a room",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Fixed empty location in change queue status dialog

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="954" alt="Capture 4" src="https://user-images.githubusercontent.com/19533785/231225203-ec35c52f-677c-4d3c-ab1a-cc5192b5bd3c.PNG">

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
