### PR TITLE
(fix) O3-2152: Rtl support, fix styles for active visits header

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.scss
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.scss
@@ -139,6 +139,9 @@ html[dir='rtl'] {
   .activeVisitsContainer {
     .activeVisitsDetailHeaderContainer {
       padding: spacing.$spacing-04 spacing.$spacing-05 spacing.$spacing-04 0;
+    }
+    .desktopHeading,
+    .tabletHeading {
       h4 {
         text-align: right;
       }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Active visits table header was displayed incorrectly when applying rtl


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-2152


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
