### PR TITLE
(enhc) Update obs fields to include `required` attribute for validation

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/obs/obs-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/obs/obs-field.component.tsx
@@ -36,16 +36,24 @@ export function ObsField({ fieldDefinition }: ObsFieldProps) {
           concept={concept}
           validationRegex={fieldDefinition.validation.matches}
           label={fieldDefinition.label}
+          required={fieldDefinition.validation.required}
         />
       );
     case 'Numeric':
-      return <NumericObsField concept={concept} label={fieldDefinition.label} />;
+      return (
+        <NumericObsField
+          concept={concept}
+          label={fieldDefinition.label}
+          required={fieldDefinition.validation.required}
+        />
+      );
     case 'Coded':
       return (
         <CodedObsField
           concept={concept}
           answerConceptSetUuid={fieldDefinition.answerConceptSetUuid}
           label={fieldDefinition.label}
+          required={fieldDefinition.validation.required}
         />
       );
     default:
@@ -61,9 +69,10 @@ interface TextObsFieldProps {
   concept: ConceptResponse;
   validationRegex: string;
   label: string;
+  required?: boolean;
 }
 
-function TextObsField({ concept, validationRegex, label }: TextObsFieldProps) {
+function TextObsField({ concept, validationRegex, label, required }: TextObsFieldProps) {
   const { t } = useTranslation();
 
   const validateInput = (value: string) => {
@@ -87,6 +96,7 @@ function TextObsField({ concept, validationRegex, label }: TextObsFieldProps) {
             <Input
               id={fieldName}
               labelText={label ?? concept.display}
+              required={required}
               invalid={errors[fieldName] && touched[fieldName]}
               {...field}
             />
@@ -100,9 +110,10 @@ function TextObsField({ concept, validationRegex, label }: TextObsFieldProps) {
 interface NumericObsFieldProps {
   concept: ConceptResponse;
   label: string;
+  required?: boolean;
 }
 
-function NumericObsField({ concept, label }: NumericObsFieldProps) {
+function NumericObsField({ concept, label, required }: NumericObsFieldProps) {
   const { t } = useTranslation();
 
   const fieldName = `obs.${concept.uuid}`;
@@ -115,6 +126,7 @@ function NumericObsField({ concept, label }: NumericObsFieldProps) {
             <Input
               id={fieldName}
               labelText={label ?? concept.display}
+              required={required}
               invalid={errors[fieldName] && touched[fieldName]}
               type="number"
               {...field}
@@ -130,9 +142,10 @@ interface CodedObsFieldProps {
   concept: ConceptResponse;
   answerConceptSetUuid?: string;
   label?: string;
+  required?: boolean;
 }
 
-function CodedObsField({ concept, answerConceptSetUuid, label }: CodedObsFieldProps) {
+function CodedObsField({ concept, answerConceptSetUuid, label, required }: CodedObsFieldProps) {
   const config = useConfig() as RegistrationConfig;
   const { data: conceptAnswers, isLoading: isLoadingConceptAnswers } = useConceptAnswers(
     answerConceptSetUuid ?? concept.uuid,
@@ -152,6 +165,7 @@ function CodedObsField({ concept, answerConceptSetUuid, label }: CodedObsFieldPr
                   <Select
                     id={fieldName}
                     name={fieldName}
+                    required={required}
                     labelText={label ?? concept?.display}
                     invalid={errors[fieldName] && touched[fieldName]}
                     {...field}>
@@ -169,6 +183,7 @@ function CodedObsField({ concept, answerConceptSetUuid, label }: CodedObsFieldPr
                   id={fieldName}
                   name={fieldName}
                   labelText={label ?? concept?.display}
+                  required={required}
                   invalid={errors[fieldName] && touched[fieldName]}
                   {...field}>
                   <SelectItem key={`no-answer-select-item-${fieldName}`} value={''} text="" />


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR updates obs field to have `required` attribute to enable validation.


## Screenshots

![Kapture 2023-10-04 at 16 58 27](https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/e201473e-b4c7-4949-9dfc-799c2d42a507)



## Related Issue

https://thepalladiumgroup.atlassian.net/browse/KHP3-4323


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
