### PR TITLE
(fix) `useInitialEncounters` hook throws error for obs with no value

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.types.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.types.tsx
@@ -1,4 +1,4 @@
-import { Session } from '@openmrs/esm-framework';
+import { OpenmrsResource, Session } from '@openmrs/esm-framework';
 import { RegistrationConfig } from '../config-schema';
 import { SavePatientTransactionManager } from './form-manager';
 
@@ -128,8 +128,8 @@ export interface Encounter {
   }>;
   form: string;
   obs: Array<{
-    concept: string;
-    value: string | number;
+    concept: string | OpenmrsResource;
+    value: string | number | OpenmrsResource;
   }>;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
When the obs for a patient are fetched and the obs' value is `null`, the `value['uuid']` throws an error.

## Screenshots

*None.*

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
