### PR TITLE
(fix) Temporarily disable the patient search banner tags slot

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -101,11 +101,11 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
                   <h2 className={styles.patientName}>{`${patient.name?.[0]?.given?.join(' ')} ${
                     patient.name?.[0]?.family
                   }`}</h2>
-                  <ExtensionSlot
+                  {/* <ExtensionSlot
                     name="patient-banner-tags-slot"
                     state={{ patient, patientUuid: patient.id }}
                     className={styles.flexRow}
-                  />
+                  /> */}
                 </div>
                 <p className={styles.demographics}>
                   {getGender(patient.gender)} <span className={styles.middot}>&middot;</span> {age(patient.birthDate)}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

I've temporarily disabled the `patient-banner-tags-slot` slot in the patient search banner component. For whatever reason, the visit tags extension unmounts immediately after search results are fetched. This is also affecting e2e tests, where the patient search spec is still failing for some time now. This is not the most ideal approach, but we need to unblock other PRs in the queue whose tests are failing.

## Other
[Slack thread (with video)](https://openmrs.slack.com/archives/CP343JH1R/p1694685523647519).