### PR TITLE
(refactor) Update fetching visit queue entry number from config to uuid in queues

### DIFF
--- a/packages/esm-service-queues-app/src/active-visits/active-visits-tab.test.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-tab.test.tsx
@@ -5,9 +5,7 @@ import ActiveVisitsTabs from './active-visits-tab.component';
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   useConfig: jest.fn(() => ({
-    concepts: {
-      visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
-    },
+    visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
   })),
 }));
 

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.resource.ts
@@ -190,9 +190,7 @@ export function useVisitQueueEntries(currServiceName: string, locationUuid: stri
   const { queueLocations } = useQueueLocations();
   const queueLocationUuid = locationUuid ? locationUuid : queueLocations[0]?.id;
   const config = useConfig();
-  const {
-    concepts: { visitQueueNumberAttributeUuid },
-  } = config;
+  const { visitQueueNumberAttributeUuid } = config;
 
   const apiUrl = `/ws/rest/v1/visit-queue-entry?location=${queueLocationUuid}&v=full`;
   const { t } = useTranslation();

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.test.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.test.tsx
@@ -73,8 +73,8 @@ describe('ActiveVisitsTable: ', () => {
         concepts: {
           priorityConceptSetUuid: '96105db1-abbf-48d2-8a52-a1d561fd8c90',
           serviceConceptSetUuid: '330c0ec6-0ac7-4b86-9c70-29d76f0ae20a',
-          visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
         },
+        visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
         showQueueTableTab: false,
       } as ConfigObject);
   });

--- a/packages/esm-service-queues-app/src/add-patient-toqueue/add-patient-toqueue-dialog.component.tsx
+++ b/packages/esm-service-queues-app/src/add-patient-toqueue/add-patient-toqueue-dialog.component.tsx
@@ -65,7 +65,7 @@ const AddVisitToQueue: React.FC<AddVisitToQueueDialogProps> = ({ visitDetails, c
     const emergencyPriorityConceptUuid = config.concepts.emergencyPriorityConceptUuid;
     const sortWeight = priority === emergencyPriorityConceptUuid ? 1.0 : 0.0;
     const status = config.concepts.defaultStatusConceptUuid;
-    const visitQueueNumberAttributeUuid = config.concepts.visitQueueNumberAttributeUuid;
+    const visitQueueNumberAttributeUuid = config.visitQueueNumberAttributeUuid;
 
     addQueueEntry(
       visitUuid,
@@ -104,7 +104,7 @@ const AddVisitToQueue: React.FC<AddVisitToQueueDialogProps> = ({ visitDetails, c
     priority,
     config.concepts.emergencyPriorityConceptUuid,
     config.concepts.defaultStatusConceptUuid,
-    config.concepts.visitQueueNumberAttributeUuid,
+    config.visitQueueNumberAttributeUuid,
     visitUuid,
     patientUuid,
     selectedQueueLocation,

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.test.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.test.tsx
@@ -60,9 +60,7 @@ jest.mock('../active-visits/active-visits-table.resource.ts', () => {
 describe('Clinic metrics', () => {
   it('renders a dashboard outlining metrics from the outpatient clinic', async () => {
     mockedUseConfig.mockReturnValue({
-      concepts: {
-        visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
-      },
+      visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
     });
 
     mockedOpenmrsFetch.mockReturnValue({ data: mockMetrics });

--- a/packages/esm-service-queues-app/src/patient-search/patient-scheduled-visits.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/patient-scheduled-visits.component.tsx
@@ -83,7 +83,7 @@ const ScheduledVisits: React.FC<{
   const allVisitTypes = useVisitTypes();
   const { currentVisit } = useVisit(patientUuid);
   const config = useConfig() as ConfigObject;
-  const visitQueueNumberAttributeUuid = config.concepts.visitQueueNumberAttributeUuid;
+  const visitQueueNumberAttributeUuid = config.visitQueueNumberAttributeUuid;
   const { queueLocations } = useQueueLocations();
   const [selectedQueueLocation, setSelectedQueueLocation] = useState(queueLocations[0]?.id);
 

--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.test.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.test.tsx
@@ -9,9 +9,9 @@ jest.mock('@openmrs/esm-framework', () => ({
   showToast: jest.fn(),
   useConfig: jest.fn(() => ({
     concepts: {
-      visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
       defaultStatusConceptUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
     },
+    visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
   })),
 }));
 jest.mock('../hooks/useQueueLocations', () => ({

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
@@ -74,7 +74,7 @@ const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchTyp
   const { activePatientEnrollment, isLoading } = useActivePatientEnrollment(patientUuid);
   const [enrollment, setEnrollment] = useState<PatientProgram>(activePatientEnrollment[0]);
   const { mutate } = useVisitQueueEntries('', '');
-  const visitQueueNumberAttributeUuid = config.concepts.visitQueueNumberAttributeUuid;
+  const visitQueueNumberAttributeUuid = config.visitQueueNumberAttributeUuid;
   const [selectedLocation, setSelectedLocation] = useState('');
   const [visitType, setVisitType] = useState('');
 

--- a/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.test.tsx
+++ b/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.test.tsx
@@ -7,9 +7,7 @@ jest.mock('@openmrs/esm-framework', () => ({
   voidQueueEntry: jest.fn(),
   showNotification: jest.fn(),
   useConfig: jest.fn(() => ({
-    concepts: {
-      visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
-    },
+    visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
   })),
 }));
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
-Update fetching visit queue entry number from config to uuid in queues
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
https://www.loom.com/share/7abefcf405d94dbc9b49784d4dd45169?sid=adc3d38a-eca8-48d8-9153-2385366a9c30

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
