### PR TITLE
(fix) Fix wrong `component` name in outpatients app routes

### DIFF
--- a/packages/esm-outpatient-app/src/routes.json
+++ b/packages/esm-outpatient-app/src/routes.json
@@ -3,72 +3,89 @@
   "backendDependencies": {
     "webservices.rest": "^2.2.0"
   },
-  "pages": [{
-    "component": "appointmentsList",
-    "route": "appointments-list",
-    "online": true,
-    "offline": true
-  }, {
-    "component": "queueList",
-    "route": "queue-list",
-    "online": true,
-    "offline": true
-  }],
-  "extensions": [{
-    "name": "outpatient-side-nav-ext",
-    "component": "outpatientSideNav",
-    "slot": "outpatient-sidebar-slot",
-    "online": true,
-    "offline": true
-  }, {
-    "name": "service-queues-dashboard-link",
-    "component": "homepage-dashboard-slot",
-    "slot": "homepage-dashboard-slot",
-    "meta": {
-      "name": "service-queues",
+  "pages": [
+    {
+      "component": "appointmentsList",
+      "route": "appointments-list",
+      "online": true,
+      "offline": true
+    }, 
+    {
+      "component": "queueList",
+      "route": "queue-list",
+      "online": true,
+      "offline": true
+    }
+  ],
+  "extensions": [
+    {
+      "name": "outpatient-side-nav-ext",
+      "component": "outpatientSideNav",
+      "slot": "outpatient-sidebar-slot",
+      "online": true,
+      "offline": true
+    }, 
+    {
+      "name": "service-queues-dashboard-link",
+      "component": "serviceQueuesDashboardLink",
+      "slot": "homepage-dashboard-slot",
+      "meta": {
+        "name": "service-queues",
+        "slot": "service-queues-dashboard-slot",
+        "title": "Service queues"
+      },
+      "online": true,
+      "offline": true
+    }, 
+    {
+      "name": "home-dashboard",
+      "component": "homeDashboard",
       "slot": "service-queues-dashboard-slot",
-      "title": "Service queues"
-    },
-    "online": true,
-    "offline": true
-  }, {
-    "name": "home-dashboard",
-    "component": "homeDashboard",
-    "slot": "service-queues-dashboard-slot",
-    "online": true,
-    "offline": true
-  }, {
-    "name": "edit-queue-entry-status-modal",
-    "component": "editQueueEntryStatusModal"
-  }, {
-    "name": "patient-info-banner-slot",
-    "component": "patientInfoBannerSlot"
-  }, {
-    "name": "add-patient-to-queue",
-    "component": "addPatientToQueue",
-    "slot": "add-patient-to-queue-slot"
-  }, {
-    "name": "remove-queue-entry",
-    "component": "removeQueueEntry"
-  }, {
-    "name": "clear-all-queue-entries",
-    "component": "clearAllQueueEntries"
-  }, {
-    "name": "add-visit-to-queue-modal",
-    "component": "addVisitToQueueModal"
-  }, {
-    "name": "transition-queue-entry-status-modal",
-    "component": "transitionQueueEntryStatusModal"
-  }, {
-    "name": "previous-visit-summary-widget",
-    "component": "previousVisitSummaryWidget",
-    "slot": "previous-visit-summary-slot"
-  }, {
-    "name": "add-provider-to-room-modal",
-    "component": "addProviderToRoomModal"
-  }, {
-    "name": "add-queue-entry-widget",
-    "component": "addQueueEntryWidget",
-    "slot": "add-queue-entry-slot"
-  }]
+      "online": true,
+      "offline": true
+    }, 
+    {
+      "name": "edit-queue-entry-status-modal",
+      "component": "editQueueEntryStatusModal"
+    }, 
+    {
+      "name": "patient-info-banner-slot",
+      "component": "patientInfoBannerSlot"
+    }, 
+    {
+      "name": "add-patient-to-queue",
+      "component": "addPatientToQueue",
+      "slot": "add-patient-to-queue-slot"
+    }, 
+    {
+      "name": "remove-queue-entry",
+      "component": "removeQueueEntry"
+    }, 
+    {
+      "name": "clear-all-queue-entries",
+      "component": "clearAllQueueEntries"
+    }, 
+    {
+      "name": "add-visit-to-queue-modal",
+      "component": "addVisitToQueueModal"
+    }, 
+    {
+      "name": "transition-queue-entry-status-modal",
+      "component": "transitionQueueEntryStatusModal"
+    }, 
+    {
+      "name": "previous-visit-summary-widget",
+      "component": "previousVisitSummaryWidget",
+      "slot": "previous-visit-summary-slot"
+    }, 
+    {
+      "name": "add-provider-to-room-modal",
+      "component": "addProviderToRoomModal"
+    }, 
+    {
+      "name": "add-queue-entry-widget",
+      "component": "addQueueEntryWidget",
+      "slot": "add-queue-entry-slot"
+    }
+  ]
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Fixes a wrong `component` name property.

<img width="830" alt="Screenshot 2023-06-24 at 12 10 36 AM" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/a6c1cd08-3850-4ebf-a0e8-97f5de67276a">
