### PR TITLE
(fix) Fix patient list side rail icon

### DIFF
--- a/packages/esm-patient-list-app/src/patient-list-action-button.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-action-button.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@carbon/react';
+import { Button, IconButton } from '@carbon/react';
 import { Events } from '@carbon/react/icons';
 import { navigate, useLayoutType } from '@openmrs/esm-framework';
 import styles from './patient-list-action-button.scss';
@@ -21,18 +21,15 @@ const PatientListActionButton: React.FC = () => {
   }
 
   return (
-    <Button
+    <IconButton
+      align="left"
       className={styles.container}
-      onClick={navigateToPatientList}
-      kind="ghost"
-      renderIcon={(props) => <Events size={20} {...props} />}
-      hasIconOnly
-      iconDescription={t('patientLists', 'Patient lists')}
       enterDelayMs={1000}
-      tooltipAlignment="center"
-      tooltipPosition="left"
-      size="sm"
-    />
+      kind="ghost"
+      label={t('patientLists', 'Patient lists')}
+      onClick={navigateToPatientList}>
+      <Events size={20} />
+    </IconButton>
   );
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR attempts to fix an issue where icon buttons in the side rail don't look quite 
right. I've swapped out how the Patient list icon button gets rendered, replacing the existing implementation with the approach suggested in the Carbon [IconButton docs](https://react.carbondesignsystem.com/?path=/docs/components-iconbutton--overview) and passing the appropriate props to it.

## Screenshots

<img width="195" alt="Patient list icon button" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/1e73ae76-8fbd-4769-8094-3596cb912ad2">

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
