### PR TITLE
(fix) Fixed the undefined `values.attributes` error thrown when saving a new patient

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -53,7 +53,7 @@ export class FormManager {
   ) => {
     const syncItem: PatientRegistration = {
       fhirPatient: FormManager.mapPatientToFhirPatient(
-        FormManager.getPatientToCreate(values, patientUuidMap, initialAddressFieldValues, []),
+        FormManager.getPatientToCreate(isNewPatient, values, patientUuidMap, initialAddressFieldValues, []),
       ),
       _patientRegistrationData: {
         isNewPatient,
@@ -101,6 +101,7 @@ export class FormManager {
     );
 
     const createdPatient = FormManager.getPatientToCreate(
+      isNewPatient,
       values,
       patientUuidMap,
       initialAddressFieldValues,
@@ -281,6 +282,7 @@ export class FormManager {
   }
 
   static getPatientToCreate(
+    isNewPatient: boolean,
     values: FormValues,
     patientUuidMap: PatientUuidMapType,
     initialAddressFieldValues: Record<string, any>,
@@ -303,7 +305,7 @@ export class FormManager {
         gender: values.gender.charAt(0),
         birthdate,
         birthdateEstimated: values.birthdateEstimated,
-        attributes: FormManager.getPatientAttributes(values, patientUuidMap),
+        attributes: FormManager.getPatientAttributes(isNewPatient, values, patientUuidMap),
         addresses: [values.address],
         ...FormManager.getPatientDeathInfo(values),
       },
@@ -335,7 +337,7 @@ export class FormManager {
     return names;
   }
 
-  static getPatientAttributes(values: FormValues, patientUuidMap: PatientUuidMapType) {
+  static getPatientAttributes(isNewPatient: boolean, values: FormValues, patientUuidMap: PatientUuidMapType) {
     const attributes: Array<AttributeValue> = [];
     if (values.attributes) {
       Object.entries(values.attributes)
@@ -347,7 +349,7 @@ export class FormManager {
           });
         });
 
-      if (values.patientUuid) {
+      if (!isNewPatient && values.patientUuid) {
         Object.entries(values.attributes)
           .filter(([, value]) => !value)
           .forEach(async ([key]) => {

--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -346,26 +346,27 @@ export class FormManager {
             value,
           });
         });
+
+      if (values.patientUuid) {
+        Object.entries(values.attributes)
+          .filter(([, value]) => !value)
+          .forEach(async ([key]) => {
+            const attributeUuid = patientUuidMap[`attribute.${key}`];
+            await openmrsFetch(`/ws/rest/v1/person/${values.patientUuid}/attribute/${attributeUuid}`, {
+              method: 'DELETE',
+            }).catch((err) => {
+              console.error(err);
+            });
+          });
+      }
     }
+
     if (values.unidentifiedPatient) {
       attributes.push({
         // The UUID of the 'Unknown Patient' attribute-type will always be static across all implementations of OpenMRS
         attributeType: '8b56eac7-5c76-4b9c-8c6f-1deab8d3fc47',
         value: 'true',
       });
-    }
-
-    if (values.patientUuid) {
-      Object.entries(values.attributes)
-        .filter(([, value]) => !value)
-        .forEach(async ([key]) => {
-          const attributeUuid = patientUuidMap[`attribute.${key}`];
-          await openmrsFetch(`/ws/rest/v1/person/${values.patientUuid}/attribute/${attributeUuid}`, {
-            method: 'DELETE',
-          }).catch((err) => {
-            console.error(err);
-          });
-        });
     }
 
     return attributes;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes the undefined `values.attributes` error thrown when saving a new patient.
`Object.entries(values.attributes)` was throwing an error in case `values.attributes` was undefined.
Wrapped the deletion of visit attributes only if values.attributes is defined.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
