### PR TITLE
(feat) Active visits display user configurable headers

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -30,12 +30,65 @@ import {
 } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { EmptyDataIllustration } from './empty-data-illustration.component';
-import { ActiveVisit, useActiveVisits, getOriginFromPathName } from './active-visits.resource';
+import { useActiveVisits, getOriginFromPathName } from './active-visits.resource';
 import styles from './active-visits.scss';
 
 interface NameLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
   from: string;
+}
+
+function ComputeExpensiveValue(t, config) {
+  let headersIndex = 0;
+
+  const headers = [
+    {
+      id: headersIndex++,
+      header: t('visitStartTime', 'Visit Time'),
+      key: 'visitStartTime',
+    },
+  ];
+
+  config?.activeVisits?.identifiers?.map((identifier) => {
+    headers.push({
+      id: headersIndex++,
+      header: t(identifier?.header?.key, identifier?.header?.default),
+      key: identifier?.header?.key,
+    });
+  });
+
+  config?.activeVisits?.attributes?.map((attribute) => {
+    headers.push({
+      id: headersIndex++,
+      header: t(attribute?.header?.key, attribute?.header?.default),
+      key: attribute?.header?.key,
+    });
+  });
+
+  headers.push(
+    {
+      id: headersIndex++,
+      header: t('name', 'Name'),
+      key: 'name',
+    },
+    {
+      id: headersIndex++,
+      header: t('gender', 'Gender'),
+      key: 'gender',
+    },
+    {
+      id: headersIndex++,
+      header: t('age', 'Age'),
+      key: 'age',
+    },
+    {
+      id: headersIndex++,
+      header: t('visitType', 'Visit Type'),
+      key: 'visitType',
+    },
+  );
+
+  return headers;
 }
 
 const PatientNameLink: React.FC<NameLinkProps> = ({ from, to, children }) => {
@@ -63,53 +116,21 @@ const ActiveVisitsTable = () => {
   const currentPathName = window.location.pathname;
   const fromPage = getOriginFromPathName(currentPathName);
 
-  const headerData = useMemo(
-    () => [
-      {
-        id: 0,
-        header: t('visitStartTime', 'Visit Time'),
-        key: 'visitStartTime',
-      },
-      {
-        id: 1,
-        header: t('idNumber', 'ID Number'),
-        key: 'idNumber',
-      },
-      {
-        id: 2,
-        header: t('name', 'Name'),
-        key: 'name',
-      },
-      {
-        id: 3,
-        header: t('gender', 'Gender'),
-        key: 'gender',
-      },
-      {
-        id: 4,
-        header: t('age', 'Age'),
-        key: 'age',
-      },
-      {
-        id: 5,
-        header: t('visitType', 'Visit Type'),
-        key: 'visitType',
-      },
-    ],
-    [t],
-  );
+  const headerData = useMemo(() => ComputeExpensiveValue(t, config), [config, t]);
 
   const searchResults = useMemo(() => {
-    if (searchString && searchString.trim() !== '') {
-      const search = searchString.toLowerCase();
-      return activeVisits.filter((activeVisitRow) =>
-        Object.entries(activeVisitRow).some(([header, value]) => {
-          if (header === 'patientUuid') {
-            return false;
-          }
-          return `${value}`.toLowerCase().includes(search);
-        }),
-      );
+    if (activeVisits !== undefined && activeVisits.length > 0) {
+      if (searchString && searchString.trim() !== '') {
+        const search = searchString.toLowerCase();
+        return activeVisits?.filter((activeVisitRow) =>
+          Object.entries(activeVisitRow).some(([header, value]) => {
+            if (header === 'patientUuid') {
+              return false;
+            }
+            return `${value}`.toLowerCase().includes(search);
+          }),
+        );
+      }
     }
 
     return activeVisits;
@@ -181,115 +202,115 @@ const ActiveVisitsTable = () => {
         </Layer>
       </div>
     );
-  }
-
-  return (
-    <div className={styles.activeVisitsContainer}>
-      <div className={styles.activeVisitsDetailHeaderContainer}>
-        <div className={!isDesktop(layout) ? styles.tabletHeading : styles.desktopHeading}>
-          <h4>{t('activeVisits', 'Active Visits')}</h4>
+  } else {
+    return (
+      <div className={styles.activeVisitsContainer}>
+        <div className={styles.activeVisitsDetailHeaderContainer}>
+          <div className={!isDesktop(layout) ? styles.tabletHeading : styles.desktopHeading}>
+            <h4>{t('activeVisits', 'Active Visits')}</h4>
+          </div>
+          <div className={styles.backgroundDataFetchingIndicator}>
+            <span>{isValidating ? <InlineLoading /> : null}</span>
+          </div>
         </div>
-        <div className={styles.backgroundDataFetchingIndicator}>
-          <span>{isValidating ? <InlineLoading /> : null}</span>
-        </div>
-      </div>
-      <Search
-        labelText=""
-        placeholder={t('filterTable', 'Filter table')}
-        onChange={handleSearch}
-        size={isDesktop(layout) ? 'sm' : 'lg'}
-      />
-      <DataTable
-        rows={results}
-        headers={headerData}
-        size={isDesktop(layout) ? 'sm' : 'lg'}
-        useZebraStyles={activeVisits?.length > 1 ? true : false}>
-        {({ rows, headers, getHeaderProps, getTableProps, getRowProps, getExpandHeaderProps }) => (
-          <TableContainer className={styles.tableContainer}>
-            <Table className={styles.activeVisitsTable} {...getTableProps()}>
-              <TableHead>
-                <TableRow>
-                  <TableExpandHeader enableToggle {...getExpandHeaderProps()} />
-                  {headers.map((header) => (
-                    <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
-                  ))}
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {rows.map((row, index) => (
-                  <React.Fragment key={index}>
-                    <TableExpandRow
-                      {...getRowProps({ row })}
-                      data-testid={`activeVisitRow${activeVisits?.[index]?.patientUuid}`}>
-                      {row.cells.map((cell) => (
-                        <TableCell key={cell.id} data-testid={cell.id}>
-                          {cell.info.header === 'name' ? (
-                            <PatientNameLink
-                              from={fromPage}
-                              to={`\${openmrsSpaBase}/patient/${activeVisits?.[index]?.patientUuid}/chart/`}>
-                              {cell.value}
-                            </PatientNameLink>
-                          ) : (
-                            cell.value
-                          )}
-                        </TableCell>
-                      ))}
-                    </TableExpandRow>
-                    {row.isExpanded ? (
-                      <TableRow className={styles.expandedActiveVisitRow}>
-                        <th colSpan={headers.length + 2}>
-                          <ExtensionSlot
-                            className={styles.visitSummaryContainer}
-                            extensionSlotName="visit-summary-slot"
-                            state={{
-                              visitUuid: activeVisits[index]?.visitUuid,
-                              patientUuid: activeVisits[index]?.patientUuid,
-                            }}
-                          />
-                        </th>
-                      </TableRow>
-                    ) : (
-                      <TableExpandedRow className={styles.hiddenRow} colSpan={headers.length + 2} />
-                    )}
-                  </React.Fragment>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        )}
-      </DataTable>
-      {searchResults.length === 0 && (
-        <div className={styles.filterEmptyState}>
-          <Layer level={0}>
-            <Tile className={styles.filterEmptyStateTile}>
-              <p className={styles.filterEmptyStateContent}>{t('noPatientsToDisplay', 'No patients to display')}</p>
-              <p className={styles.filterEmptyStateHelper}>{t('checkFilters', 'Check the filters above')}</p>
-            </Tile>
-          </Layer>
-        </div>
-      )}
-      {paginated && (
-        <Pagination
-          forwardText="Next page"
-          backwardText="Previous page"
-          page={currentPage}
-          pageSize={pageSize}
-          pageSizes={pageSizes}
-          totalItems={searchResults?.length}
-          className={styles.pagination}
+        <Search
+          labelText=""
+          placeholder={t('filterTable', 'Filter table')}
+          onChange={handleSearch}
           size={isDesktop(layout) ? 'sm' : 'lg'}
-          onChange={({ pageSize: newPageSize, page: newPage }) => {
-            if (newPageSize !== pageSize) {
-              setPageSize(newPageSize);
-            }
-            if (newPage !== currentPage) {
-              goTo(newPage);
-            }
-          }}
         />
-      )}
-    </div>
-  );
+        <DataTable
+          rows={results}
+          headers={headerData}
+          size={isDesktop(layout) ? 'sm' : 'lg'}
+          useZebraStyles={activeVisits?.length > 1 ? true : false}>
+          {({ rows, headers, getHeaderProps, getTableProps, getRowProps, getExpandHeaderProps }) => (
+            <TableContainer className={styles.tableContainer}>
+              <Table className={styles.activeVisitsTable} {...getTableProps()}>
+                <TableHead>
+                  <TableRow>
+                    <TableExpandHeader enableToggle {...getExpandHeaderProps()} />
+                    {headers.map((header) => (
+                      <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
+                    ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((row, index) => (
+                    <React.Fragment key={index}>
+                      <TableExpandRow
+                        {...getRowProps({ row })}
+                        data-testid={`activeVisitRow${activeVisits?.[index]?.patientUuid}`}>
+                        {row.cells.map((cell) => (
+                          <TableCell key={cell.id} data-testid={cell.id}>
+                            {cell.info.header === 'name' ? (
+                              <PatientNameLink
+                                from={fromPage}
+                                to={`\${openmrsSpaBase}/patient/${activeVisits?.[index]?.patientUuid}/chart/`}>
+                                {cell.value}
+                              </PatientNameLink>
+                            ) : (
+                              cell.value
+                            )}
+                          </TableCell>
+                        ))}
+                      </TableExpandRow>
+                      {row.isExpanded ? (
+                        <TableRow className={styles.expandedActiveVisitRow}>
+                          <th colSpan={headers.length + 2}>
+                            <ExtensionSlot
+                              className={styles.visitSummaryContainer}
+                              extensionSlotName="visit-summary-slot"
+                              state={{
+                                visitUuid: activeVisits[index]?.visitUuid,
+                                patientUuid: activeVisits[index]?.patientUuid,
+                              }}
+                            />
+                          </th>
+                        </TableRow>
+                      ) : (
+                        <TableExpandedRow className={styles.hiddenRow} colSpan={headers.length + 2} />
+                      )}
+                    </React.Fragment>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </DataTable>
+        {searchResults?.length === 0 && (
+          <div className={styles.filterEmptyState}>
+            <Layer level={0}>
+              <Tile className={styles.filterEmptyStateTile}>
+                <p className={styles.filterEmptyStateContent}>{t('noPatientsToDisplay', 'No patients to display')}</p>
+                <p className={styles.filterEmptyStateHelper}>{t('checkFilters', 'Check the filters above')}</p>
+              </Tile>
+            </Layer>
+          </div>
+        )}
+        {paginated && (
+          <Pagination
+            forwardText="Next page"
+            backwardText="Previous page"
+            page={currentPage}
+            pageSize={pageSize}
+            pageSizes={pageSizes}
+            totalItems={searchResults?.length}
+            className={styles.pagination}
+            size={isDesktop(layout) ? 'sm' : 'lg'}
+            onChange={({ pageSize: newPageSize, page: newPage }) => {
+              if (newPageSize !== pageSize) {
+                setPageSize(newPageSize);
+              }
+              if (newPage !== currentPage) {
+                goTo(newPage);
+              }
+            }}
+          />
+        )}
+      </div>
+    );
+  }
 };
 
 export default ActiveVisitsTable;

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -3,7 +3,15 @@ import useSWRInfinite from 'swr/infinite';
 import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday';
 import last from 'lodash-es/last';
-import { openmrsFetch, Visit, useSession, FetchResponse, formatDatetime, parseDate } from '@openmrs/esm-framework';
+import {
+  openmrsFetch,
+  Visit,
+  useSession,
+  FetchResponse,
+  formatDatetime,
+  parseDate,
+  useConfig,
+} from '@openmrs/esm-framework';
 dayjs.extend(isToday);
 
 export interface ActiveVisit {
@@ -17,6 +25,7 @@ export interface ActiveVisit {
   visitStartTime: string;
   visitType: string;
   visitUuid: string;
+  [identifier: string]: string;
 }
 
 interface VisitResponse {
@@ -27,11 +36,12 @@ interface VisitResponse {
 
 export function useActiveVisits() {
   const session = useSession();
+  const config = useConfig();
   const startDate = dayjs().format('YYYY-MM-DD');
   const sessionLocation = session?.sessionLocation?.uuid;
 
   const customRepresentation =
-    'custom:(uuid,patient:(uuid,identifiers:(identifier,uuid),person:(age,display,gender,uuid)),' +
+    'custom:(uuid,patient:(uuid,identifiers:(identifier,uuid,identifierType:(name,uuid)),person:(age,display,gender,uuid,attributes:(value,attributeType:(uuid,display)))),' +
     'visitType:(uuid,name,display),location:(uuid,name,display),startDatetime,stopDatetime)';
 
   const getUrl = (pageIndex, previousPageData: FetchResponse<VisitResponse>) => {
@@ -63,18 +73,64 @@ export function useActiveVisits() {
     }
   }, [data, pageNumber]);
 
-  const mapVisitProperties = (visit: Visit): ActiveVisit => ({
-    age: visit?.patient?.person?.age,
-    id: visit.uuid,
-    idNumber: visit?.patient?.identifiers[0]?.identifier,
-    gender: visit?.patient?.person?.gender,
-    location: visit?.location?.uuid,
-    name: visit?.patient?.person?.display,
-    patientUuid: visit?.patient?.uuid,
-    visitStartTime: formatDatetime(parseDate(visit?.startDatetime)),
-    visitType: visit?.visitType?.display,
-    visitUuid: visit.uuid,
-  });
+  const mapVisitProperties = (visit: Visit): ActiveVisit => {
+    //create base object
+    const activeVisits: ActiveVisit = {
+      age: visit?.patient?.person?.age,
+      id: visit.uuid,
+      idNumber: null,
+      gender: visit?.patient?.person?.gender,
+      location: visit?.location?.uuid,
+      name: visit?.patient?.person?.display,
+      patientUuid: visit?.patient?.uuid,
+      visitStartTime: formatDatetime(parseDate(visit?.startDatetime)),
+      visitType: visit?.visitType?.display,
+      visitUuid: visit.uuid,
+    };
+
+    //in case no configuration is given the previsous behavior remanes the same
+    if (!config?.activeVisits?.identifiers) {
+      config.activeVisits.identifiers = [
+        {
+          header: {
+            key: 'idNumber',
+            default: 'ID Number',
+          },
+          identifierName: visit?.patient?.identifiers[0].identifierType?.name,
+        },
+      ];
+    } else {
+      //map identifires on config
+      config?.activeVisits?.identifiers?.map((configIdentifier) => {
+        //check if in the current visit the patient has in his identifiers the current identifierType name
+        const visitIdentifier = visit?.patient?.identifiers.find(
+          (visitIdentifier) => visitIdentifier?.identifierType?.name === configIdentifier?.identifierName,
+        );
+
+        //add the new identifier or rewrite existing one to activeVisit object
+        //the parameter will corresponde to the name of the key value of the configuration
+        //and the respective value is the visit identifier
+        //If there isn't a identifier we display this default text '--'
+        activeVisits[configIdentifier.header?.key] = visitIdentifier?.identifier ?? '--';
+      });
+
+      //map attributes on config
+      config?.activeVisits?.attributes?.map(({ display, header }) => {
+        //check if in the current visit the person has in his attributes the current display
+        const personAttributes = visit?.patient?.person?.attributes.find(
+          (personAttributes) => personAttributes?.attributeType?.display === display,
+        );
+
+        //add the new attribute or rewrite existing one to activeVisit object
+        //the parameter will corresponde to the name of the key value of the configuration
+        //and the respective value is the persons value
+        //If there isn't a attribute we display this default text '--'
+        activeVisits[header?.key] = personAttributes?.value ?? '--';
+      });
+    }
+
+    return activeVisits;
+  };
 
   const formattedActiveVisits: Array<ActiveVisit> = data
     ? [].concat(

--- a/packages/esm-active-visits-app/src/config-schema.ts
+++ b/packages/esm-active-visits-app/src/config-schema.ts
@@ -1,5 +1,22 @@
 import { Type } from '@openmrs/esm-framework';
 
+export interface SectionDefinition {
+  activeVisits: {
+    pageSize: Number;
+    pageSizes: Array<Number>;
+    identifiers: Array<IdentifiersDefinition>;
+  };
+}
+
+export interface IdentifiersDefinition {
+  id: Number;
+  header: {
+    key: string;
+    default: string;
+  };
+  identifierName: string;
+}
+
 export const configSchema = {
   activeVisits: {
     pageSize: {
@@ -11,6 +28,30 @@ export const configSchema = {
       _type: Type.Array,
       _description: 'Customizable page sizes that user can choose',
       _default: [10, 20, 50],
+    },
+    identifiers: {
+      _type: Type.Array,
+      _description: 'Customizable list of identifiers to display on active visits table',
+      _elements: {
+        header: {
+          key: {
+            _type: Type.String,
+            _default: null,
+            _description: 'Key to be used for translation purposes.',
+          },
+          default: {
+            _type: Type.String,
+            _default: null,
+            _description: 'Default text to be displayed if no translation is found.',
+          },
+        },
+        identifierName: {
+          _type: Type.String,
+          _default: null,
+          _description: 'Name of the desired identifier to filter data returned from the visit resource.',
+        },
+      },
+      _default: null,
     },
   },
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
In Active visits, we now have the possibility to display multiple user keys through the configuration. 

The configuration contemplates the structure to add the desired header and respective key of the field.
The keys are programmed to be displayed between the visit time and the user's name, if no configuration is provided the widget will behave normally.

## Screenshots
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/106243905/209830774-6a20f366-b038-49cc-bb13-370b2121dcc4.png">

Where the black boxes are there should be the respective keys.
