### PR TITLE
(fix) Fix the appearance of the service column in the appointments widget

### DIFF
--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.scss
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.scss
@@ -84,6 +84,8 @@
 
 .serviceContainer {
   display: flex;
+  align-items: center;
+  width: max-content;
 }
 
 .identifier {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Fixes the appearance of the service column in the `today's appointment`'s widget datatable.

## Screenshots

> Before
<img width="316" alt="Screenshot 2023-04-13 at 3 38 12 PM" src="https://user-images.githubusercontent.com/8509731/231760874-2c32b86f-774d-421d-8177-498fa1fa8094.png">

> After
<img width="310" alt="Screenshot 2023-04-13 at 3 38 26 PM" src="https://user-images.githubusercontent.com/8509731/231760890-310c9283-1d56-42f6-99d7-6a9ba3a53ab3.png">
