### PR TITLE
(fix) O3-2152: Rtl support, fix styles

### DIFF
--- a/packages/esm-appointments-app/src/appointments-calendar/header/calendar-header.scss
+++ b/packages/esm-appointments-app/src/appointments-calendar/header/calendar-header.scss
@@ -46,3 +46,10 @@
     }
   }
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .titleContent {
+    margin-left: 1rem;
+  }
+}

--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.scss
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.scss
@@ -69,3 +69,15 @@
     color: colors.$blue-10;
   }
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .date-and-location {
+    & > svg {
+      order: -1;
+    }
+    & > span:nth-child(2) {
+      order: -2;
+    }
+  }
+}

--- a/packages/esm-appointments-app/src/empty-state/empty-state.scss
+++ b/packages/esm-appointments-app/src/empty-state/empty-state.scss
@@ -60,3 +60,11 @@
   @include type.type-style('heading-compact-01');
   margin-bottom: 1rem;
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .desktopHeading,
+  .tabletHeading {
+    text-align: right;
+  }
+}

--- a/packages/esm-appointments-app/src/patient-queue/visit-form/base-visit-type.scss
+++ b/packages/esm-appointments-app/src/patient-queue/visit-form/base-visit-type.scss
@@ -93,3 +93,11 @@
 .emptyVisitType {
   margin: spacing.$spacing-05;
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .desktopHeading,
+  .tabletHeading {
+    text-align: right;
+  }
+}

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.scss
@@ -244,7 +244,6 @@
 // Overriding styles for RTL support
 html[dir='rtl'] {
   .headerContainer {
-    padding: spacing.$spacing-04 spacing.$spacing-05 spacing.$spacing-04 0;
     svg {
       margin-left: 0;
       margin-right: spacing.$spacing-03;

--- a/packages/esm-outpatient-app/src/overlay.scss
+++ b/packages/esm-outpatient-app/src/overlay.scss
@@ -86,3 +86,11 @@
     overflow-y: auto;
   }
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .desktopOverlay {
+    right: unset;
+    left: 0;
+  }
+}

--- a/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.scss
+++ b/packages/esm-outpatient-app/src/patient-queue-header/patient-queue-header.scss
@@ -69,3 +69,20 @@
     left: -10.15rem;
   }
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .date-and-location {
+    margin-right: unset;
+    margin-left: spacing.$spacing-05;
+    & > svg:first-child {
+      order: -1;
+    }
+    & > svg:nth-child(4) {
+      order: 1;
+    }
+    & > span:nth-child(2) {
+      order: -2;
+    }
+  }
+}

--- a/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.scss
+++ b/packages/esm-outpatient-app/src/patient-queue-metrics/metrics-card.scss
@@ -67,3 +67,14 @@
     margin-left: spacing.$spacing-03;
   }
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .link {
+    svg {
+      margin-right: spacing.$spacing-03;
+      margin-left: unset;
+      transform: scale(-1, 1);
+    }
+  }
+}

--- a/packages/esm-outpatient-app/src/patient-search/visit-form/base-visit-type.scss
+++ b/packages/esm-outpatient-app/src/patient-search/visit-form/base-visit-type.scss
@@ -90,3 +90,11 @@
   text-align: center;
   border: 1px solid $ui-03;
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .desktopHeading,
+  .tabletHeading {
+    text-align: right;
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Some elements were displayed incorrectly when applying rtl.


## Screenshots
Icon positions were fixed
![1](https://github.com/openmrs/openmrs-esm-patient-management/assets/68945262/07ca1a8a-fa0c-48dd-b261-916035727a75)
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/68945262/c50d00e7-52c4-4162-874b-eba0f9639da0)

Some margins were fixed
![1](https://github.com/openmrs/openmrs-esm-patient-management/assets/68945262/c9722452-7ac6-485a-950f-8d9d029809f3)

## Related Issue
https://issues.openmrs.org/browse/O3-2152


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
