### PR TITLE
(fix) Fix address hierarchy drop down styles

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/input/combo-input/combo-input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/combo-input/combo-input.component.tsx
@@ -94,27 +94,29 @@ const ComboInput: React.FC<ComboInputProps> = ({ entries, fieldProps, handleInpu
       </Layer>
       <div className={styles.comboInputEntries}>
         {showEntries && (
-          <div id="downshift-1-menu" className="cds--list-box__menu" role="listbox">
-            {filteredEntries.map((entry, indx) => (
-              <div
-                key={indx}
-                id="downshift-1-item-0"
-                role="option"
-                className={`cds--list-box__menu-item ${
-                  indx === highlightedEntry && 'cds--list-box__menu-item--highlighted'
-                }`}
-                tabIndex={-1}
-                aria-selected="true"
-                onClick={() => handleOptionClick(entry)}>
+          <div className="cds--combo-box cds--list-box cds--list-box--expanded">
+            <div id="downshift-1-menu" className="cds--list-box__menu" role="listbox">
+              {filteredEntries.map((entry, indx) => (
                 <div
-                  className={`cds--list-box__menu-item__option ${styles.comboInputItemOption} ${
-                    entry === value && 'cds--list-box__menu-item--active'
-                  }`}>
-                  {entry}
-                  {entry === value && <SelectionTick />}
+                  key={indx}
+                  id="downshift-1-item-0"
+                  role="option"
+                  className={`cds--list-box__menu-item ${
+                    indx === highlightedEntry && 'cds--list-box__menu-item--highlighted'
+                  }`}
+                  tabIndex={-1}
+                  aria-selected="true"
+                  onClick={() => handleOptionClick(entry)}>
+                  <div
+                    className={`cds--list-box__menu-item__option ${styles.comboInputItemOption} ${
+                      entry === value && 'cds--list-box__menu-item--active'
+                    }`}>
+                    {entry}
+                    {entry === value && <SelectionTick />}
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes address hierarchy drop-down styles. This is as a result of carbon  version upgrade.

## Screenshots

![Screenshot from 2023-10-17 00-40-18](https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/cb251800-88bd-42ff-a212-f32fcd859b85)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
