### PR TITLE
(fix) Remove deprecated `extensionSlotName` prop

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -268,7 +268,7 @@ const ActiveVisitsTable = () => {
                           <th colSpan={headers.length + 2}>
                             <ExtensionSlot
                               className={styles.visitSummaryContainer}
-                              extensionSlotName="visit-summary-slot"
+                              name="visit-summary-slot"
                               state={{
                                 visitUuid: activeVisits[index]?.visitUuid,
                                 patientUuid: activeVisits[index]?.patientUuid,

--- a/packages/esm-active-visits-app/src/visits-summary/visits-components/tests-summary.component.tsx
+++ b/packages/esm-active-visits-app/src/visits-summary/visits-components/tests-summary.component.tsx
@@ -13,7 +13,7 @@ const TestsSummary = ({ patientUuid, encounters }: { patientUuid: string; encoun
 
   return (
     <div className={`${styles.bodyLong01} ${styles.testSummaryExtension}`}>
-      <ExtensionSlot extensionSlotName="test-results-filtered-overview" state={{ filter, patientUuid }} />
+      <ExtensionSlot name="test-results-filtered-overview" state={{ filter, patientUuid }} />
     </div>
   );
 };

--- a/packages/esm-appointments-app/src/appointments-calendar/patient-list/calendar-patient-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-calendar/patient-list/calendar-patient-list.component.tsx
@@ -70,7 +70,7 @@ const CalendarPatientList: React.FC<CalendarPatientListProps> = () => {
 
   return (
     <>
-      <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+      <ExtensionSlot name="breadcrumbs-slot" />
       <div className={styles.container}>
         <div className={styles.header}>
           <h2>{serviceName === 'Total' ? 'All Services' : `${serviceName} ${t('list', 'List')}`}</h2>

--- a/packages/esm-appointments-app/src/appointments-metrics/metrics-header.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-metrics/metrics-header.component.tsx
@@ -33,7 +33,7 @@ const MetricsHeader: React.FC = () => {
           {t('appointmentsCalendar', 'Appointments Calendar')}
         </Button>
         <ExtensionSlot
-          extensionSlotName="patient-search-button-slot"
+          name="patient-search-button-slot"
           state={{
             selectPatientAction: launchCreateAppointmentForm,
             buttonText: t('createNewAppointment', 'Create new appointment'),

--- a/packages/esm-appointments-app/src/appointments/forms/cancel-form/cancel-appointment.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/cancel-form/cancel-appointment.component.tsx
@@ -56,7 +56,7 @@ const CancelAppointment: React.FC<CancelAppointmentProps> = ({ appointment }) =>
     <div className={styles.formContainer}>
       {patient && (
         <ExtensionSlot
-          extensionSlotName="patient-header-slot"
+          name="patient-header-slot"
           state={{
             patient,
             patientUuid: appointment.patientUuid,

--- a/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-form.component.tsx
@@ -134,7 +134,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment, patientU
       ) : (
         <div className={styles.stickyFormHeader}>
           <ExtensionSlot
-            extensionSlotName="patient-header-slot"
+            name="patient-header-slot"
             state={{
               patient,
               patientUuid: patientAppointment.patientUuid,

--- a/packages/esm-appointments-app/src/appointments/forms/defaulter-tracing-form/default-tracing-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/defaulter-tracing-form/default-tracing-form.component.tsx
@@ -23,7 +23,7 @@ const DefaulterTracingForm: React.FC<DefaulterTracingForm> = ({ patientUuid }) =
     [patientUuid, patient],
   );
 
-  return <>{patient && <ExtensionSlot extensionSlotName="form-widget-slot" state={state} />}</>;
+  return <>{patient && <ExtensionSlot name="form-widget-slot" state={state} />}</>;
 };
 
 export default DefaulterTracingForm;

--- a/packages/esm-appointments-app/src/patient-queue/visit-form/visit-form.component.tsx
+++ b/packages/esm-appointments-app/src/patient-queue/visit-form/visit-form.component.tsx
@@ -179,13 +179,13 @@ const VisitForm: React.FC<VisitFormProps> = ({ patientUuid, appointment }) => {
       <div>
         {isTablet ? (
           <Row className={styles.headerGridRow}>
-            <ExtensionSlot extensionSlotName="visit-form-header-slot" className={styles.dataGridRow} state={state} />
+            <ExtensionSlot name="visit-form-header-slot" className={styles.dataGridRow} state={state} />
           </Row>
         ) : isLoading ? (
           <SkeletonText />
         ) : (
           <ExtensionSlot
-            extensionSlotName="patient-header-slot"
+            name="patient-header-slot"
             state={{
               patient,
               patientUuid: appointment.patientUuid,
@@ -351,7 +351,7 @@ const VisitForm: React.FC<VisitFormProps> = ({ patientUuid, appointment }) => {
           )}
 
           {/* Queue location and queue fields. These get shown when queue location and queue fields are configured */}
-          {config.showServiceQueueFields && <ExtensionSlot extensionSlotName="add-queue-entry-slot" />}
+          {config.showServiceQueueFields && <ExtensionSlot name="add-queue-entry-slot" />}
         </Stack>
       </div>
       <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>

--- a/packages/esm-appointments-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-appointments-app/src/patient-search/patient-search.component.tsx
@@ -19,7 +19,7 @@ const PatientSearch: React.FC = () => {
     <div className="omrs-main-content">
       <span className={styles.searchBarWrapper}>
         <ExtensionSlot
-          extensionSlotName="patient-search-bar-slot"
+          name="patient-search-bar-slot"
           state={{
             selectPatientAction: launchCreateAppointmentForm,
             buttonProps: {

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-tab.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-tab.component.tsx
@@ -21,7 +21,7 @@ function ActiveVisitsTabs() {
     <div className={styles.container}>
       <div className={styles.headerBtnContainer}>
         <ExtensionSlot
-          extensionSlotName="patient-search-button-slot"
+          name="patient-search-button-slot"
           state={{
             buttonText: t('addPatientToQueue', 'Add patient to queue'),
             overlayHeader: t('addPatientToQueue', 'Add patient to queue'),

--- a/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-outpatient-app/src/active-visits/active-visits-table.component.tsx
@@ -288,7 +288,7 @@ function ActiveVisitsTable() {
               </div>
               <div className={styles.headerButtons}>
                 <ExtensionSlot
-                  extensionSlotName="patient-search-button-slot"
+                  name="patient-search-button-slot"
                   state={{
                     buttonText: t('addPatientToQueue', 'Add patient to queue'),
                     overlayHeader: t('addPatientToQueue', 'Add patient to queue'),
@@ -468,7 +468,7 @@ function ActiveVisitsTable() {
             </div>
             <div className={styles.headerButtons}>
               <ExtensionSlot
-                extensionSlotName="patient-search-button-slot"
+                name="patient-search-button-slot"
                 state={{
                   buttonText: t('addPatientToQueue', 'Add patient to queue'),
                   overlayHeader: t('addPatientToQueue', 'Add patient to queue'),
@@ -493,7 +493,7 @@ function ActiveVisitsTable() {
         <Tile className={styles.tile}>
           <p className={styles.content}>{t('noPatientsToDisplay', 'No patients to display')}</p>
           <ExtensionSlot
-            extensionSlotName="patient-search-button-slot"
+            name="patient-search-button-slot"
             state={{
               buttonText: t('addPatientToQueue', 'Add patient to queue'),
               overlayHeader: t('addPatientToQueue', 'Add patient to queue'),

--- a/packages/esm-outpatient-app/src/patient-info/patient-info.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-info/patient-info.component.tsx
@@ -29,7 +29,7 @@ const PatientInfo: React.FC<PatientInfoProps> = ({ patient, handlePatientInfoCli
   return (
     <ClickableTile className={styles.container} onClick={handlePatientInfoClick}>
       <div className={`${showContactDetails ? styles.activePatientInfoContainer : styles.patientInfoContainer}`}>
-        <ExtensionSlot extensionSlotName="patient-photo-slot" state={patientPhotoSlotState} />
+        <ExtensionSlot name="patient-photo-slot" state={patientPhotoSlotState} />
         <div className={styles.patientInfoContent}>
           <div className={styles.patientInfoRow}>
             <span className={styles.patientName}>{patientName}</span>

--- a/packages/esm-outpatient-app/src/patient-search/visit-form/visit-form.component.tsx
+++ b/packages/esm-outpatient-app/src/patient-search/visit-form/visit-form.component.tsx
@@ -197,7 +197,7 @@ const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchTyp
       <div>
         {isTablet && (
           <Row className={styles.headerGridRow}>
-            <ExtensionSlot extensionSlotName="visit-form-header-slot" className={styles.dataGridRow} state={state} />
+            <ExtensionSlot name="visit-form-header-slot" className={styles.dataGridRow} state={state} />
           </Row>
         )}
         <div className={styles.backButton}>
@@ -345,7 +345,7 @@ const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchTyp
             </section>
           )}
         </Stack>
-        <ExtensionSlot extensionSlotName="add-queue-entry-slot" />
+        <ExtensionSlot name="add-queue-entry-slot" />
       </div>
       <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
         <Button className={styles.button} kind="secondary" onClick={closePanel}>

--- a/packages/esm-outpatient-app/src/queue-patient-linelists/queue-linelist-base-table.component.tsx
+++ b/packages/esm-outpatient-app/src/queue-patient-linelists/queue-linelist-base-table.component.tsx
@@ -116,7 +116,7 @@ const QueuePatientBaseTable: React.FC<QueuePatientTableProps> = ({
 
   return (
     <div className={styles.container}>
-      <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+      <ExtensionSlot name="breadcrumbs-slot" />
 
       <div className={styles.headerContainer}>
         <div>

--- a/packages/esm-outpatient-app/src/queue-patient-linelists/scheduled-appointments-table.component.tsx
+++ b/packages/esm-outpatient-app/src/queue-patient-linelists/scheduled-appointments-table.component.tsx
@@ -169,7 +169,7 @@ const AppointmentsTable: React.FC = () => {
 
   return (
     <div className={styles.container}>
-      <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+      <ExtensionSlot name="breadcrumbs-slot" />
 
       <div className={styles.headerContainer}>
         <div>

--- a/packages/esm-outpatient-app/src/side-menu/nav-group/nav-group.component.tsx
+++ b/packages/esm-outpatient-app/src/side-menu/nav-group/nav-group.component.tsx
@@ -16,7 +16,7 @@ const NavGroupExtension = ({ title, slotName, renderIcon }: NavGroupExtensionPro
 
   return (
     <SideNavMenu renderIcon={renderIcon} title={title}>
-      <ExtensionSlot extensionSlotName={slotName} />
+      <ExtensionSlot name={slotName} />
     </SideNavMenu>
   );
 };

--- a/packages/esm-outpatient-app/src/transition-queue-entry/transition-queue-entry-dialog.component.tsx
+++ b/packages/esm-outpatient-app/src/transition-queue-entry/transition-queue-entry-dialog.component.tsx
@@ -154,7 +154,7 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
           </section>
           <ExtensionSlot
             className={styles.visitSummaryContainer}
-            extensionSlotName="previous-visit-summary-slot"
+            name="previous-visit-summary-slot"
             state={{
               patientUuid: queueEntry?.patientUuid,
             }}

--- a/packages/esm-outpatient-app/src/visits-missing-inqueue/visits-missing-inqueue.component.tsx
+++ b/packages/esm-outpatient-app/src/visits-missing-inqueue/visits-missing-inqueue.component.tsx
@@ -231,7 +231,7 @@ const MissingQueueEntries = () => {
                           <th colSpan={headers.length + 2}>
                             <ExtensionSlot
                               className={styles.visitSummaryContainer}
-                              extensionSlotName="visit-summary-slot"
+                              name="visit-summary-slot"
                               state={{
                                 visitUuid: paginatedActiveVisits[index]?.visitUuid,
                                 patientUuid: paginatedActiveVisits[index]?.patientUuid,

--- a/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.component.tsx
@@ -104,7 +104,7 @@ const PatientListDetailComponent = () => {
   return (
     <main className={`omrs-main-content ${styles.patientListDetailsPage}`}>
       <section>
-        <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+        <ExtensionSlot name="breadcrumbs-slot" />
         <div className={styles.cohortHeader} data-testid="patientListHeader">
           <div>
             {patientListDetails && (

--- a/packages/esm-patient-list-app/src/patient-list-list/patient-list-list.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-list/patient-list-list.component.tsx
@@ -97,7 +97,7 @@ const PatientListList: React.FC = () => {
   return (
     <main className={`omrs-main-content ${styles.patientListListPage}`}>
       <section className={styles.patientListList}>
-        <ExtensionSlot extensionSlotName="breadcrumbs-slot" className={styles.breadcrumbsSlot} />
+        <ExtensionSlot name="breadcrumbs-slot" className={styles.breadcrumbsSlot} />
         <div className={styles.patientListHeader}>
           <div className={styles.leftJustifiedItems}>
             <Illustration />

--- a/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field.component.tsx
@@ -62,7 +62,7 @@ export const NameField = () => {
         {displayCapturePhoto && (
           <ExtensionSlot
             className={styles.photoExtension}
-            extensionSlotName="capture-patient-photo-slot"
+            name="capture-patient-photo-slot"
             state={{ onCapturePhoto, initialState: currentPhoto }}
           />
         )}

--- a/packages/esm-patient-registration-app/src/root.component.tsx
+++ b/packages/esm-patient-registration-app/src/root.component.tsx
@@ -34,7 +34,7 @@ export default function Root({ savePatientForm, isOffline }: RootProps) {
     <main className={`omrs-main-content ${styles.root}`}>
       <Grid className={styles.grid}>
         <Row>
-          <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+          <ExtensionSlot name="breadcrumbs-slot" />
         </Row>
         <ResourcesContext.Provider
           value={{

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -83,7 +83,7 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
               className={`${styles.patientSearchResult} ${isDeceased ? styles.deceased : ''}`}>
               <div className={styles.patientAvatar} role="img">
                 <ExtensionSlot
-                  extensionSlotName="patient-photo-slot"
+                  name="patient-photo-slot"
                   state={{
                     patientUuid: patient.id,
                     patientName: `${patient.name?.[0]?.given?.join(' ')} ${patient.name?.[0]?.family}`,
@@ -97,7 +97,7 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
                     patient.name?.[0]?.family
                   }`}</h2>
                   <ExtensionSlot
-                    extensionSlotName="patient-banner-tags-slot"
+                    name="patient-banner-tags-slot"
                     state={{ patient, patientUuid: patient.id }}
                     className={styles.flexRow}
                   />

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -56,7 +56,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
 
   const patientAvatar = (
     <div className={styles.patientAvatar} role="img">
-      <ExtensionSlot extensionSlotName="patient-photo-slot" state={patientPhotoSlotState} />
+      <ExtensionSlot name="patient-photo-slot" state={patientPhotoSlotState} />
     </div>
   );
 
@@ -106,7 +106,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
             <div className={styles.flexRow}>
               <span className={styles.patientName}>{patientName}</span>
               <ExtensionSlot
-                extensionSlotName="patient-banner-tags-slot"
+                name="patient-banner-tags-slot"
                 state={{ patientUuid, patient: fhirPatient }}
                 className={styles.flexRow}
               />
@@ -134,7 +134,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
                 dropDownMenu={showDropdown}>
                 <ExtensionSlot
                   onClick={closeDropdownMenu}
-                  extensionSlotName="patient-search-actions-slot"
+                  name="patient-search-actions-slot"
                   state={patientActionsSlotState}
                 />
               </CustomOverflowMenuComponent>
@@ -143,7 +143,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({
           {!isDeceased &&
             (!currentVisit ? (
               <ExtensionSlot
-                extensionSlotName="start-visit-button-slot"
+                name="start-visit-button-slot"
                 state={{
                   patientUuid,
                 }}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Removes the deprecated `extensionSlotName` prop and replaces it with `name`.