### PR TITLE
(fix) O3-2071: improved coverage for select-input component

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/select/select-input.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/select/select-input.test.tsx
@@ -3,16 +3,16 @@ import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import { Formik, Form } from 'formik';
 import { SelectInput } from './select-input.component';
 
-describe.skip('select input', () => {
+describe('select input', () => {
   const setupSelect = async () => {
     render(
       <Formik initialValues={{ select: '' }} onSubmit={null}>
         <Form>
-          <SelectInput label="Select" name="select" options={['A Option', 'B Option']} />
+          <SelectInput label="Select" name="select" options={['A Option', 'B Option']} required />
         </Form>
       </Formik>,
     );
-    return screen.getByLabelText('select') as HTMLInputElement;
+    return screen.getByLabelText('Select') as HTMLInputElement;
   };
 
   it('exists', async () => {
@@ -28,5 +28,15 @@ describe.skip('select input', () => {
     fireEvent.blur(input);
 
     await waitFor(() => expect(input.value).toEqual(expected));
+  });
+  it('optional get added if the input is not required', () => {
+    const input = render(
+      <Formik initialValues={{ select: '' }} onSubmit={null}>
+        <Form>
+          <SelectInput label="Select" name="select" options={['A Option', 'B Option']} />
+        </Form>
+      </Formik>,
+    );
+    expect(screen.getByLabelText('Select (optional)')).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/select/select-input.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/select/select-input.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import { Formik, Form } from 'formik';
 import { SelectInput } from './select-input.component';
 
-describe('select input', () => {
+describe('the select input', () => {
   const setupSelect = async () => {
     render(
       <Formik initialValues={{ select: '' }} onSubmit={null}>
@@ -29,14 +29,16 @@ describe('select input', () => {
 
     await waitFor(() => expect(input.value).toEqual(expected));
   });
-  it('optional get added if the input is not required', () => {
-    const input = render(
+  it('should show optional label if the input is not required', () => {
+    render(
       <Formik initialValues={{ select: '' }} onSubmit={null}>
         <Form>
           <SelectInput label="Select" name="select" options={['A Option', 'B Option']} />
         </Form>
       </Formik>,
     );
-    expect(screen.getByLabelText('Select (optional)')).toBeInTheDocument();
+    const selectInput = screen.getByRole('combobox', { name: 'Select (optional)' }) as HTMLSelectElement;
+    expect(selectInput.labels).toHaveLength(1);
+    expect(selectInput.labels[0]).toHaveTextContent('Select (optional)');
   });
 });

--- a/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/select/select-input.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/select/select-input.test.tsx
@@ -29,6 +29,7 @@ describe('the select input', () => {
 
     await waitFor(() => expect(input.value).toEqual(expected));
   });
+
   it('should show optional label if the input is not required', () => {
     render(
       <Formik initialValues={{ select: '' }} onSubmit={null}>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

In this PR I updated the tests for select-input component. Earlier test under the file `select-input.test.tsx` was getting skipped because they were failing due to querying using incorrect label text. I corrected the label text and also added a new test case for covering the uncovered scenario which is "if the input is not required then the label will have (optional) as suffix".

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

https://issues.openmrs.org/browse/O3-2071
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
