### PR TITLE
(test)O3-2215: Add tests for field.component

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
@@ -219,10 +219,38 @@ describe('Field', () => {
     expect(screen.getByText('Address')).toBeInTheDocument();
   });
 
-  it.skip('should render Identifiers component when name prop is "id"', () => {
+  it('should render Identifiers component when name prop is "id"', () => {
     (useConfig as jest.Mock).mockImplementation(() => ({
       defaultPatientIdentifierTypes: ['OpenMRS ID'],
     }));
+    // initial value for the identifiers field
+    const openmrsID = {
+      name: 'OpenMRS ID',
+      fieldName: 'openMrsId',
+      required: true,
+      uuid: '05a29f94-c0ed-11e2-94be-8c13b969e334',
+      format: null,
+      isPrimary: true,
+      identifierSources: [
+        {
+          uuid: '691eed12-c0f1-11e2-94be-8c13b969e334',
+          name: 'Generator 1 for OpenMRS ID',
+          autoGenerationOption: {
+            manualEntryEnabled: false,
+            automaticGenerationEnabled: true,
+          },
+        },
+        {
+          uuid: '01af8526-cea4-4175-aa90-340acb411771',
+          name: 'Generator 2 for OpenMRS ID',
+          autoGenerationOption: {
+            manualEntryEnabled: true,
+            automaticGenerationEnabled: true,
+          },
+        },
+      ],
+      autoGenerationSource: null,
+    };
     render(
       <ResourcesContext.Provider value={mockResourcesContextValue}>
         <Formik initialValues={{}} onSubmit={null}>
@@ -230,29 +258,10 @@ describe('Field', () => {
             <PatientRegistrationContext.Provider
               value={{
                 setFieldValue: jest.fn(),
+                initialFormValues: { identifiers: { openmrsID } },
                 setInitialFormValues: jest.fn(),
                 values: {
-                  patientUuid: '',
-                  givenName: '',
-                  middleName: '',
-                  familyName: '',
-                  unidentifiedPatient: false,
-                  additionalGivenName: '',
-                  additionalMiddleName: '',
-                  additionalFamilyName: '',
-                  addNameInLocalLanguage: false,
-                  gender: '',
-                  birthdate: '',
-                  yearsEstimated: 0,
-                  monthsEstimated: 0,
-                  birthdateEstimated: false,
-                  telephoneNumber: '',
-                  isDead: false,
-                  deathDate: '',
-                  deathCause: '',
-                  relationships: [],
-                  identifiers: { mockedIdentifierTypes },
-                  address: {},
+                  identifiers: { openmrsID },
                 },
               }}>
               <Field name="id" />
@@ -261,7 +270,7 @@ describe('Field', () => {
         </Formik>
       </ResourcesContext.Provider>,
     );
-    expect(screen.getByTestId('identifiers')).toBeInTheDocument();
+    expect(screen.getByText('Identifiers')).toBeInTheDocument();
   });
 
   it('should return null and report an error for an invalid field name', () => {

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
@@ -1,0 +1,282 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Field } from './field.component';
+import { useConfig } from '@openmrs/esm-framework';
+import { PatientRegistrationContext } from '../patient-registration-context';
+import { Resources, ResourcesContext } from '../../offline.resources';
+import { Form, Formik } from 'formik';
+
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  useConfig: jest.fn(),
+}));
+const predefinedAddressTemplate = {
+  results: [
+    {
+      value:
+        '<org.openmrs.layout.address.AddressTemplate>\r\n     <nameMappings class="properties">\r\n       <property name="postalCode" value="Location.postalCode"/>\r\n       <property name="address2" value="Location.address2"/>\r\n       <property name="address1" value="Location.address1"/>\r\n       <property name="country" value="Location.country"/>\r\n       <property name="stateProvince" value="Location.stateProvince"/>\r\n       <property name="cityVillage" value="Location.cityVillage"/>\r\n     </nameMappings>\r\n     <sizeMappings class="properties">\r\n       <property name="postalCode" value="4"/>\r\n       <property name="address1" value="40"/>\r\n       <property name="address2" value="40"/>\r\n       <property name="country" value="10"/>\r\n       <property name="stateProvince" value="10"/>\r\n       <property name="cityVillage" value="10"/>\r\n       <asset name="cityVillage" value="10"/>\r\n     </sizeMappings>\r\n     <lineByLineFormat>\r\n       <string>address1 address2</string>\r\n       <string>cityVillage stateProvince postalCode</string>\r\n       <string>country</string>\r\n     </lineByLineFormat>\r\n     <elementDefaults class="properties">\r\n            <property name="country" value=""/>\r\n     </elementDefaults>\r\n     <elementRegex class="properties">\r\n            <property name="address1" value="[a-zA-Z]+$"/>\r\n     </elementRegex>\r\n     <elementRegexFormats class="properties">\r\n            <property name="address1" value="Countries can only be letters"/>\r\n     </elementRegexFormats>\r\n   </org.openmrs.layout.address.AddressTemplate>',
+    },
+  ],
+};
+
+const mockedIdentifierTypes = [
+  {
+    fieldName: 'openMrsId',
+    format: null,
+    identifierSources: [
+      {
+        uuid: '8549f706-7e85-4c1d-9424-217d50a2988b',
+        name: 'Generator for OpenMRS ID',
+        description: 'Generator for OpenMRS ID',
+        baseCharacterSet: '0123456789ACDEFGHJKLMNPRTUVWXY',
+        prefix: '',
+      },
+    ],
+    isPrimary: true,
+    name: 'OpenMRS ID',
+    required: true,
+    uniquenessBehavior: 'UNIQUE',
+    uuid: '05a29f94-c0ed-11e2-94be-8c13b969e334',
+  },
+  {
+    fieldName: 'idCard',
+    format: null,
+    identifierSources: [],
+    isPrimary: false,
+    name: 'ID Card',
+    required: false,
+    uniquenessBehavior: 'UNIQUE',
+    uuid: 'b4143563-16cd-4439-b288-f83d61670fc8',
+  },
+  {
+    fieldName: 'legacyId',
+    format: null,
+    identifierSources: [],
+    isPrimary: false,
+    name: 'Legacy ID',
+    required: false,
+    uniquenessBehavior: null,
+    uuid: '22348099-3873-459e-a32e-d93b17eda533',
+  },
+  {
+    fieldName: 'oldIdentificationNumber',
+    format: '',
+    identifierSources: [],
+    isPrimary: false,
+    name: 'Old Identification Number',
+    required: false,
+    uniquenessBehavior: null,
+    uuid: '8d79403a-c2cc-11de-8d13-0010c6dffd0f',
+  },
+  {
+    fieldName: 'openMrsIdentificationNumber',
+    format: '',
+    identifierSources: [],
+    isPrimary: false,
+    name: 'OpenMRS Identification Number',
+    required: false,
+    uniquenessBehavior: null,
+    uuid: '8d793bee-c2cc-11de-8d13-0010c6dffd0f',
+  },
+];
+const mockResourcesContextValue = {
+  addressTemplate: predefinedAddressTemplate,
+  currentSession: {
+    authenticated: true,
+    sessionId: 'JSESSION',
+    currentProvider: { uuid: 'provider-uuid', identifier: 'PRO-123' },
+  },
+  relationshipTypes: [],
+  identifierTypes: [...mockedIdentifierTypes],
+} as Resources;
+
+describe('Field', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render NameField component when name prop is "name"', () => {
+    (useConfig as jest.Mock).mockImplementation(() => ({
+      fieldConfigurations: {
+        name: {
+          displayMiddleName: true,
+          unidentifiedPatient: true,
+          defaultUnknownGivenName: 'UNKNOWN',
+          defaultUnknownFamilyName: 'UNKNOWN',
+        },
+      },
+    }));
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Formik initialValues={{}} onSubmit={null}>
+          <Form>
+            <PatientRegistrationContext.Provider
+              value={{
+                setFieldValue: jest.fn(),
+                setInitialFormValues: jest.fn(),
+                values: {},
+              }}>
+              <Field name="name" />
+            </PatientRegistrationContext.Provider>
+          </Form>
+        </Formik>
+      </ResourcesContext.Provider>,
+    );
+    expect(screen.getByText('Full Name')).toBeInTheDocument();
+  });
+
+  it('should render GenderField component when name prop is "gender"', () => {
+    (useConfig as jest.Mock).mockImplementation(() => ({
+      fieldConfigurations: {
+        gender: [
+          {
+            value: 'Male',
+            label: 'Male',
+            id: 'male',
+          },
+        ],
+      },
+    }));
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Formik initialValues={{}} onSubmit={null}>
+          <Form>
+            <PatientRegistrationContext.Provider
+              value={{
+                setFieldValue: jest.fn(),
+                setInitialFormValues: jest.fn(),
+                values: {},
+              }}>
+              <Field name="gender" />
+            </PatientRegistrationContext.Provider>
+          </Form>
+        </Formik>
+      </ResourcesContext.Provider>,
+    );
+    expect(screen.getByLabelText('Male')).toBeInTheDocument();
+  });
+
+  it('should render DobField component when name prop is "dob"', () => {
+    (useConfig as jest.Mock).mockImplementation(() => ({
+      fieldConfigurations: {
+        dob: {
+          minAgeLimit: 0,
+          maxAgeLimit: 120,
+        },
+      },
+    }));
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Formik initialValues={{}} onSubmit={null}>
+          <Form>
+            <PatientRegistrationContext.Provider
+              value={{
+                setFieldValue: jest.fn(),
+                setInitialFormValues: jest.fn(),
+                values: {},
+              }}>
+              <Field name="dob" />
+            </PatientRegistrationContext.Provider>
+          </Form>
+        </Formik>
+      </ResourcesContext.Provider>,
+    );
+    expect(screen.getByText('Birth')).toBeInTheDocument();
+  });
+
+  it('should render AddressComponent component when name prop is "address"', () => {
+    jest.mock('./address/address-hierarchy.resource', () => ({
+      ...(jest.requireActual('../address-hierarchy.resource') as jest.Mock),
+      useOrderedAddressHierarchyLevels: jest.fn(),
+    }));
+    (useConfig as jest.Mock).mockImplementation(() => ({
+      fieldConfigurations: {
+        address: {
+          useAddressHierarchy: {
+            enabled: false,
+            useQuickSearch: false,
+            searchAddressByLevel: false,
+          },
+        },
+      },
+    }));
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Formik initialValues={{}} onSubmit={null}>
+          <Form>
+            <PatientRegistrationContext.Provider
+              value={{
+                setFieldValue: jest.fn(),
+                setInitialFormValues: jest.fn(),
+                values: {},
+              }}>
+              <Field name="address" />
+            </PatientRegistrationContext.Provider>
+          </Form>
+        </Formik>
+      </ResourcesContext.Provider>,
+    );
+    expect(screen.getByText('Address')).toBeInTheDocument();
+  });
+
+  it.skip('should render Identifiers component when name prop is "id"', () => {
+    (useConfig as jest.Mock).mockImplementation(() => ({
+      defaultPatientIdentifierTypes: ['OpenMRS ID'],
+    }));
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Formik initialValues={{}} onSubmit={null}>
+          <Form>
+            <PatientRegistrationContext.Provider
+              value={{
+                setFieldValue: jest.fn(),
+                setInitialFormValues: jest.fn(),
+                values: {
+                  patientUuid: '',
+                  givenName: '',
+                  middleName: '',
+                  familyName: '',
+                  unidentifiedPatient: false,
+                  additionalGivenName: '',
+                  additionalMiddleName: '',
+                  additionalFamilyName: '',
+                  addNameInLocalLanguage: false,
+                  gender: '',
+                  birthdate: '',
+                  yearsEstimated: 0,
+                  monthsEstimated: 0,
+                  birthdateEstimated: false,
+                  telephoneNumber: '',
+                  isDead: false,
+                  deathDate: '',
+                  deathCause: '',
+                  relationships: [],
+                  identifiers: { mockedIdentifierTypes },
+                  address: {},
+                },
+              }}>
+              <Field name="id" />
+            </PatientRegistrationContext.Provider>
+          </Form>
+        </Formik>
+      </ResourcesContext.Provider>,
+    );
+    expect(screen.getByTestId('identifiers')).toBeInTheDocument();
+  });
+
+  it('should return null and report an error for an invalid field name', () => {
+    (useConfig as jest.Mock).mockImplementation(() => ({
+      fieldDefinitions: [{ id: 'weight' }],
+    }));
+    let error = null;
+    try {
+      render(<Field name="invalidField" />);
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBe(
+      "Invalid field name 'invalidField'. Valid options are 'weight', 'name', 'gender', 'dob', 'address', 'id', 'phone & email'.",
+    );
+    expect(screen.queryByTestId('invalid-field')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

In this PR I have added the Tests for field.component.tsx of esm-patient-registration-app.

## Screenshots
<img width="963" alt="Screenshot 2023-06-24 at 10 30 08 PM" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/54752747/d313afe7-8abb-470d-afcd-3d9357181d2e">



## Related Issue
https://issues.openmrs.org/browse/O3-2215
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
