### PR TITLE
(fix) Fix logic that determines props to pass to active visit extensions

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -271,8 +271,8 @@ const ActiveVisitsTable = () => {
                                 className={styles.visitSummaryContainer}
                                 name="visit-summary-slot"
                                 state={{
-                                  visitUuid: activeVisits[index]?.visitUuid,
-                                  patientUuid: activeVisits[index]?.patientUuid,
+                                  visitUuid: visit.visitUuid,
+                                  patientUuid: visit.patientUuid,
                                 }}
                               />
                             </th>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This is a follow-up fix that should have been part of https://github.com/openmrs/openmrs-esm-patient-management/pull/761.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
