### PR TITLE
(feat) Remove encounters from past visit widget in service queues

### DIFF
--- a/packages/esm-outpatient-app/src/current-visit/visit-details/vitals.component.tsx
+++ b/packages/esm-outpatient-app/src/current-visit/visit-details/vitals.component.tsx
@@ -86,8 +86,6 @@ const Vitals: React.FC<VitalsComponentProps> = ({ vitals, patientUuid, visitType
                 </p>
               </div>
             </Tile>
-          </div>
-          <div className={styles.row}>
             <Tile className={styles.tile}>
               <p>{t('sp02', 'Sp02')}</p>
               <div className={styles.vitalValuesWrapper}>
@@ -97,6 +95,8 @@ const Vitals: React.FC<VitalsComponentProps> = ({ vitals, patientUuid, visitType
                 <p className={styles.unit}>{conceptUnits.get(config.concepts.oxygenSaturationUuid) ?? ''}</p>
               </div>
             </Tile>
+          </div>
+          <div className={styles.row}>
             <Tile className={styles.tile}>
               <p>{t('rRate', 'R. Rate')}</p>
               <div className={styles.vitalValuesWrapper}>
@@ -106,13 +106,18 @@ const Vitals: React.FC<VitalsComponentProps> = ({ vitals, patientUuid, visitType
                 <p className={styles.unit}>{conceptUnits.get(config.concepts.respiratoryRateUuid) ?? ''}</p>
               </div>
             </Tile>
-          </div>
-          <div className={styles.row}>
             <Tile className={styles.tile}>
               <p>{t('height', 'Height')}</p>
               <div className={styles.vitalValuesWrapper}>
                 <p className={styles.vitalValues}>{vitalsToDisplay.height ? vitalsToDisplay.height : '--'}</p>
                 <p className={styles.unit}>{conceptUnits.get(config.concepts.heightUuid) ?? ''}</p>
+              </div>
+            </Tile>
+            <Tile className={styles.tile}>
+              <p>{t('weight', 'Weight')}</p>
+              <div className={styles.vitalValuesWrapper}>
+                <p className={styles.vitalValues}>{vitalsToDisplay.weight ? vitalsToDisplay.weight : '--'} </p>
+                <p className={styles.unit}>{conceptUnits.get(config.concepts.weightUuid) ?? ''}</p>
               </div>
             </Tile>
             <Tile className={styles.tile}>
@@ -123,13 +128,6 @@ const Vitals: React.FC<VitalsComponentProps> = ({ vitals, patientUuid, visitType
                   {calculateBMI(Number(vitalsToDisplay.weight), Number(vitalsToDisplay.height))}
                 </p>
                 <p className={styles.unit}>{config.biometrics['bmiUnit']}</p>
-              </div>
-            </Tile>
-            <Tile className={styles.tile}>
-              <p>{t('weight', 'Weight')}</p>
-              <div className={styles.vitalValuesWrapper}>
-                <p className={styles.vitalValues}>{vitalsToDisplay.weight ? vitalsToDisplay.weight : '--'} </p>
-                <p className={styles.unit}>{conceptUnits.get(config.concepts.weightUuid) ?? ''}</p>
               </div>
             </Tile>
           </div>

--- a/packages/esm-outpatient-app/src/past-visit/past-visit-details/past-visit-summary.component.tsx
+++ b/packages/esm-outpatient-app/src/past-visit/past-visit-details/past-visit-summary.component.tsx
@@ -144,12 +144,6 @@ const PastVisitSummary: React.FC<PastVisitSummaryProps> = ({ encounters, patient
               onClick={() => setSelectedTabIndex(2)}>
               {t('medications', 'Medications')}
             </Tab>
-            <Tab
-              className={`${styles.tab} ${selectedTabIndex === 3 && styles.selectedTab}`}
-              id="encounters-tab"
-              onClick={() => setSelectedTabIndex(3)}>
-              {t('encounters', 'Encounters')}
-            </Tab>
           </TabList>
           <TabPanels>
             <TabPanel>

--- a/packages/esm-outpatient-app/src/past-visit/past-visit.scss
+++ b/packages/esm-outpatient-app/src/past-visit/past-visit.scss
@@ -26,8 +26,8 @@
 
 .container {
   background-color: $ui-background;
-  padding: spacing.$spacing-05;
-  margin: spacing.$spacing-05 0rem spacing.$spacing-05;
+  padding: spacing.$spacing-03;
+  margin: spacing.$spacing-03 0rem spacing.$spacing-03;
   width: 100%;
 }
 

--- a/packages/esm-outpatient-app/src/past-visit/past-visit.test.tsx
+++ b/packages/esm-outpatient-app/src/past-visit/past-visit.test.tsx
@@ -24,18 +24,15 @@ describe('PastVisit: ', () => {
 
     expect(screen.queryAllByText(/vitals/i));
     const vitalsTab = screen.getByRole('tab', { name: /vitals/i });
-    const encountersTab = screen.getByRole('tab', { name: /encounters/i });
 
     expect(vitalsTab).toBeInTheDocument();
 
     expect(screen.getByRole('tab', { name: /notes/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /medications/i })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: /^encounters$/i })).toBeInTheDocument();
 
     await user.click(vitalsTab);
 
     expect(vitalsTab).toHaveAttribute('aria-selected', 'true');
-    expect(encountersTab).toHaveAttribute('aria-selected', 'false');
   });
 });
 

--- a/packages/esm-outpatient-app/src/transition-queue-entry/transition-queue-entry-dialog.scss
+++ b/packages/esm-outpatient-app/src/transition-queue-entry/transition-queue-entry-dialog.scss
@@ -3,6 +3,7 @@
 
 .modalBody {
   padding-bottom: spacing.$spacing-03;
+  margin-bottom: 0rem;
 }
 
 .p {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Remove encounters from past visit widget in service queues to make the call patient modal lightweight and responsive

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="645" alt="calltoqueue" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/19533785/f5997348-f2e4-4789-977e-5b9964e50fe6">

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
