### PR TITLE
O3-2309: Implement dynamic frontend docker images for e2e test

### DIFF
--- a/e2e/commands/patient-operations.ts
+++ b/e2e/commands/patient-operations.ts
@@ -77,7 +77,7 @@ export const generateRandomPatient = async (api: APIRequestContext): Promise<Pat
         ],
         attributes: [],
         birthdate: '2020-2-1',
-        birthdateEstimated: false,
+        birthdateEstimated: true,
         dead: false,
         gender: 'M',
         names: [

--- a/e2e/pages/registration-and-edit-page.ts
+++ b/e2e/pages/registration-and-edit-page.ts
@@ -1,4 +1,4 @@
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 export type PatientRegistrationSex = 'male' | 'female' | 'other' | 'unknown';
 
@@ -38,10 +38,6 @@ export class RegistrationAndEditPage {
 
   async goto(editPatientUuid?: string) {
     await this.page.goto(editPatientUuid ? `patient/${editPatientUuid}/edit` : 'patient-registration');
-  }
-
-  async waitUntilTheFormIsLoaded() {
-    await expect(this.createPatientButton()).toBeEnabled();
   }
 
   async fillPatientRegistrationForm(formValues: PatientRegistrationFormValues) {

--- a/e2e/specs/edit-patient.spec.ts
+++ b/e2e/specs/edit-patient.spec.ts
@@ -32,7 +32,6 @@ test('Edit a patient', async ({ page, api }) => {
 
   await test.step("When I visit the registration page to a patient's details", async () => {
     await patientEditPage.goto(patient.uuid);
-    await patientEditPage.waitUntilTheFormIsLoaded();
   });
 
   await test.step('And then I click on fill new values into the registration form and then click the `Submit` button', async () => {

--- a/e2e/specs/register-new-patient.spec.ts
+++ b/e2e/specs/register-new-patient.spec.ts
@@ -29,7 +29,6 @@ test('Register a new patient', async ({ page, api }) => {
 
   await test.step('When I visit the registration page', async () => {
     await patientRegistrationPage.goto();
-    await patientRegistrationPage.waitUntilTheFormIsLoaded();
   });
 
   await test.step('And then I click on fill new values into the registration form and then click the `Submit` button', async () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ const config: PlaywrightTestConfig = {
   testDir: './e2e/specs',
   timeout: 3 * 60 * 1000,
   expect: {
-    timeout: 60 * 1000,
+    timeout: 40 * 1000,
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

With this PR, we can avoid resource limitation issues in GitHub actions. When the e2e tests are running, it will automatically create a lightweight prod version of the front end (as a docker image), only containing the changed MFs and the necessary MFs. So it can run with less than 300 MBs of RAM. That docker image will be used to create the frontend instance of the e2e docker-compose stack. This will also reduce the loading durations. (This will also be implemented in patient-chart in future.)

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

<img width="1001" alt="image" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/27498587/b628eea1-3be0-4f59-9f3d-9dd3c7f65fb6">

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://issues.openmrs.org/browse/O3-2309


## Other
Reference: https://github.com/openmrs/openmrs-esm-patient-chart/commit/1ac7ed5776d8c959e39221db3371070e4d2ff795

The failing 2 tests will be fixed with https://github.com/openmrs/openmrs-esm-patient-management/pull/763
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
