### PR TITLE
(fix) O3-2280: Fix navigation links in the active visits widget

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -116,9 +116,9 @@ const ActiveVisitsTable = () => {
   const { t } = useTranslation();
   const config = useConfig();
   const layout = useLayoutType();
-  const [pageSize, setPageSize] = useState(config?.activeVisits?.pageSize ?? 10);
   const pageSizes = config?.activeVisits?.pageSizes ?? [10, 20, 30, 40, 50];
-  const { activeVisits, isLoading, isValidating, isError } = useActiveVisits();
+  const [pageSize, setPageSize] = useState(config?.activeVisits?.pageSize ?? 10);
+  const { activeVisits, isLoading, isValidating, error } = useActiveVisits();
   const [searchString, setSearchString] = useState('');
 
   const currentPathName = window.location.pathname;
@@ -184,11 +184,11 @@ const ActiveVisitsTable = () => {
     );
   }
 
-  if (isError) {
+  if (error) {
     return (
       <div className={styles.activeVisitsContainer}>
         <Layer>
-          <ErrorState error={isError} headerTitle={t('activeVisits', 'Active Visits')} />
+          <ErrorState error={error} headerTitle={t('activeVisits', 'Active Visits')} />
         </Layer>
       </div>
     );
@@ -244,43 +244,47 @@ const ActiveVisitsTable = () => {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {rows.map((row, index) => (
-                    <React.Fragment key={index}>
-                      <TableExpandRow
-                        {...getRowProps({ row })}
-                        data-testid={`activeVisitRow${activeVisits?.[index]?.patientUuid}`}>
-                        {row.cells.map((cell) => (
-                          <TableCell key={cell.id} data-testid={cell.id}>
-                            {cell.info.header === 'name' ? (
-                              <PatientNameLink
-                                from={fromPage}
-                                to={`\${openmrsSpaBase}/patient/${activeVisits?.[index]?.patientUuid}/chart/`}>
-                                {cell.value}
-                              </PatientNameLink>
-                            ) : (
-                              cell.value
-                            )}
-                          </TableCell>
-                        ))}
-                      </TableExpandRow>
-                      {row.isExpanded ? (
-                        <TableRow className={styles.expandedActiveVisitRow}>
-                          <th colSpan={headers.length + 2}>
-                            <ExtensionSlot
-                              className={styles.visitSummaryContainer}
-                              name="visit-summary-slot"
-                              state={{
-                                visitUuid: activeVisits[index]?.visitUuid,
-                                patientUuid: activeVisits[index]?.patientUuid,
-                              }}
-                            />
-                          </th>
-                        </TableRow>
-                      ) : (
-                        <TableExpandedRow className={styles.hiddenRow} colSpan={headers.length + 2} />
-                      )}
-                    </React.Fragment>
-                  ))}
+                  {rows.map((row, index) => {
+                    const visit = activeVisits.find((visit) => visit.id === row.id);
+
+                    return (
+                      <React.Fragment key={index}>
+                        <TableExpandRow
+                          {...getRowProps({ row })}
+                          data-testid={`activeVisitRow${activeVisits?.[index]?.patientUuid}`}>
+                          {row.cells.map((cell) => (
+                            <TableCell key={cell.id} data-testid={cell.id}>
+                              {cell.info.header === 'name' ? (
+                                <PatientNameLink
+                                  from={fromPage}
+                                  to={`\${openmrsSpaBase}/patient/${visit.patientUuid}/chart/Patient%20Summary`}>
+                                  {cell.value}
+                                </PatientNameLink>
+                              ) : (
+                                cell.value
+                              )}
+                            </TableCell>
+                          ))}
+                        </TableExpandRow>
+                        {row.isExpanded ? (
+                          <TableRow className={styles.expandedActiveVisitRow}>
+                            <th colSpan={headers.length + 2}>
+                              <ExtensionSlot
+                                className={styles.visitSummaryContainer}
+                                name="visit-summary-slot"
+                                state={{
+                                  visitUuid: activeVisits[index]?.visitUuid,
+                                  patientUuid: activeVisits[index]?.patientUuid,
+                                }}
+                              />
+                            </th>
+                          </TableRow>
+                        ) : (
+                          <TableExpandedRow className={styles.hiddenRow} colSpan={headers.length + 2} />
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
                 </TableBody>
               </Table>
             </TableContainer>

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -249,9 +249,7 @@ const ActiveVisitsTable = () => {
 
                     return (
                       <React.Fragment key={index}>
-                        <TableExpandRow
-                          {...getRowProps({ row })}
-                          data-testid={`activeVisitRow${activeVisits?.[index]?.patientUuid}`}>
+                        <TableExpandRow {...getRowProps({ row })} data-testid={`activeVisitRow${visit.patientUuid}`}>
                           {row.cells.map((cell) => (
                             <TableCell key={cell.id} data-testid={cell.id}>
                               {cell.info.header === 'name' ? (

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -48,9 +48,10 @@ export function useActiveVisits() {
       return null;
     }
 
-    let url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}&`;
+    let url = `/ws/rest/v1/visit?v=${customRepresentation}&`;
     let urlSearchParams = new URLSearchParams();
 
+    urlSearchParams.append('includeInactive', 'false');
     urlSearchParams.append('totalCount', 'true');
     urlSearchParams.append('location', `${sessionLocation}`);
 

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -48,13 +48,17 @@ export function useActiveVisits() {
       return null;
     }
 
-    let url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}&totalCount=true&location=${sessionLocation}`;
+    let url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}&`;
+    let urlSearchParams = new URLSearchParams();
+
+    urlSearchParams.append('totalCount', 'true');
+    urlSearchParams.append('location', `${sessionLocation}`);
 
     if (pageIndex) {
-      url += `&startIndex=${pageIndex * 50}`;
+      urlSearchParams.append('startIndex', `${pageIndex * 50}`);
     }
 
-    return url;
+    return url + urlSearchParams.toString();
   };
 
   const {
@@ -73,7 +77,7 @@ export function useActiveVisits() {
   }, [data, pageNumber]);
 
   const mapVisitProperties = (visit: Visit): ActiveVisit => {
-    //create base object
+    // create base object
     const activeVisits: ActiveVisit = {
       age: visit?.patient?.person?.age,
       id: visit.uuid,
@@ -87,36 +91,36 @@ export function useActiveVisits() {
       visitUuid: visit.uuid,
     };
 
-    //in case no configuration is given the previous behavior remains the same
+    // in case no configuration is given the previous behavior remains the same
     if (!config?.activeVisits?.identifiers) {
       activeVisits.idNumber = visit?.patient?.identifiers[0]?.identifier ?? '--';
     } else {
-      //map identifiers on config
+      // map identifiers on config
       config?.activeVisits?.identifiers?.map((configIdentifier) => {
-        //check if in the current visit the patient has in his identifiers the current identifierType name
+        // check if in the current visit the patient has in his identifiers the current identifierType name
         const visitIdentifier = visit?.patient?.identifiers.find(
           (visitIdentifier) => visitIdentifier?.identifierType?.name === configIdentifier?.identifierName,
         );
 
-        //add the new identifier or rewrite existing one to activeVisit object
-        //the parameter will corresponds to the name of the key value of the configuration
-        //and the respective value is the visit identifier
-        //If there isn't a identifier we display this default text '--'
+        // add the new identifier or rewrite existing one to activeVisit object
+        // the parameter will corresponds to the name of the key value of the configuration
+        // and the respective value is the visit identifier
+        // If there isn't a identifier we display this default text '--'
         activeVisits[configIdentifier.header?.key] = visitIdentifier?.identifier ?? '--';
       });
     }
 
-    //map attributes on config
+    // map attributes on config
     config?.activeVisits?.attributes?.map(({ display, header }) => {
-      //check if in the current visit the person has in his attributes the current display
+      // check if in the current visit the person has in his attributes the current display
       const personAttributes = visit?.patient?.person?.attributes.find(
         (personAttributes) => personAttributes?.attributeType?.display === display,
       );
 
-      //add the new attribute or rewrite existing one to activeVisit object
-      //the parameter will correspond to the name of the key value of the configuration
-      //and the respective value is the persons value
-      //If there isn't a attribute we display this default text '--'
+      // add the new attribute or rewrite existing one to activeVisit object
+      // the parameter will correspond to the name of the key value of the configuration
+      // and the respective value is the persons value
+      // If there isn't a attribute we display this default text '--'
       activeVisits[header?.key] = personAttributes?.value ?? '--';
     });
 
@@ -129,9 +133,9 @@ export function useActiveVisits() {
 
   return {
     activeVisits: formattedActiveVisits,
+    error,
     isLoading,
     isValidating,
-    isError: error,
     totalResults: data?.[0]?.data?.totalCount ?? 0,
   };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR fixes an issue where clicking on a patient's name in the active visits widget would sometimes navigate the user to the wrong patient chart.

## Video

> Expected behaviour

https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/ca58fd08-9b2c-4468-9661-5af1233a6274

## Related Issue

https://issues.openmrs.org/browse/O3-2280
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->

## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
