### PR TITLE
(fix) Add encoding to address hierarchy `searchString`

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.resource.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.resource.tsx
@@ -25,9 +25,10 @@ export function useOrderedAddressHierarchyLevels() {
 }
 
 export function useAddressEntries(fetchResults, searchString) {
+  const encodedSearchString = encodeURIComponent(searchString);
   const { data, isLoading, error } = useSWRImmutable<FetchResponse<Array<{ name: string }>>>(
     fetchResults
-      ? `module/addresshierarchy/ajax/getChildAddressHierarchyEntries.form?searchString=${searchString}`
+      ? `module/addresshierarchy/ajax/getChildAddressHierarchyEntries.form?searchString=${encodedSearchString}`
       : null,
     openmrsFetch,
   );


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR addresses an issue related to loading a child address corresponding to a parent entity, when provided with a search string format such as `Uganda|Western Province`.

The core problem emerges due to the utilization of the pipe character (|), which, according to the standard defined in RFC 3986, is classified as an illegal character in a URL. This PR implements an update to the code to rectify this issue.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
