### PR TITLE
O3-2418: Update Eslint configuration to restrict unused variables

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-src/**/*.test.tsx
-src/**/*.spec.tsx
 **/*.d.tsx
+**/dist/**/*
 **/node_modules/**/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,8 @@
   "extends": ["ts-react-important-stuff", "plugin:prettier/recommended"],
   "rules": {
     "curly": ["error", "all"],
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }],
     "no-restricted-imports": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "verify": "turbo lint && turbo typescript && turbo test --color --concurrency=5",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx,css,scss}\" \"e2e/**/*.ts\"",
     "test-e2e": "playwright test",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "postinstall": "husky install",
     "extract-translations": "lerna run extract-translations -- --config ../../tools/i18next-parser.config.js"
   },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Currently the unused imports and the variables are overlooked by our eslint which is not okay. The goal of this PR is to update the eslint configuration to throw errors if there is unused parameters.



## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

[O3-2418](https://issues.openmrs.org/browse/O3-2418)
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
