### PR TITLE
(refactor) Remove deprecated completed appointment tab

### DIFF
--- a/packages/esm-appointments-app/src/appointments/appointment-tabs.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-tabs.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { renderWithSwr, waitForLoadingToFinish } from '../../../../tools/test-helpers';
@@ -21,17 +21,14 @@ describe('AppointmentTabs', () => {
     await waitForLoadingToFinish();
 
     const scheduledAppointmentsTab = screen.getByRole('tab', { name: /^scheduled$/i });
-    const completedAppointmentsTab = screen.getByRole('tab', { name: /completed/i });
     const unsheduledAppointment = screen.getByRole('tab', { name: /^unscheduled$/i });
     const pendingAppointments = screen.getByRole('tab', { name: /^unscheduled$/i });
 
     expect(scheduledAppointmentsTab).toBeInTheDocument();
-    expect(completedAppointmentsTab).toBeInTheDocument();
     expect(unsheduledAppointment).toBeInTheDocument();
     expect(pendingAppointments).toBeInTheDocument();
 
     expect(scheduledAppointmentsTab).toHaveAttribute('aria-selected', 'true');
-    expect(completedAppointmentsTab).toHaveAttribute('aria-selected', 'false');
     expect(unsheduledAppointment).toHaveAttribute('aria-selected', 'false');
     expect(pendingAppointments).toHaveAttribute('aria-selected', 'false');
 
@@ -52,11 +49,6 @@ describe('AppointmentTabs', () => {
     expectedTableRows.forEach((row) => {
       expect(screen.getByRole('row', { name: new RegExp(row, 'i') })).toBeInTheDocument();
     });
-
-    await waitFor(() => user.click(completedAppointmentsTab));
-
-    expect(scheduledAppointmentsTab).toHaveAttribute('aria-selected', 'false');
-    expect(completedAppointmentsTab).toHaveAttribute('aria-selected', 'true');
   });
 });
 

--- a/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ContentSwitcher, Switch } from '@carbon/react';
-import {
-  useAppointmentList,
-  useCompletedAppointmentList,
-  useEarlyAppointmentList,
-} from '../../hooks/useAppointmentList';
+import { useAppointmentList, useEarlyAppointmentList } from '../../hooks/useAppointmentList';
 import { useAppointmentDate } from '../../helpers';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
@@ -36,7 +32,6 @@ const ScheduledAppointments: React.FC<ScheduledAppointmentsProps> = ({ visits, a
     currentAppointmentDate,
     patientIdentifierType,
   );
-  const { completedAppointments } = useCompletedAppointmentList(currentAppointmentDate, patientIdentifierType);
   const isDateInPast = dayjs(currentAppointmentDate).isBefore(dayjs(), 'date');
   const isDateInFuture = dayjs(currentAppointmentDate).isAfter(dayjs(), 'date');
   const isToday = dayjs(currentAppointmentDate).isSame(dayjs(), 'date');
@@ -94,13 +89,6 @@ const ScheduledAppointments: React.FC<ScheduledAppointmentsProps> = ({ visits, a
       visits,
       scheduleType,
     },
-    Completed: {
-      appointments: completedAppointments,
-      isLoading,
-      tableHeading: t('completed', 'Completed'),
-      visits,
-      scheduleType,
-    },
   };
 
   const currentConfig = appointmentsBaseTableConfig[scheduleType];
@@ -112,7 +100,6 @@ const ScheduledAppointments: React.FC<ScheduledAppointmentsProps> = ({ visits, a
           <Switch name={'Scheduled'} text={t('scheduled', 'Scheduled')} />
           <Switch name={'Honoured'} text={t('honored', 'Honored')} />
           <Switch name={'Pending'} text={t('notArrived', 'Not arrived')} />
-          <Switch name={'Completed'} text={t('completed', 'Completed')} />
           <Switch name={'CameEarly'} text={t('cameEarly', 'Came early')} />
         </ContentSwitcher>
       )}
@@ -120,7 +107,6 @@ const ScheduledAppointments: React.FC<ScheduledAppointmentsProps> = ({ visits, a
         <ContentSwitcher className={styles.switcher} size="sm" onChange={({ name }) => setScheduleType(name)}>
           <Switch name={'Scheduled'} text={t('scheduled', 'Scheduled')} />
           <Switch name={'Honoured'} text={t('honored', 'Honored')} />
-          <Switch name={'Completed'} text={t('completed', 'Completed')} />
           <Switch name={'Pending'} text={t('missed', 'Missed')} />
         </ContentSwitcher>
       )}

--- a/packages/esm-appointments-app/src/hooks/useAppointmentList.tsx
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentList.tsx
@@ -47,18 +47,6 @@ export const useEarlyAppointmentList = (startDate?: string, identifierType?: str
   return { earlyAppointmentList: (appointments as Array<any>) ?? [], isLoading, error };
 };
 
-export const useCompletedAppointmentList = (startDate?: string, identifierType?: string) => {
-  const { currentAppointmentDate } = useAppointmentDate();
-  const forDate = startDate ? startDate : currentAppointmentDate;
-  const url = `/ws/rest/v1/appointment/completedAppointment?forDate=${forDate}`;
-
-  const { data, error, isLoading } = useSWR<{ data: Array<AppointmentPatientList> }>(url, openmrsFetch, {
-    errorRetryCount: 2,
-  });
-  const appointments = data?.data?.map((appointment) => toAppointmentObject(appointment, identifierType));
-  return { completedAppointments: (appointments as Array<any>) ?? [], isLoading, error };
-};
-
 function toAppointmentObject(appointment: AppointmentPatientList, identifierType: string) {
   const patientIdentifier = appointment.patient.identifiers.find(
     (identifier) => identifier.identifierName === identifierType,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Remove deprecated completed appointment tab, does not serve the intended purpose

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
