### PR TITLE
(feat) Implement the deceased variant of the patient banner in the advanced search

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -120,11 +120,11 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
           {!hideActionsOverflow && (
             <div className={styles.overflowMenuContainer} ref={overflowMenuRef}>
               <CustomOverflowMenuComponent
-                deceased={isDeceased}
+                isDeceased={isDeceased}
                 menuTitle={
                   <>
                     <span className={styles.actionsButtonText}>{t('actions', 'Actions')}</span>{' '}
-                    <OverflowMenuVertical size={16} style={{ marginLeft: '0.5rem', fill: '#78A9FF' }} />
+                    <OverflowMenuVertical size={16} />
                   </>
                 }
                 dropDownMenu={showDropdown}>

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -23,7 +23,6 @@ interface PatientBannerProps {
   onTransition?: () => void;
   hideActionsOverflow?: boolean;
   selectPatientAction: (evt: any, patientUuid: string) => void;
-  isActivePatient?: boolean;
 }
 
 const PatientBanner: React.FC<PatientBannerProps> = ({

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -40,7 +40,6 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
   const { currentVisit } = useVisit(patientUuid);
   const [showDropdown, setShowDropdown] = React.useState(false);
   const config = useConfig();
-  const isDeceased = patient.person.dead;
 
   const patientActionsSlotState = React.useMemo(
     () => ({ patientUuid, selectPatientAction, onTransition, launchPatientChart: true }),

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -23,6 +23,7 @@ interface PatientBannerProps {
   onTransition?: () => void;
   hideActionsOverflow?: boolean;
   selectPatientAction: (evt: any, patientUuid: string) => void;
+  isActivePatient?: boolean;
 }
 
 const PatientBanner: React.FC<PatientBannerProps> = ({
@@ -33,12 +34,13 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
   selectPatientAction,
 }) => {
   const { t } = useTranslation();
-  const overFlowMenuRef = React.useRef(null);
+  const overflowMenuRef = React.useRef(null);
   const showContactDetailsRef = React.useRef(null);
   const startVisitButtonRef = React.useRef(null);
   const { currentVisit } = useVisit(patientUuid);
   const [showDropdown, setShowDropdown] = React.useState(false);
   const config = useConfig();
+  const isDeceased = patient.person.dead;
 
   const patientActionsSlotState = React.useMemo(
     () => ({ patientUuid, selectPatientAction, onTransition, launchPatientChart: true }),
@@ -84,7 +86,11 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
 
   return (
     <>
-      <div className={styles.container} role="banner">
+      <div
+        className={`${styles.container} ${
+          isDeceased ? styles.deceasedPatientContainer : styles.activePatientContainer
+        }`}
+        role="banner">
         <ConfigurableLink
           to={`${interpolateString(config.search.patientResultUrl, {
             patientUuid: patientUuid,
@@ -112,12 +118,13 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
         </ConfigurableLink>
         <div className={styles.buttonCol}>
           {!hideActionsOverflow && (
-            <div ref={overFlowMenuRef}>
+            <div className={styles.overflowMenuContainer} ref={overflowMenuRef}>
               <CustomOverflowMenuComponent
+                deceased={isDeceased}
                 menuTitle={
                   <>
                     <span className={styles.actionsButtonText}>{t('actions', 'Actions')}</span>{' '}
-                    <OverflowMenuVertical size={16} style={{ marginLeft: '0.5rem' }} />
+                    <OverflowMenuVertical size={16} style={{ marginLeft: '0.5rem', fill: '#78A9FF' }} />
                   </>
                 }
                 dropDownMenu={showDropdown}>

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -122,14 +122,13 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
                 menuTitle={
                   <>
                     <span className={styles.actionsButtonText}>{t('actions', 'Actions')}</span>{' '}
-                    <OverflowMenuVertical size={16} />
+                    <OverflowMenuVertical className={styles.menu} size={16} />
                   </>
                 }
                 dropDownMenu={showDropdown}>
                 <ExtensionSlot
                   onClick={closeDropdownMenu}
                   extensionSlotName="patient-search-actions-slot"
-                  className={styles.overflowMenuItemList}
                   state={patientActionsSlotState}
                 />
               </CustomOverflowMenuComponent>

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
@@ -15,7 +15,7 @@
 }
 
 .deceasedPatientContainer {
-  background-color: colors.$gray-80;
+  background-color: colors.$gray-70;
 
   .patientName {
     color: $ui-01;
@@ -30,9 +30,16 @@
     color: colors.$blue-40;
   }
 
+  .OverflowMenuVertical {
+    width: 16px;
+    height: 16px;
+    margin-left: 0.5rem;
+    fill: #78a9ff;
+  }
+
   &:focus,
   &:hover {
-    background-color: colors.$gray-90;
+    background-color: colors.$gray-70;
   }
 }
 

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
@@ -14,8 +14,14 @@
   background-color: $ui-02;
 }
 
+.menu {
+  width: 1rem;
+  height: 1rem;
+  margin-left: 0.5rem;
+}
+
 .deceasedPatientContainer {
-  background-color: colors.$gray-70;
+  background-color: colors.$gray-80;
 
   .patientName {
     color: $ui-01;
@@ -30,21 +36,14 @@
     color: colors.$blue-40;
   }
 
-  .OverflowMenuVertical {
-    width: 16px;
-    height: 16px;
-    margin-left: 0.5rem;
-    fill: #78a9ff;
+  .menu {
+    fill: colors.$blue-40;
   }
 
   &:focus,
   &:hover {
-    background-color: colors.$gray-70;
+    background-color: colors.$gray-90;
   }
-}
-
-.overflowMenuContainer {
-  margin: -0.75rem 0;
 }
 
 .patientBanner {

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
@@ -1,3 +1,4 @@
+@use '@carbon/colors';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import '~@openmrs/esm-styleguide/src/vars';
@@ -7,6 +8,36 @@
   background-color: $ui-02;
   display: grid;
   grid-template-columns: 1fr auto;
+}
+
+.activePatientContainer {
+  background-color: $ui-02;
+}
+
+.deceasedPatientContainer {
+  background-color: colors.$gray-80;
+
+  .patientName {
+    color: $ui-01;
+  }
+
+  .demographics,
+  .identifiers {
+    color: $ui-02;
+  }
+
+  .actionsButtonText {
+    color: colors.$blue-40;
+  }
+
+  &:focus,
+  &:hover {
+    background-color: colors.$gray-90;
+  }
+}
+
+.overflowMenuContainer {
+  margin: -0.75rem 0;
 }
 
 .patientBanner {
@@ -87,8 +118,4 @@
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-end;
-
-  :global(.cds--tooltip--definition .cds--tooltip__trigger) {
-    border-bottom: none;
-  }
 }

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.component.tsx
@@ -1,16 +1,18 @@
-import { Button } from '@carbon/react';
 import React, { useState, useCallback, useEffect, useRef } from 'react';
+import styles from './overflow-menu.scss';
 
 interface CustomOverflowMenuComponentProps {
-  children?: React.ReactNode;
   menuTitle: React.ReactNode;
   dropDownMenu: boolean;
+  children: React.ReactNode;
+  deceased?: boolean;
 }
 
 const CustomOverflowMenuComponent: React.FC<CustomOverflowMenuComponentProps> = ({
   dropDownMenu,
   menuTitle,
   children,
+  deceased,
 }) => {
   const [showMenu, setShowMenu] = useState(false);
   const wrapperRef = useRef(null);
@@ -43,49 +45,25 @@ const CustomOverflowMenuComponent: React.FC<CustomOverflowMenuComponentProps> = 
   }, [wrapperRef]);
 
   return (
-    <div
-      data-overflow-menu
-      className="cds--overflow-menu"
-      style={{
-        width: 'auto',
-        height: 'auto',
-      }}
-      ref={wrapperRef}>
-      <Button
-        kind="ghost"
-        className={`cds--overflow-menu__trigger ${showMenu && 'cds--overflow-menu--open'}`}
+    <div data-overflow-menu className={`cds--overflow-menu ${styles.container}`} ref={wrapperRef}>
+      <button
+        className={`cds--btn cds--btn--ghost cds--overflow-menu__trigger ${showMenu && 'cds--overflow-menu--open'} ${
+          deceased && styles.deceased
+        } ${styles.overflowMenuButton}`}
         aria-haspopup="true"
         aria-expanded={showMenu}
         id="custom-actions-overflow-menu-trigger"
         aria-controls="custom-actions-overflow-menu"
-        onClick={toggleShowMenu}
-        style={{
-          width: 'auto',
-          height: 'auto',
-          padding: '1rem',
-          color: '#0f62fe',
-          outline: '2rem solid transparent',
-          boxShadow: showMenu ? '0 2px 6px 0 rgb(0 0 0 / 30%)' : 'none',
-        }}>
+        onClick={toggleShowMenu}>
         {menuTitle}
-      </Button>
+      </button>
       <div
-        className="cds--overflow-menu-options cds--overflow-menu--flip"
+        className={`cds--overflow-menu-options cds--overflow-menu--flip ${styles.menu} ${showMenu && styles.show}`}
         tabIndex={0}
         data-floating-menu-direction="bottom"
         role="menu"
         aria-labelledby="custom-actions-overflow-menu-trigger"
-        id="custom-actions-overflow-menu"
-        style={{
-          display: showMenu ? 'block' : 'none',
-          top: '3.125rem',
-          minWidth: 'initial',
-          left: 'auto',
-          right: '0',
-          backgroundColor: '#f4f4f4',
-          marginRight: '0.2rem',
-          boxShadow: '0 6px 6px rgb(0 0 0 / 30%)',
-        }}>
+        id="custom-actions-overflow-menu">
         <ul className="cds--overflow-menu-options__content">{children}</ul>
         <span />
       </div>

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.component.tsx
@@ -50,7 +50,7 @@ const CustomOverflowMenuComponent: React.FC<CustomOverflowMenuComponentProps> = 
       <Button
         kind="ghost"
         className={`cds--overflow-menu__trigger ${showMenu && 'cds--overflow-menu--open'} ${
-          isDeceased ? styles.isDeceased : ''
+          isDeceased ? styles.deceased : ''
         } ${styles.overflowMenuButton}`}
         aria-haspopup="true"
         aria-expanded={showMenu}

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.component.tsx
@@ -1,18 +1,19 @@
+import { Button } from '@carbon/react';
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import styles from './overflow-menu.scss';
 
 interface CustomOverflowMenuComponentProps {
   menuTitle: React.ReactNode;
   dropDownMenu: boolean;
-  children: React.ReactNode;
-  deceased?: boolean;
+  children?: React.ReactNode;
+  isDeceased?: boolean;
 }
 
 const CustomOverflowMenuComponent: React.FC<CustomOverflowMenuComponentProps> = ({
   dropDownMenu,
   menuTitle,
   children,
-  deceased,
+  isDeceased,
 }) => {
   const [showMenu, setShowMenu] = useState(false);
   const wrapperRef = useRef(null);
@@ -46,9 +47,10 @@ const CustomOverflowMenuComponent: React.FC<CustomOverflowMenuComponentProps> = 
 
   return (
     <div data-overflow-menu className={`cds--overflow-menu ${styles.container}`} ref={wrapperRef}>
-      <button
-        className={`cds--btn cds--btn--ghost cds--overflow-menu__trigger ${showMenu && 'cds--overflow-menu--open'} ${
-          deceased && styles.deceased
+      <Button
+        kind="ghost"
+        className={`cds--overflow-menu__trigger ${showMenu && 'cds--overflow-menu--open'} ${
+          isDeceased ? styles.isDeceased : ''
         } ${styles.overflowMenuButton}`}
         aria-haspopup="true"
         aria-expanded={showMenu}
@@ -56,7 +58,7 @@ const CustomOverflowMenuComponent: React.FC<CustomOverflowMenuComponentProps> = 
         aria-controls="custom-actions-overflow-menu"
         onClick={toggleShowMenu}>
         {menuTitle}
-      </button>
+      </Button>
       <div
         className={`cds--overflow-menu-options cds--overflow-menu--flip ${styles.menu} ${showMenu && styles.show}`}
         tabIndex={0}

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.scss
@@ -1,0 +1,39 @@
+@use '@carbon/colors';
+@import '~@openmrs/esm-styleguide/src/vars';
+
+.container {
+  padding: 0.875rem 1rem;
+
+  width: auto;
+  height: auto;
+}
+
+.menu {
+  display: none;
+  top: 3.125rem;
+  min-width: initial;
+  left: auto;
+  right: 0;
+  background-color: $ui-01;
+  margin-right: 0.2rem;
+  box-shadow: 0 6px 6px rgb(0 0 0 / 30%);
+}
+
+.show {
+  display: block;
+}
+
+.overflowMenuButton {
+  width: auto;
+  height: auto;
+  padding: 0.875rem 1rem;
+  color: colors.$blue-60;
+
+  &:hover {
+    background-color: colors.$gray-10-hover;
+  }
+}
+
+.deceased {
+  color: colors.$blue-40;
+}

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.scss
@@ -3,7 +3,6 @@
 
 .container {
   padding: 0.875rem 1rem;
-
   width: auto;
   height: auto;
 }

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.scss
@@ -2,7 +2,6 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .container {
-  padding: 0.875rem 1rem;
   width: auto;
   height: auto;
 }
@@ -20,6 +19,7 @@
 
 .show {
   display: block;
+  left: -6rem !important;
 }
 
 .overflowMenuButton {
@@ -35,4 +35,8 @@
 
 .deceased {
   color: colors.$blue-40;
+
+  > svg {
+    fill: colors.$blue-40 !important;
+  }
 }

--- a/packages/esm-patient-search-app/src/types/index.ts
+++ b/packages/esm-patient-search-app/src/types/index.ts
@@ -3,6 +3,7 @@ export interface SearchedPatient {
   uuid: string;
   identifiers: Array<Identifier>;
   person: {
+    [x: string]: any;
     addresses: Array<Address>;
     age: number;
     birthdate: string;

--- a/packages/esm-patient-search-app/src/types/index.ts
+++ b/packages/esm-patient-search-app/src/types/index.ts
@@ -3,7 +3,6 @@ export interface SearchedPatient {
   uuid: string;
   identifiers: Array<Identifier>;
   person: {
-    [x: string]: any;
     addresses: Array<Address>;
     age: number;
     birthdate: string;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

I implemented the next iteration of the patient banner when searching a deceased  patient on Advanced search  based on the design on this link https://zeroheight.com/23a080e38/p/6663f3-patient-header. i.e. Changed the colour of the deceased tag, background colour of the header and amended the font colours to match what's outlined in the design.

<!--
Required.
Please describe what problems your PR addresses.
-->



## Screenshots
![Screenshot 2023-04-18 at 7 48 52 PM](https://user-images.githubusercontent.com/33891016/232848373-17288a04-0b84-4c3b-8a33-9e6c0ac26c65.png)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
