### PR TITLE
(fix) Mutate list of patients not in queue on adding new queue entries

### DIFF
--- a/packages/esm-outpatient-app/src/add-patient-toqueue/add-patient-toqueue-dialog.component.tsx
+++ b/packages/esm-outpatient-app/src/add-patient-toqueue/add-patient-toqueue-dialog.component.tsx
@@ -21,7 +21,7 @@ import {
   useVisitQueueEntries,
 } from '../active-visits/active-visits-table.resource';
 import styles from './add-patient-toqueue-dialog.scss';
-import { ActiveVisit } from '../visits-missing-inqueue/visits-missing-inqueue.resource';
+import { ActiveVisit, useMissingQueueEntries } from '../visits-missing-inqueue/visits-missing-inqueue.resource';
 import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
 
 interface AddVisitToQueueDialogProps {
@@ -48,6 +48,7 @@ const AddVisitToQueue: React.FC<AddVisitToQueueDialogProps> = ({ visitDetails, c
   const config = useConfig() as ConfigObject;
   const { mutate } = useVisitQueueEntries('', selectedQueueLocation);
   const [priority, setPriority] = useState(config.concepts.defaultPriorityConceptUuid);
+  const { mutateQueueEntries } = useMissingQueueEntries();
 
   const addVisitToQueue = useCallback(() => {
     if (!queueUuid) {
@@ -86,6 +87,7 @@ const AddVisitToQueue: React.FC<AddVisitToQueueDialogProps> = ({ visitDetails, c
           });
           closeModal();
           mutate();
+          mutateQueueEntries();
         }
       },
       (error) => {

--- a/packages/esm-outpatient-app/src/visits-missing-inqueue/visits-missing-inqueue.resource.ts
+++ b/packages/esm-outpatient-app/src/visits-missing-inqueue/visits-missing-inqueue.resource.ts
@@ -39,11 +39,12 @@ export function useMissingQueueEntries() {
     isValidating: visitsIsValidating,
   } = useSWR<{ data: { results: Array<Visit> } }, Error>(sessionLocation ? url : null, openmrsFetch);
 
-  const apiUrl = `/ws/rest/v1/visit-queue-entry?v=full`;
+  const apiUrl = `/ws/rest/v1/visit-queue-entry`;
   const {
     data: queueData,
     error: queueError,
     isValidating: queueIsValidating,
+    mutate: mutateQueueEntries,
   } = useSWR<{ data: { results: Array<VisitQueueEntry> } }, Error>(apiUrl, openmrsFetch);
 
   const byId = {};
@@ -82,6 +83,7 @@ export function useMissingQueueEntries() {
     isLoading: !data && !visitsError && !queueError,
     isError: !visitsError && !queueError,
     visitsIsValidating,
+    mutateQueueEntries,
   };
 }
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Mutate list of patients not in queue on adding new queue entries

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
https://www.loom.com/share/b972c4abbf1541638b072917f4d1b41b?sid=d07d93ef-4180-4ad3-bd6b-cf8a297f6075

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
