### PR TITLE
O3-2464 Service Queue - Checked in patients shows incorrect value on …

### DIFF
--- a/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.resource.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.resource.tsx
@@ -21,12 +21,19 @@ export function useActiveVisits() {
     openmrsFetch,
   );
 
-  const activeVisitsCount = data?.data?.results.length
-    ? data.data.results.filter((visit) => dayjs(visit.startDatetime).isToday())?.length
-    : 0;
+  // Create a Set to store unique patient UUIDs
+  const uniquePatientUUIDs = new Set();
+
+  data?.data?.results.forEach((visit) => {
+    const patientUUID = visit.patient?.uuid;
+    const isToday = dayjs(visit.startDatetime).isToday();
+    if (patientUUID && isToday) {
+      uniquePatientUUIDs.add(patientUUID);
+    }
+  });
 
   return {
-    activeVisitsCount: activeVisitsCount,
+    activeVisitsCount: uniquePatientUUIDs.size,
     isLoading,
     isError: error,
     isValidating,


### PR DESCRIPTION
…home page

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
"Checked in patients" metric should further reduce the response from the visits endpoint to the total number of distinct patients, not just the number of active visits.

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="777" alt="ms" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/19533785/64b50fc5-cca5-4942-ae7f-520faa45c2c7">

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
