### PR TITLE
(feat) Implement the deceased variant of the patient banner in the compact search

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -72,7 +72,7 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
           const patientIdentifiers = patient.identifier.filter((identifier) =>
             config.defaultIdentifierTypes.includes(identifier.identifierType.uuid),
           );
-          const isDeceased = !!patient.deceasedDateTime || !!patient.deceasedBoolean;
+          const isDeceased = Boolean(patient?.deceasedDateTime);
           return (
             <ConfigurableLink
               onClick={(evt) => selectPatientAction(evt, indx)}
@@ -92,9 +92,16 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
                 />
               </div>
               <div>
-                <h2 className={styles.patientName}>{`${patient.name?.[0]?.given?.join(' ')} ${
-                  patient.name?.[0]?.family
-                }`}</h2>
+                <div className={styles.flexRow}>
+                  <h2 className={styles.patientName}>{`${patient.name?.[0]?.given?.join(' ')} ${
+                    patient.name?.[0]?.family
+                  }`}</h2>
+                  <ExtensionSlot
+                    extensionSlotName="patient-banner-tags-slot"
+                    state={{ patient }}
+                    className={styles.flexRow}
+                  />
+                </div>
                 <p className={styles.demographics}>
                   {getGender(patient.gender)} <span className={styles.middot}>&middot;</span> {age(patient.birthDate)}
                   <span className={styles.middot}>&middot;</span>

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -72,6 +72,7 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
           const patientIdentifiers = patient.identifier.filter((identifier) =>
             config.defaultIdentifierTypes.includes(identifier.identifierType.uuid),
           );
+          const isDeceased = !!patient.deceasedDateTime || !!patient.deceasedBoolean;
           return (
             <ConfigurableLink
               onClick={(evt) => selectPatientAction(evt, indx)}
@@ -79,7 +80,7 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
                 patientUuid: patient.id,
               })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`}
               key={patient.id}
-              className={styles.patientSearchResult}>
+              className={`${styles.patientSearchResult} ${isDeceased ? styles.deceased : ''}`}>
               <div className={styles.patientAvatar} role="img">
                 <ExtensionSlot
                   extensionSlotName="patient-photo-slot"

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -100,6 +100,7 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
                     extensionSlotName="patient-banner-tags-slot"
                     state={{ patient }}
                     className={styles.flexRow}
+                    select={(extensions) => extensions.filter((ext) => ext.name === 'deceased-patient-tag')}
                   />
                 </div>
                 <p className={styles.demographics}>

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
@@ -1,3 +1,4 @@
+@use '@carbon/colors';
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @import '~@openmrs/esm-styleguide/src/vars';
@@ -16,6 +17,27 @@
     background-color: $ui-01;
     border: 0;
     outline: 0;
+  }
+}
+
+.deceased.patientSearchResult {
+  background-color: colors.$gray-70;
+
+  .patientName {
+    color: $ui-01;
+  }
+
+  .demographics,
+  .patientIdentifiers,
+  .identifierTag {
+    color: $ui-02;
+
+    &:hover,
+    &:focus {
+      background-color: colors.$gray-70;
+      border: 0;
+      outline: 0;
+    }
   }
 }
 

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
@@ -31,13 +31,6 @@
   .patientIdentifiers,
   .identifierTag {
     color: $ui-02;
-
-    &:hover,
-    &:focus {
-      background-color: colors.$gray-70;
-      border: 0;
-      outline: 0;
-    }
   }
 
   &:focus,

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
@@ -53,7 +53,7 @@
 .patientName {
   @include type.type-style('heading-02');
   color: $text-02;
-  margin-right: 0.25rem;
+  margin-right: spacing.$spacing-02;
 }
 
 .patientAvatar {

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
@@ -21,7 +21,7 @@
 }
 
 .deceased.patientSearchResult {
-  background-color: colors.$gray-70;
+  background-color: colors.$gray-80;
 
   .patientName {
     color: $ui-01;
@@ -39,6 +39,11 @@
       outline: 0;
     }
   }
+
+  &:focus,
+  &:hover {
+    background-color: colors.$gray-90;
+  }
 }
 
 .patientBanner {
@@ -48,6 +53,7 @@
 .patientName {
   @include type.type-style('heading-02');
   color: $text-02;
+  margin-right: 0.25rem;
 }
 
 .patientAvatar {
@@ -98,4 +104,14 @@
 .configuredLabel {
   @include type.type-style('label-01');
   color: $ui-05;
+}
+
+.deceased .configuredLabel {
+  color: $ui-01;
+}
+
+.flexRow {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
I implemented the next iteration of the compact patient banner when searching a deceased patient based on the design on this link https://zeroheight.com/23a080e38/p/6663f3-patient-header. i.e. Changed the colour of the deceased tag, background colour of the header and amended the font colours to match what's outlined in the design.

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
![Screenshot 2023-04-23 at 4 15 52 PM](https://user-images.githubusercontent.com/33891016/233841988-6de25708-9788-4989-8d61-eabf32ac2848.png)

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
