### PR TITLE
(fix) Exports should reference the result of getSync / getAsync

### DIFF
--- a/packages/esm-active-visits-app/src/index.ts
+++ b/packages/esm-active-visits-app/src/index.ts
@@ -12,25 +12,8 @@ export const importTranslation = require.context('../translations', false, /.jso
 
 export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
-
-  return {
-    extensions: [
-      {
-        name: 'active-visits-widget',
-        slot: 'homepage-widgets-slot',
-        order: 0,
-        load: getAsyncLifecycle(() => import('./active-visits-widget/active-visits.component'), options),
-      },
-      {
-        id: 'visit-summary-widget',
-        slot: 'visit-summary-slot',
-        load: getAsyncLifecycle(() => import('./visits-summary/visit-detail.component'), options),
-      },
-    ],
-  };
 }
 
-export const activeVisits = () =>
-  getAsyncLifecycle(() => import('./active-visits-widget/active-visits.component'), options);
+export const activeVisits = getAsyncLifecycle(() => import('./active-visits-widget/active-visits.component'), options);
 
-export const visitDetail = () => getAsyncLifecycle(() => import('./visits-summary/visit-detail.component'), options);
+export const visitDetail = getAsyncLifecycle(() => import('./visits-summary/visit-detail.component'), options);

--- a/packages/esm-appointments-app/src/index.ts
+++ b/packages/esm-appointments-app/src/index.ts
@@ -31,14 +31,16 @@ export function startupApp() {
   ]);
 }
 
-export const appointmentsDashboardLink = () => getSyncLifecycle(createDashboardLink(dashboardMeta), options);
+export const appointmentsDashboardLink = getSyncLifecycle(createDashboardLink(dashboardMeta), options);
 
 export const appointmentsCalendarDashboardLink = () =>
   getSyncLifecycle(createDashboardLink(appointmentCalendarDashboardMeta), options);
 
-export const appointmentsDashboard = () => getAsyncLifecycle(() => import('./appointments.component'), options);
+export const appointmentsDashboard = getAsyncLifecycle(() => import('./appointments.component'), options);
 
-export const checkInModal = () =>
-  getAsyncLifecycle(() => import('./home-appointments/check-in-modal/check-in-modal.component'), options);
+export const checkInModal = getAsyncLifecycle(
+  () => import('./home-appointments/check-in-modal/check-in-modal.component'),
+  options,
+);
 
-export const homeAppointments = () => getAsyncLifecycle(() => import('./home-appointments'), options);
+export const homeAppointments = getAsyncLifecycle(() => import('./home-appointments'), options);

--- a/packages/esm-patient-list-app/src/index.ts
+++ b/packages/esm-patient-list-app/src/index.ts
@@ -38,30 +38,29 @@ export function startupApp() {
   ]);
 }
 
-export const root = () => getAsyncLifecycle(() => import('./root.component'), options);
+export const root = getAsyncLifecycle(() => import('./root.component'), options);
 
-export const addPatientToListModal = () =>
-  getAsyncLifecycle(() => import('./add-patient/add-patient.component'), {
-    featureName: 'patient-actions-modal',
-    moduleName,
-  });
+export const addPatientToListModal = getAsyncLifecycle(() => import('./add-patient/add-patient.component'), {
+  featureName: 'patient-actions-modal',
+  moduleName,
+});
 
-export const addPatientToPatientListMenuItem = () =>
-  getAsyncLifecycle(() => import('./add-patient-to-patient-list-menu-item.component'), {
+export const addPatientToPatientListMenuItem = getAsyncLifecycle(
+  () => import('./add-patient-to-patient-list-menu-item.component'),
+  {
     featureName: 'patient-actions-slot',
     moduleName,
-  });
+  },
+);
 
-export const patientListActionButton = () =>
-  getAsyncLifecycle(() => import('./patient-list-action-button.component'), {
-    featureName: 'patient-list-action-menu-item',
-    moduleName,
-  });
+export const patientListActionButton = getAsyncLifecycle(() => import('./patient-list-action-button.component'), {
+  featureName: 'patient-list-action-menu-item',
+  moduleName,
+});
 
-export const patientListDashboardLink = () => getSyncLifecycle(createDashboardLink(dashboardMeta), options);
+export const patientListDashboardLink = getSyncLifecycle(createDashboardLink(dashboardMeta), options);
 
-export const patientTable = () =>
-  getAsyncLifecycle(() => import('./patient-table/patient-table.component'), {
-    featureName: 'patient-table',
-    moduleName,
-  });
+export const patientTable = getAsyncLifecycle(() => import('./patient-table/patient-table.component'), {
+  featureName: 'patient-table',
+  moduleName,
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->

const export = () => getSyncLifecycle() should be const export = getSyncLifecycle(), etc.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
