### PR TITLE
(test)O3-2328: Add tests for `esm-appointments-app` frontend module

### DIFF
--- a/packages/esm-appointments-app/src/appointments-calendar/appointments-calendar-view.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-calendar/appointments-calendar-view.component.tsx
@@ -14,7 +14,7 @@ const AppointmentsCalendarView: React.FC = () => {
   const { calendarEvents } = useAppointmentsCalendar(currentDate.toISOString(), calendarView);
 
   return (
-    <div>
+    <div data-testid="appointments-calendar">
       <AppointmentsHeader title={t('appointments', 'Appointments')} />
       <CalendarHeader onChangeView={setCalendarView} calendarView={calendarView} />
       <CalendarView

--- a/packages/esm-appointments-app/src/appointments-calendar/daily/daily-view-workload.test.tsx
+++ b/packages/esm-appointments-app/src/appointments-calendar/daily/daily-view-workload.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import dayjs from 'dayjs';
+import { navigate } from '@openmrs/esm-framework';
+import DailyWorkloadView from './daily-view-workload.component';
+import { spaBasePath } from '../../constants';
+import { CalendarType } from '../../types';
+
+jest.mock('@openmrs/esm-framework', () => ({
+  navigate: jest.fn(),
+  useLayoutType: jest.fn(),
+}));
+
+describe('DailyWorkloadView Component', () => {
+  const mockData = {
+    type: 'daily' as CalendarType,
+    dateTime: dayjs('2023-08-18'),
+    currentDate: dayjs('2023-08-18'),
+    events: [
+      {
+        appointmentDate: '2023-08-18',
+        service: [
+          { serviceName: 'HIV', count: 2 },
+          { serviceName: 'Lab testing', count: 3 },
+        ],
+      },
+    ],
+  };
+
+  it('renders properly when type is "daily"', () => {
+    render(<DailyWorkloadView {...mockData} />);
+
+    expect(screen.getByText('All Day')).toBeInTheDocument();
+    expect(screen.getByText('HIV')).toBeInTheDocument();
+    expect(screen.getByText('Lab testing')).toBeInTheDocument();
+  });
+
+  it('navigates when a service area is clicked', () => {
+    render(<DailyWorkloadView {...mockData} />);
+
+    fireEvent.click(screen.getByText('HIV'));
+
+    expect(navigate).toHaveBeenCalledWith({
+      to: `${spaBasePath}/appointments/list/Fri, 18 Aug 2023 00:00:00 GMT/HIV`,
+    });
+  });
+
+  it('calculates and displays the total count correctly', () => {
+    render(<DailyWorkloadView {...mockData} />);
+
+    expect(screen.getByText('Total')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+});

--- a/packages/esm-appointments-app/src/appointments-calendar/patient-list/calendar-patient-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-calendar/patient-list/calendar-patient-list.component.tsx
@@ -63,7 +63,7 @@ const CalendarPatientList: React.FC<CalendarPatientListProps> = () => {
   if (isLoading) {
     return (
       <>
-        <DataTableSkeleton />
+        <DataTableSkeleton data-testid="calendar-patient-list" />
       </>
     );
   }

--- a/packages/esm-appointments-app/src/appointments-calendar/weekly/weekly-view-workload.test.tsx
+++ b/packages/esm-appointments-app/src/appointments-calendar/weekly/weekly-view-workload.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import dayjs from 'dayjs';
+import WeeklyWorkloadView from './weekly-view-workload.component';
+import { CalendarType } from '../../types';
+import { spaBasePath } from '../../constants';
+import { navigate } from '@openmrs/esm-framework';
+
+jest.mock('@openmrs/esm-framework', () => ({
+  navigate: jest.fn(),
+  useLayoutType: jest.fn(),
+}));
+
+describe('WeeklyWorkloadView Component', () => {
+  const mockData = {
+    type: 'weekly' as CalendarType,
+    dateTime: dayjs('2023-08-17'),
+    currentDate: dayjs('2023-08-17'),
+    events: [
+      {
+        appointmentDate: '2023-08-17',
+        service: [
+          { serviceName: 'HIV', count: 2 },
+          { serviceName: 'Lab testing', count: 3 },
+        ],
+      },
+    ],
+    index: 1,
+  };
+
+  it('renders properly when type is "weekly"', () => {
+    render(<WeeklyWorkloadView {...mockData} />);
+
+    expect(screen.getByText('All Day')).toBeInTheDocument();
+    expect(screen.getByText('HIV')).toBeInTheDocument();
+    expect(screen.getByText('Lab testing')).toBeInTheDocument();
+  });
+
+  it('navigates when a service area is clicked', () => {
+    render(<WeeklyWorkloadView {...mockData} />);
+
+    fireEvent.click(screen.getByText('HIV'));
+
+    expect(navigate).toHaveBeenCalledWith({
+      to: `${spaBasePath}/appointments/list/Thu, 17 Aug 2023 00:00:00 GMT/HIV`,
+    });
+  });
+
+  it('calculates and displays the total count correctly', () => {
+    render(<WeeklyWorkloadView {...mockData} />);
+
+    expect(screen.getByText('Total')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+});

--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
@@ -22,7 +22,7 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, onChange 
   const location = session?.sessionLocation?.display;
   const { serviceTypes } = useAppointmentServices();
   return (
-    <div className={styles.header}>
+    <div className={styles.header} data-testid="appointments-header">
       <div className={styles['left-justified-items']}>
         <AppointmentsIllustration />
         <div className={styles['page-labels']}>

--- a/packages/esm-appointments-app/src/appointments-metrics/appointments-metrics.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-metrics/appointments-metrics.component.tsx
@@ -37,7 +37,7 @@ const AppointmentsMetrics: React.FC<{ serviceUuid: string }> = ({ serviceUuid })
   return (
     <>
       <MetricsHeader />
-      <div className={styles.cardContainer}>
+      <div className={styles.cardContainer} data-testid="clinic-metrics">
         <MetricsCard
           label={t('patients', 'Patients')}
           value={totalScheduledAppointments}

--- a/packages/esm-appointments-app/src/appointments.test.tsx
+++ b/packages/esm-appointments-app/src/appointments.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ClinicalAppointments from './appointments.component';
+
+describe('ClinicalAppointments Component', () => {
+  it('renders AppointmentsCalendarListView when pathname includes "calendar"', () => {
+    // Mock window.location.pathname
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: '/some-path/calendar',
+      },
+      writable: true,
+    });
+
+    render(<ClinicalAppointments />);
+
+    expect(screen.getByTestId('appointments-calendar')).toBeInTheDocument();
+  });
+
+  it('renders CalendarPatientList when pathname includes "list"', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: '/some-path/list',
+      },
+      writable: true,
+    });
+
+    render(<ClinicalAppointments />);
+
+    expect(screen.getByTestId('calendar-patient-list')).toBeInTheDocument();
+  });
+
+  it('renders other components when pathname does not include "calendar" or "list"', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: '/some-path/some-other-path',
+      },
+      writable: true,
+    });
+
+    render(<ClinicalAppointments />);
+
+    expect(screen.getByTestId('appointments-header')).toBeInTheDocument();
+    expect(screen.getByTestId('clinic-metrics')).toBeInTheDocument();
+    expect(screen.getByTestId('appointment-list')).toBeInTheDocument();
+  });
+});

--- a/packages/esm-appointments-app/src/appointments/appointment-tabs.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-tabs.component.tsx
@@ -22,7 +22,7 @@ const AppointmentTabs: React.FC<AppointmentTabsProps> = ({ appointmentServiceTyp
   };
 
   return (
-    <div className={styles.appointmentList}>
+    <div className={styles.appointmentList} data-testid="appointment-list">
       <Tabs selectedIndex={activeTabIndex} onChange={handleTabChange} className={styles.tabs}>
         <TabList style={{ paddingLeft: '1rem' }} aria-label="Appointment tabs" contained>
           <Tab className={styles.tab}>{t('scheduled', 'Scheduled')}</Tab>

--- a/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-forms.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-forms.test.tsx
@@ -42,7 +42,7 @@ let mockOpenmrsConfig = {
   hiddenFormFields: [],
 };
 
-xdescribe('AppointmentForm', () => {
+describe('AppointmentForm', () => {
   const patient = mockPatient;
   beforeEach(() => {
     mockedUseConfig.mockReturnValue(mockOpenmrsConfig);

--- a/packages/esm-appointments-app/src/home-appointments/appointment-actions.test.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/appointment-actions.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ActionsMenu } from './appointment-actions.component';
+
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  useConfig: jest.fn(() => mockUseConfig),
+  useSWRConfig: jest.fn(),
+  navigate: jest.fn(),
+}));
+
+jest.mock('@carbon/react', () => ({
+  Layer: ({ children }) => children,
+  OverflowMenu: ({ children }) => <div>{children}</div>,
+  OverflowMenuItem: ({ children, ...props }) => <button {...props}>{children}</button>,
+}));
+
+jest.mock('./common', () => ({
+  handleUpdateStatus: jest.fn(),
+  handleComplete: jest.fn(),
+  launchCheckInAppointmentModal: jest.fn(),
+}));
+
+const mockUseConfig = {
+  bahmniAppointmentsUiBaseUrl: 'https://example.com',
+};
+
+describe('ActionsMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the actions menu with correct options and handlers', () => {
+    const mockAppointment = {
+      id: '123',
+      recurring: false,
+      status: 'Scheduled',
+    };
+
+    const { getByText } = render(<ActionsMenu appointment={mockAppointment} useBahmniUI="true" />);
+
+    fireEvent.click(getByText('Edit Appointment'));
+    fireEvent.click(getByText('Check In'));
+    fireEvent.click(getByText('Complete'));
+    fireEvent.click(getByText('Missed'));
+    fireEvent.click(getByText('Cancel'));
+    fireEvent.click(getByText('Add new appointment'));
+
+    expect(screen.getByText('Edit Appointment')).toBeInTheDocument();
+    expect(screen.getByText('Check In')).toBeInTheDocument();
+    expect(screen.getByText('Complete')).toBeInTheDocument();
+    expect(screen.getByText('Missed')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Add new appointment')).toBeInTheDocument();
+  });
+
+  it('renders the actions menu with correct options and handlers in non-BahmniUI mode', () => {
+    const mockAppointment = {
+      id: '456',
+      recurring: true,
+      status: 'CheckedIn',
+    };
+
+    const { getByText } = render(<ActionsMenu appointment={mockAppointment} useBahmniUI={undefined} />);
+
+    fireEvent.click(getByText('Edit Appointment'));
+    fireEvent.click(getByText('Check In'));
+    fireEvent.click(getByText('Complete'));
+    fireEvent.click(getByText('Missed'));
+    fireEvent.click(getByText('Cancel'));
+    fireEvent.click(getByText('Add new appointment'));
+
+    expect(screen.getByText('Edit Appointment')).toBeInTheDocument();
+    expect(screen.getByText('Check In')).toBeInTheDocument();
+    expect(screen.getByText('Complete')).toBeInTheDocument();
+    expect(screen.getByText('Missed')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Add new appointment')).toBeInTheDocument();
+  });
+});

--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.test.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AppointmentsBaseTable from './appointments-list.component';
+import { mockSession } from '../../../../__mocks__/session.mock';
+import { useTodaysAppointments } from './appointments-table.resource';
+import { usePagination } from '@openmrs/esm-framework';
+import { mockAppointmentsData } from '../../../../__mocks__/appointments.mock';
+
+const useTodaysAppointmentsMock = useTodaysAppointments as jest.Mock;
+const usePaginationMock = usePagination as jest.Mock;
+
+jest.mock('./appointments-table.resource');
+
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  useSession: jest.fn(() => ({ user: { mockSession } })),
+  useConfig: jest.fn(() => ({
+    useBahmniAppointmentsUI: false,
+    useFullViewPrivilege: false,
+    fullViewPrivilege: 'somePrivilege',
+  })),
+  userHasAccess: jest.fn(() => true),
+}));
+
+describe('AppointmentsBaseTable', () => {
+  it('renders loading skeleton when loading', () => {
+    useTodaysAppointmentsMock.mockImplementationOnce(() => ({
+      appointments: [],
+      isLoading: true,
+      isValidating: false,
+    }));
+
+    render(<AppointmentsBaseTable />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders no appointments message when no appointments are available', () => {
+    useTodaysAppointmentsMock.mockImplementationOnce(() => ({
+      appointments: [],
+      isLoading: false,
+      isValidating: false,
+    }));
+
+    render(<AppointmentsBaseTable />);
+    expect(
+      screen.getByText(/There are no appointments scheduled for today to display for this location/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders appointments and actions', () => {
+    useTodaysAppointmentsMock.mockImplementationOnce(() => ({
+      appointments: [
+        {
+          id: 1,
+          dateTime: '2023-08-18 10:00 AM',
+          name: 'John Doe',
+          identifier: 'JD123',
+          location: 'Clinic A',
+          serviceColor: 'blue',
+          serviceType: 'Checkup',
+          status: 'Scheduled',
+        },
+      ],
+      isLoading: false,
+      isValidating: false,
+    }));
+    usePaginationMock.mockImplementationOnce(() => ({
+      goto: jest.fn(),
+      currentPage: 1,
+      results: [
+        {
+          id: 1,
+          dateTime: '2023-08-18 10:00 AM',
+          name: 'John Doe',
+          identifier: 'JD123',
+          location: 'Clinic A',
+          serviceColor: 'blue',
+          serviceType: 'Checkup',
+          status: 'Scheduled',
+        },
+      ],
+    }));
+    render(<AppointmentsBaseTable />);
+
+    // Assert that appointment data is displayed
+    expect(screen.getByText('2023-08-18 10:00 AM')).toBeInTheDocument();
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('JD123')).toBeInTheDocument();
+    expect(screen.getByText('Clinic A')).toBeInTheDocument();
+    expect(screen.getByText('Checkup')).toBeInTheDocument();
+  });
+});

--- a/packages/esm-appointments-app/src/home-appointments/check-in-modal/check-in-modal.test.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/check-in-modal/check-in-modal.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import CheckInAppointmentModal from './check-in-modal.component';
 import { showActionableNotification, showNotification } from '@openmrs/esm-framework';
-import { handleUndoAction } from '../common';
 import { updateAppointmentStatus } from '../appointments-table.resource';
 
 const mockUpdateAppointmentStatus = updateAppointmentStatus as jest.Mock;

--- a/packages/esm-appointments-app/src/home-appointments/check-in-modal/check-in-modal.test.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/check-in-modal/check-in-modal.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CheckInAppointmentModal from './check-in-modal.component';
+import { showActionableNotification, showNotification } from '@openmrs/esm-framework';
+import { handleUndoAction } from '../common';
+import { updateAppointmentStatus } from '../appointments-table.resource';
+
+const mockUpdateAppointmentStatus = updateAppointmentStatus as jest.Mock;
+const appointmentUuid = '7cd38a6d-377e-491b-8284-b04cf8b8c6d8';
+
+jest.mock('@openmrs/esm-framework');
+jest.mock('../appointments-table.resource');
+
+describe('CheckInAppointmentModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits and displays success notification', async () => {
+    mockUpdateAppointmentStatus.mockResolvedValue({ status: 200 });
+    const closeCheckInModal = jest.fn();
+
+    render(<CheckInAppointmentModal closeCheckInModal={closeCheckInModal} appointmentUuid={appointmentUuid} />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '10:30' } });
+    fireEvent.click(screen.getByText('Yes'));
+
+    await waitFor(() => {
+      expect(closeCheckInModal).toHaveBeenCalled();
+      expect(showActionableNotification).toHaveBeenCalled();
+    });
+  });
+
+  it('displays error notification on submit failure', async () => {
+    mockUpdateAppointmentStatus.mockResolvedValue({ status: 400 });
+    const closeCheckInModal = jest.fn();
+
+    render(<CheckInAppointmentModal closeCheckInModal={closeCheckInModal} appointmentUuid={appointmentUuid} />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '10:30' } });
+    fireEvent.click(screen.getByText('Yes'));
+
+    await waitFor(() => {
+      expect(showNotification).toHaveBeenCalled();
+    });
+  });
+
+  it('closes modal on "No" button click', () => {
+    const closeCheckInModal = jest.fn();
+
+    render(<CheckInAppointmentModal closeCheckInModal={closeCheckInModal} appointmentUuid={appointmentUuid} />);
+
+    fireEvent.click(screen.getByText('No'));
+
+    expect(closeCheckInModal).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

In this PR I have added multiple tests for `esm-appointments-app`. I think few of the components are not getting used but I am not sure need confirmation on this. The components of `esm-appointments-app` which are not getting used according to me are `appointment-services.component.tsx` ,  `past-visit.component.tsx`, `encounter-list.component.tsx`

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

https://issues.openmrs.org/browse/O3-2328
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
