### PR TITLE
(fix) O3-2152: Fix "See all appointments" button position

### DIFF
--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
@@ -210,9 +210,11 @@ const AppointmentsBaseTable = () => {
     return (
       <Layer className={styles.container}>
         <Tile className={styles.tile}>
-          <div className={!isDesktop(layout) ? styles.tabletHeading : styles.desktopHeading}>
+          <div className={isDesktop(layout) ? styles.desktopHeading : styles.tabletHeading}>
             <h4>{t('todaysAppointments', "Today's Appointments")}</h4>
-            <AddAppointmentLink />
+            <div className={styles.actionLink}>
+              <AddAppointmentLink />
+            </div>
           </div>
           <EmptyDataIllustration />
           <p className={styles.content}>

--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.scss
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.scss
@@ -40,10 +40,6 @@
   display: none;
 }
 
-.addButtonContainer {
-  margin-left: 1.25rem;
-}
-
 .tableContainer {
   a {
     text-decoration: none;
@@ -249,6 +245,10 @@
   }
 }
 
+.actionLink {
+  margin: -1rem;
+}
+
 .actionLinks {
   display: flex;
   align-items: center;
@@ -293,7 +293,7 @@
   width: 1px;
   height: layout.$spacing-05;
   color: colors.$gray-20;
-  margin-left: layout.$spacing-05;
+  margin: 0 layout.$spacing-05;
 }
 
 .overflowMenu {

--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.scss
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.scss
@@ -312,6 +312,7 @@ html[dir='rtl'] {
       text-align: right;
     }
   }
+
   .pagination {
     & > :nth-child(1) {
       & > span {
@@ -345,6 +346,7 @@ html[dir='rtl'] {
       }
     }
   }
+
   .tableContainer {
     th > div {
       text-align: right;
@@ -360,5 +362,9 @@ html[dir='rtl'] {
         text-align: right;
       }
     }
+  }
+
+  .seeAllLink {
+    left: -22rem;
   }
 }

--- a/packages/esm-appointments-app/src/home-appointments/links.component.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/links.component.tsx
@@ -35,7 +35,7 @@ const AddAppointmentLink = () => {
   const { t } = useTranslation();
 
   return (
-    <div className={styles.addButtonContainer}>
+    <div>
       {useBahmniUI ? (
         <Button
           target="_blank"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
 Fix "See all appointments" button position when RTL mode is applied


## Screenshots
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/68945262/da67d3f8-0b30-4dd4-b643-b0beb412af30)


## Related Issue
https://issues.openmrs.org/browse/O3-2152


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
