### PR TITLE
(refactor): Display all active visits by removing filter for showing only today's active visits

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -37,7 +37,6 @@ interface VisitResponse {
 export function useActiveVisits() {
   const session = useSession();
   const config = useConfig();
-  const startDate = dayjs().format('YYYY-MM-DD');
   const sessionLocation = session?.sessionLocation?.uuid;
 
   const customRepresentation =
@@ -49,7 +48,7 @@ export function useActiveVisits() {
       return null;
     }
 
-    let url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}&totalCount=true&fromStartDate=${startDate}&location=${sessionLocation}`;
+    let url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}&totalCount=true&location=${sessionLocation}`;
 
     if (pageIndex) {
       url += `&startIndex=${pageIndex * 50}`;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR improves the logic for determining active visits by considering any visit that has not been ended. It enhances accuracy by ensuring that active visits are correctly identified. @vasharma05 will this break any of your implementation?

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
