### PR TITLE
(fix) Remove incorrect `order` property from routes

### DIFF
--- a/packages/esm-active-visits-app/src/routes.json
+++ b/packages/esm-active-visits-app/src/routes.json
@@ -13,8 +13,7 @@
     {
       "name": "visit-summary-widget",
       "slot": "visit-summary-slot",
-      "component": "visitDetail",
-      "order": 0
+      "component": "visitDetail"
     }
   ],
   "pages": []


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Removes an incorrect `order` prop from the extension definition of the `visit-summary-widget` extension. This was likely added by mistake.