### PR TITLE
O3-2383 Add column to denote patient previous queue in queue table

### DIFF
--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
@@ -161,8 +161,8 @@ function ActiveVisitsTable() {
       },
       {
         id: 3,
-        header: t('locationComingFrom', 'Coming from'),
-        key: 'locationComingFrom',
+        header: t('queueComingFrom', 'Coming from'),
+        key: 'queueComingFrom',
       },
       {
         id: 4,
@@ -218,8 +218,8 @@ function ActiveVisitsTable() {
           </>
         ),
       },
-      locationComingFrom: {
-        content: <span className={styles.statusContainer}>{entry?.locationComingFrom}</span>,
+      queueComingFrom: {
+        content: <span className={styles.statusContainer}>{entry?.queueComingFrom}</span>,
       },
       status: {
         content: (

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.resource.ts
@@ -71,7 +71,7 @@ export interface VisitQueueEntry {
   uuid: string;
   visit: Visit;
   sortWeight: number;
-  locationComingFrom: {
+  queueComingFrom: {
     name: string;
   };
 }
@@ -102,7 +102,7 @@ export interface MappedVisitQueueEntry {
   sortWeight: number;
   visitQueueNumber: string;
   identifiers: Array<Identifer>;
-  locationComingFrom: string;
+  queueComingFrom: string;
 }
 
 interface UseVisitQueueEntries {
@@ -248,7 +248,7 @@ export function useVisitQueueEntries(currServiceName: string, locationUuid: stri
       (e) => e.attributeType.uuid === visitQueueNumberAttributeUuid,
     )?.value,
     identifiers: visitQueueEntry.queueEntry.patient?.identifiers,
-    locationComingFrom: visitQueueEntry.queueEntry?.locationComingFrom?.name,
+    queueComingFrom: visitQueueEntry.queueEntry?.queueComingFrom?.name,
   });
 
   let mappedVisitQueueEntries;
@@ -315,7 +315,7 @@ export async function updateQueueEntry(
         },
         startedAt: toDateObjectStrict(toOmrsIsoString(new Date())),
         sortWeight: sortWeight,
-        locationComingFrom: previousQueueUuid,
+        queueComingFrom: previousQueueUuid,
       },
     },
   });


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- This is a followup PR to update renaming of the  queue locationComingFrom column to queueComingFrom 

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
