### PR TITLE
(fix) Resolved crash in active-visit component due to missing patient Uuid on visit object

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -247,15 +247,21 @@ const ActiveVisitsTable = () => {
                   {rows.map((row, index) => {
                     const visit = activeVisits.find((visit) => visit.id === row.id);
 
+                    if (!visit) {
+                      return null;
+                    }
+
+                    const patientLink = `$\{openmrsSpaBase}/patient/${visit.patientUuid}/chart/Patient%20Summary`;
+
                     return (
                       <React.Fragment key={index}>
-                        <TableExpandRow {...getRowProps({ row })} data-testid={`activeVisitRow${visit.patientUuid}`}>
+                        <TableExpandRow
+                          {...getRowProps({ row })}
+                          data-testid={`activeVisitRow${visit.patientUuid || 'unknown'}`}>
                           {row.cells.map((cell) => (
                             <TableCell key={cell.id} data-testid={cell.id}>
-                              {cell.info.header === 'name' ? (
-                                <PatientNameLink
-                                  from={fromPage}
-                                  to={`\${openmrsSpaBase}/patient/${visit.patientUuid}/chart/Patient%20Summary`}>
+                              {cell.info.header === 'name' && visit.patientUuid ? (
+                                <PatientNameLink from={fromPage} to={patientLink}>
                                   {cell.value}
                                 </PatientNameLink>
                               ) : (


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR introduces a validation check to the active-visit function, preventing crashes caused by missing patientUuid in the visit object.


## Screenshots
## Bug state
![Screenshot from 2023-08-30 00-11-45](https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/0dde8bb5-6963-41e0-9075-bd2331480c5a)


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
