### PR TITLE
(feat) Add configuration for patient name known toggle

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -41,6 +41,7 @@ export interface RegistrationConfig {
       defaultUnknownGivenName: string;
       defaultUnknownFamilyName: string;
       displayCapturePhoto: boolean;
+      displayKnownNameToggle: boolean;
     };
     gender: Array<Gender>;
     address: {
@@ -219,6 +220,11 @@ export const esmPatientRegistrationSchema = {
         _type: Type.Boolean,
         _default: true,
         _description: 'Whether to display capture patient photo slot on name field',
+      },
+      displayKnownNameToggle: {
+        _type: Type.Boolean,
+        _default: true,
+        _description: 'Determines whether to display the toggle switch for known patient names.',
       },
     },
     gender: {

--- a/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field.component.tsx
@@ -21,7 +21,7 @@ function checkNumber(value: string) {
 export const NameField = () => {
   const {
     fieldConfigurations: {
-      name: { displayCapturePhoto },
+      name: { displayCapturePhoto, displayKnownNameToggle },
     },
   } = useConfig() as RegistrationConfig;
   const { t } = useTranslation();
@@ -68,13 +68,17 @@ export const NameField = () => {
         )}
 
         <div className={styles.nameField}>
-          <div className={styles.dobContentSwitcherLabel}>
-            <span className={styles.label01}>{t('patientNameKnown', "Patient's Name is Known?")}</span>
-          </div>
-          <ContentSwitcher className={styles.contentSwitcher} onChange={toggleNameKnown}>
-            <Switch name="known" text={t('yes', 'Yes')} />
-            <Switch name="unknown" text={t('no', 'No')} />
-          </ContentSwitcher>
+          {displayKnownNameToggle && (
+            <>
+              <div className={styles.dobContentSwitcherLabel}>
+                <span className={styles.label01}>{t('patientNameKnown', "Patient's Name is Known?")}</span>
+              </div>
+              <ContentSwitcher className={styles.contentSwitcher} onChange={toggleNameKnown}>
+                <Switch name="known" text={t('yes', 'Yes')} />
+                <Switch name="unknown" text={t('no', 'No')} />
+              </ContentSwitcher>
+            </>
+          )}
           {nameKnown && (
             <>
               <Input


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This commit introduces a new configuration option, `displayKnownNameToggle`, which determines whether to display the toggle switch for known patient names. By default, the toggle switch is enabled. 

The `displayKnownNameToggle` option allows for easy customization of the user interface, giving the flexibility to show or hide the toggle switch based on the specific requirements of the application.

## Screenshots

![Peek 2023-05-23 14-55](https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/61602c18-f1b6-4cfa-a3cf-4d715530bb13)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
