### PR TITLE
(fix) KH-138(v2) : Fixed the value for the 'Select an option' option

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.component.tsx
@@ -31,17 +31,19 @@ export function CodedPersonAttributeField({
           <Field name={fieldName}>
             {({ field, form: { touched, errors }, meta }) => {
               return (
-                <Select
-                  id={id}
-                  name={`person-attribute-${personAttributeType.uuid}`}
-                  labelText={label ?? personAttributeType?.display}
-                  invalid={errors[fieldName] && touched[fieldName]}
-                  {...field}>
-                  <SelectItem value={null} text={t('selectAnOption', 'Select an option')} />
-                  {conceptAnswers.map((answer) => (
-                    <SelectItem key={answer.uuid} value={answer.uuid} text={answer.display} />
-                  ))}
-                </Select>
+                <>
+                  <Select
+                    id={id}
+                    name={`person-attribute-${personAttributeType.uuid}`}
+                    labelText={label ?? personAttributeType?.display}
+                    invalid={errors[fieldName] && touched[fieldName]}
+                    {...field}>
+                    <SelectItem value={''} text={t('selectAnOption', 'Select an option')} />
+                    {conceptAnswers.map((answer) => (
+                      <SelectItem key={answer.uuid} value={answer.uuid} text={answer.display} />
+                    ))}
+                  </Select>
+                </>
               );
             }}
           </Field>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR is an iteration to #664 with the fix for the select dropdown, where "Select an option" option's selection makes the value for the attribute to "Select an option" instead of `null`.

Instead of `null`, I have instead used `''` since the !null == !'' == true.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/KH-138


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
