### PR TITLE
fix: Broken pagination on the advanced patient search page

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
@@ -43,10 +43,6 @@ const PatientSearchComponent: React.FC<PatientSearchComponentProps> = ({
     resultsToShow,
   );
 
-  useEffect(() => {
-    goTo(1);
-  }, [query, goTo]);
-
   const handlePatientSelection = useCallback(
     (evt, patientUuid: string) => {
       evt.preventDefault();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Fixed broken pagination on the advanced patient search page 
cc @vasharma05  
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

https://user-images.githubusercontent.com/58003327/235641120-0727f594-eb48-40b6-9681-564d011f8559.mov


<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->
https://issues.openmrs.org/browse/O3-2068

## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
