### PR TITLE
(feat) By default, search should just redirect to the chart

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search-extension/index.tsx
@@ -48,7 +48,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
         navigate({
           to: `${interpolateString(config.search.patientResultUrl, {
             patientUuid: patients[index].uuid,
-          })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`,
+          })}`,
         });
       }
       handleReset();

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -78,7 +78,7 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
               onClick={(evt) => selectPatientAction(evt, indx)}
               to={`${interpolateString(config.search.patientResultUrl, {
                 patientUuid: patient.id,
-              })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`}
+              })}`}
               key={patient.id}
               className={`${styles.patientSearchResult} ${isDeceased ? styles.deceased : ''}`}>
               <div className={styles.patientAvatar} role="img">

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -51,7 +51,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
         navigate({
           to: `${interpolateString(config.search.patientResultUrl, {
             patientUuid: patients[index].uuid,
-          })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`,
+          })}`,
         });
       }
       handleCloseSearchResults();

--- a/packages/esm-patient-search-app/src/config-schema.ts
+++ b/packages/esm-patient-search-app/src/config-schema.ts
@@ -9,7 +9,7 @@ export const configSchema = {
     },
     redirectToPatientDashboard: {
       _type: Type.String,
-      _default: 'Patient Summary',
+      _default: '',
       _description:
         'On clicking the patient banner in the search results, which should be the default patient chart dashboard to redirect to.',
     },

--- a/packages/esm-patient-search-app/src/config-schema.ts
+++ b/packages/esm-patient-search-app/src/config-schema.ts
@@ -3,15 +3,9 @@ export const configSchema = {
   search: {
     patientResultUrl: {
       _type: Type.String,
-      _default: '${openmrsSpaBase}/patient/${patientUuid}/chart',
+      _default: '${openmrsSpaBase}/patient/${patientUuid}/chart/',
       _description: 'Where clicking a patient result takes the user. Accepts template parameter ${patientUuid}',
       _validators: [validators.isUrlWithTemplateParameters(['patientUuid'])],
-    },
-    redirectToPatientDashboard: {
-      _type: Type.String,
-      _default: '',
-      _description:
-        'On clicking the patient banner in the search results, which should be the default patient chart dashboard to redirect to.',
     },
   },
   includeDead: {

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -98,7 +98,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
         <ConfigurableLink
           to={`${interpolateString(config.search.patientResultUrl, {
             patientUuid: patientUuid,
-          })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`}
+          })}`}
           onClick={(evt) => selectPatientAction(evt, patientUuid)}
           className={`${styles.patientBanner} ${selectPatientAction && styles.patientAvatarButton}`}>
           {patientAvatar}

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
@@ -56,7 +56,7 @@ const PatientSearchComponent: React.FC<PatientSearchComponentProps> = ({
         navigate({
           to: `${interpolateString(config.search.patientResultUrl, {
             patientUuid: patientUuid,
-          })}/${encodeURIComponent(config.search.redirectToPatientDashboard)}`,
+          })}`,
         });
       }
       if (hidePanel) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->

It's useful to be able to configure the search to land on different pages; however, the current setup has two issues:

1. It is impossible to configure the search app to land anywhere but the patient chart, because the `redirectToPatientDashboard` property is always appended to the URL.
2. The search app should not, in the general case, be choosing which page we land on. It should defer this decision to the patient chart, to allow us to more easily and universally set the default landing page on the chart (example: in my HIV clinic, I want user's to land on my HIV view by default).

Consolidating the URL into a single config property allows us to address both issues, while still allowing the search bar to be used in contexts where we do want to land on a specific (non-default) component of the patient search.

For usability reasons, this should be merged after [patient-chart #1203](https://github.com/openmrs/openmrs-esm-patient-chart/pull/1203).

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
