### PR TITLE
(fix) O3-2152: Fix styles in appointments calendar, patient registration

### DIFF
--- a/packages/esm-appointments-app/src/appointments-calendar/daily/daily-calendar.scss
+++ b/packages/esm-appointments-app/src/appointments-calendar/daily/daily-calendar.scss
@@ -51,3 +51,21 @@
     border-top: 1px solid colors.$gray-20;
   }
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .container {
+    padding-left: unset;
+    padding-right: 50px;
+  }
+
+  .daily-calendar {
+    border-right: unset;
+    border-left: 1px solid colors.$gray-20;
+  }
+
+  .empty-cell {
+    border-right: unset;
+    border-left: 1px solid colors.$gray-20;
+  }
+}

--- a/packages/esm-appointments-app/src/appointments-calendar/daily/daily-workload-module.scss
+++ b/packages/esm-appointments-app/src/appointments-calendar/daily/daily-workload-module.scss
@@ -138,3 +138,15 @@
   color: colors.$white;
   font-weight: bold;
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .weekly-cell {
+    &:first-child {
+      .allDay {
+        border-left: 1px solid colors.$gray-20;
+        border-right: none;
+      }
+    }
+  }
+}

--- a/packages/esm-appointments-app/src/appointments-calendar/weekly/weekly-calendar.scss
+++ b/packages/esm-appointments-app/src/appointments-calendar/weekly/weekly-calendar.scss
@@ -52,3 +52,16 @@
     }
   }
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .container {
+    padding-left: unset;
+    padding-right: 50px;
+  }
+
+  .weekly-cell {
+    border-right: unset;
+    border-left: 1px solid colors.$gray-20;
+  }
+}

--- a/packages/esm-appointments-app/src/appointments-calendar/weekly/weekly-header.scss
+++ b/packages/esm-appointments-app/src/appointments-calendar/weekly/weekly-header.scss
@@ -43,3 +43,17 @@
   @include carbon--type-style('productive-heading-01');
   color: $text-02;
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .container {
+    & > span {
+      direction: ltr;
+    }
+  }
+
+  .workLoadCard {
+    padding-left: unset;
+    padding-right: 60px;
+  }
+}

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.scss
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.scss
@@ -92,3 +92,17 @@
     max-width: unset;
   }
 }
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .linkName {
+    & > svg {
+      transform: scale(-1, 1);
+    }
+  }
+
+  .infoGrid {
+    padding-left: unset;
+    padding-right: spacing.$spacing-07;
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Fixed margins and borders in appointments calendar, fixed arrows positions and padding in patient registration


## Screenshots
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/68945262/441f6fff-67d0-4e25-92c3-dd5507f3f39c)
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/68945262/6cbe6938-49f6-4e80-a83f-ddf24fb0bae5)
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/68945262/5cc2ed25-edc9-4f10-90e4-919cb722e9ec)


## Related Issue
https://issues.openmrs.org/browse/O3-2152


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
