### PR TITLE
(test) O3-2283: Add test for `coded-person-attribute-field.component.tsx`

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useConceptAnswers } from '../field.resource';
+import { CodedPersonAttributeField } from './coded-person-attribute-field.component';
+import { Form, Formik } from 'formik';
+
+jest.mock('formik', () => ({
+  ...jest.requireActual('formik'),
+}));
+
+jest.mock('../field.resource'); // Mock the useConceptAnswers hook
+
+const mockedUseConceptAnswers = useConceptAnswers as jest.Mock;
+
+describe('CodedPersonAttributeField', () => {
+  const conceptAnswers = [
+    { uuid: '1', display: 'Option 1' },
+    { uuid: '2', display: 'Option 2' },
+  ];
+  const personAttributeType = {
+    format: 'org.openmrs.Concept',
+    display: 'Referred by',
+    uuid: '4dd56a75-14ab-4148-8700-1f4f704dc5b0',
+  };
+  const answerConceptSetUuid = '6682d17f-0777-45e4-a39b-93f77eb3531c';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseConceptAnswers.mockReturnValue({
+      data: conceptAnswers,
+      isLoading: false,
+    });
+  });
+
+  it('renders the Select component when conceptAnswers are available', () => {
+    render(
+      <Formik initialValues={{}} onSubmit={() => {}}>
+        <Form>
+          <CodedPersonAttributeField
+            id="attributeId"
+            personAttributeType={personAttributeType}
+            answerConceptSetUuid={answerConceptSetUuid}
+            label={personAttributeType.display}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText(/Referred by/i)).toBeInTheDocument();
+    expect(screen.getByText(/Option 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/Option 2/i)).toBeInTheDocument();
+  });
+
+  it('renders the Input component when conceptAnswers are not available', () => {
+    mockedUseConceptAnswers.mockReturnValueOnce({
+      data: null,
+      isLoading: false,
+    });
+
+    render(
+      <Formik initialValues={{}} onSubmit={() => {}}>
+        <Form>
+          <CodedPersonAttributeField
+            id="attributeId"
+            personAttributeType={personAttributeType}
+            answerConceptSetUuid={answerConceptSetUuid}
+            label={personAttributeType.display}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText(/Referred by/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Option 1/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Option 2/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('renders the Input component when conceptAnswers are still loading', () => {
+    mockedUseConceptAnswers.mockReturnValueOnce({
+      data: null,
+      isLoading: true,
+    });
+
+    render(
+      <Formik initialValues={{}} onSubmit={() => {}}>
+        <Form>
+          <CodedPersonAttributeField
+            id="attributeId"
+            personAttributeType={personAttributeType}
+            answerConceptSetUuid={answerConceptSetUuid}
+            label={personAttributeType.display}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByLabelText(/Referred by/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Option 1/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Option 2/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->
In this PR i have added tests for person-attribute-field.component.tsx


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

[O3-2283](https://issues.openmrs.org/browse/O3-2283)

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
