### PR TITLE
(fix) Fixed the incorrect assignment to isOffline on patient registration app

### DIFF
--- a/packages/esm-patient-registration-app/src/root.component.tsx
+++ b/packages/esm-patient-registration-app/src/root.component.tsx
@@ -14,7 +14,7 @@ import useSWRImmutable from 'swr/immutable';
 import styles from './root.scss';
 
 export default function Root() {
-  const isOffline = useConnectivity();
+  const isOnline = useConnectivity();
   const currentSession = useSession();
   const { data: addressTemplate } = useSWRImmutable('patientRegistrationAddressTemplate', fetchAddressTemplate);
   const { data: relationshipTypes } = useSWRImmutable(
@@ -26,8 +26,8 @@ export default function Root() {
     fetchPatientIdentifierTypesWithSources,
   );
   const savePatientForm = useMemo(
-    () => (isOffline ? FormManager.savePatientFormOffline : FormManager.savePatientFormOnline),
-    [isOffline],
+    () => (isOnline ? FormManager.savePatientFormOnline : FormManager.savePatientFormOffline),
+    [isOnline],
   );
 
   return (
@@ -47,11 +47,11 @@ export default function Root() {
             <Routes>
               <Route
                 path="patient-registration"
-                element={<PatientRegistration savePatientForm={savePatientForm} isOffline={isOffline} />}
+                element={<PatientRegistration savePatientForm={savePatientForm} isOffline={!isOnline} />}
               />
               <Route
                 path="patient/:patientUuid/edit"
-                element={<PatientRegistration savePatientForm={savePatientForm} isOffline={isOffline} />}
+                element={<PatientRegistration savePatientForm={savePatientForm} isOffline={!isOnline} />}
               />
             </Routes>
           </BrowserRouter>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR fixes an issue where the save logic in the patient registration form is currently set up to reference the wrong workflow as reported [here](https://openmrs.slack.com/archives/CHP5QAE5R/p1687844439188119?thread_ts=1687765511.828149&cid=CHP5QAE5R). This was the result of basing the logic on the wrong variable, which led to the workflow for offline mode getting used. This PR fixes the logic, ensuring the correct boolean variable is referenced from the `useConnectivity` hook to determine which save workflow to use when registering a patient.   


## Screenshots

*None.*


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
