### PR TITLE
(fix) Various UI fixes for the active visits app

### DIFF
--- a/packages/esm-active-visits-app/src/visits-summary/visit-detail-overview.scss
+++ b/packages/esm-active-visits-app/src/visits-summary/visit-detail-overview.scss
@@ -26,7 +26,6 @@
 .visitsDetailHeaderContainer {
   display: flex;
   justify-content: space-between;
-  align-items: center;
   padding: spacing.$spacing-04 0 spacing.$spacing-04 spacing.$spacing-05;
   background-color: $ui-background;
 }
@@ -39,16 +38,26 @@
   border-bottom: 0.375rem solid $brand-teal-01;
 }
 
-.contentSwitcher :global(.cds--content-switcher-btn) {
-  width: 10rem;
+.customTable {
+  th {
+    padding: 0 !important;
+  }
+
+  tr[data-parent-row]:nth-child(odd) td {
+    background-color: $ui-02;
+  }
+
+  tbody tr[data-parent-row]:nth-child(even) td {
+    background-color: $ui-01;
+  }
 }
 
-.customTable tr[data-parent-row]:nth-child(odd) td {
-  background-color: $ui-02;
-}
-
-.customTable tbody tr[data-parent-row]:nth-child(even) td {
-  background-color: $ui-01;
+.visitEmptyState {
+  text-align: center;
+  background-color: white;
+  padding: 2rem;
+  border: 1px solid $ui-03;
+  width: 100%;
 }
 
 .encounterEmptyState {
@@ -112,6 +121,7 @@
 .tab {
   outline: 0;
   outline-offset: 0;
+  min-height: spacing.$spacing-07;
 
   &:active,
   &:focus {
@@ -172,6 +182,21 @@
 .testSummaryExtension p {
   @include type.type-style('body-01');
   color: #525252;
+}
+
+.actions {
+  margin: 0 1rem;
+}
+
+.contentSwitcher {
+  // TODO: Remove once override gets added to styleguide
+  :global(.cds--content-switcher-btn) {
+    min-width: fit-content;
+  }
+
+  :global(.cds--content-switcher__label) {
+    height: spacing.$spacing-05;
+  }
 }
 
 // Overriding styles for RTL support

--- a/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
+++ b/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
@@ -43,7 +43,7 @@ const VisitDetailComponent: React.FC<VisitDetailComponentProps> = ({ visitUuid, 
             <br />
             <p className={`${styles.bodyLong01} ${styles.text02}`}>{formatDatetime(parseDate(visit?.startDatetime))}</p>
           </h4>
-          <div style={{ margin: '0 1rem' }}>
+          <div className={styles.actions}>
             <ContentSwitcher
               className={styles.contentSwitcher}
               selectedIndex={contentSwitcherIndex}
@@ -60,7 +60,14 @@ const VisitDetailComponent: React.FC<VisitDetailComponentProps> = ({ visitUuid, 
       </div>
     );
   } else {
-    return null;
+    return (
+      <div className={styles.visitEmptyState}>
+        <h4 className={styles.productiveHeading02}>{t('noVisitsFound', 'No visits found')}</h4>
+        <p className={`${styles.bodyLong01} ${styles.text02}`}>
+          {t('thereIsNoInformationToDisplayHere', 'There is no information to display here')}
+        </p>
+      </div>
+    );
   }
 };
 

--- a/packages/esm-active-visits-app/src/visits-summary/visits-components/encounter-list.component.tsx
+++ b/packages/esm-active-visits-app/src/visits-summary/visits-components/encounter-list.component.tsx
@@ -63,12 +63,12 @@ const EncounterListDataTable: React.FC<EncounterListProps> = ({ encounters, visi
     return () => window.removeEventListener('resize', handler);
   }, []);
 
-  return encounters.length !== 0 ? (
-    <DataTable rows={encounters} headers={headerData} size={!isDesktop(layout) ? 'md' : 'sm'}>
+  return encounters.length > 0 ? (
+    <DataTable rows={encounters} headers={headerData}>
       {({ rows, headers, getHeaderProps, getRowProps, getTableProps }) => {
         return (
           <TableContainer data-testid="encountersTable">
-            <Table className={styles.customTable} {...getTableProps()}>
+            <Table className={styles.customTable} {...getTableProps()} size={isDesktop(layout) ? 'sm' : 'md'}>
               <TableHead>
                 <TableRow>
                   <TableExpandHeader />

--- a/packages/esm-active-visits-app/translations/am.json
+++ b/packages/esm-active-visits-app/translations/am.json
@@ -18,6 +18,7 @@
   "noNotesFound": "No notes found",
   "noObservationsFound": "No observations found",
   "notes": "Notes",
+  "noVisitsFound": "No visits found",
   "noVisitsToDisplay": "No visits to display",
   "orderDurationAndUnit": "for {duration} {durationUnit}",
   "orderIndefiniteDuration": "Indefinite duration",

--- a/packages/esm-active-visits-app/translations/ar.json
+++ b/packages/esm-active-visits-app/translations/ar.json
@@ -18,6 +18,7 @@
   "noNotesFound": "لم يتم العثور على ملاحظات",
   "noObservationsFound": "لم يتم العثور على ملاحظات",
   "notes": "الملاحظات",
+  "noVisitsFound": "No visits found",
   "noVisitsToDisplay": "لا زيارات للعرض",
   "orderDurationAndUnit": "لمدة {duration} {durationUnit}",
   "orderIndefiniteDuration": "مدة غير محددة",

--- a/packages/esm-active-visits-app/translations/en.json
+++ b/packages/esm-active-visits-app/translations/en.json
@@ -18,6 +18,7 @@
   "noNotesFound": "No notes found",
   "noObservationsFound": "No observations found",
   "notes": "Notes",
+  "noVisitsFound": "No visits found",
   "noVisitsToDisplay": "No visits to display",
   "orderDurationAndUnit": "for {duration} {durationUnit}",
   "orderIndefiniteDuration": "Indefinite duration",

--- a/packages/esm-active-visits-app/translations/es.json
+++ b/packages/esm-active-visits-app/translations/es.json
@@ -18,6 +18,7 @@
   "noNotesFound": "No se encontraron notas",
   "noObservationsFound": "No se encontraron observaciones",
   "notes": "Notas",
+  "noVisitsFound": "No visits found",
   "noVisitsToDisplay": "No hay visitas para mostrar",
   "orderDurationAndUnit": "para {duración} {duraciónUnidad}",
   "orderIndefiniteDuration": "Duración indefinida",

--- a/packages/esm-active-visits-app/translations/fr.json
+++ b/packages/esm-active-visits-app/translations/fr.json
@@ -18,6 +18,7 @@
   "noNotesFound": "Aucune information complémentaire",
   "noObservationsFound": "Aucune observation trouvée",
   "notes": "Informations complémentaires",
+  "noVisitsFound": "No visits found",
   "noVisitsToDisplay": "No visits to display",
   "orderDurationAndUnit": "Pour {duration} {durationUnit}",
   "orderIndefiniteDuration": "Durée illimitée",

--- a/packages/esm-active-visits-app/translations/he.json
+++ b/packages/esm-active-visits-app/translations/he.json
@@ -18,6 +18,7 @@
   "noNotesFound": "לא נמצאו הערות",
   "noObservationsFound": "לא נמצאו תצפיות",
   "notes": "הערות",
+  "noVisitsFound": "No visits found",
   "noVisitsToDisplay": "No visits to display",
   "orderDurationAndUnit": "למשך {duration} {durationUnit}",
   "orderIndefiniteDuration": "למשך זמן בלתי מוגבל",

--- a/packages/esm-active-visits-app/translations/km.json
+++ b/packages/esm-active-visits-app/translations/km.json
@@ -18,6 +18,7 @@
   "noNotesFound": "រកមិនឃើញការកត់ចំណាំទេ",
   "noObservationsFound": "រកមិនឃើញការសង្កេតទេ",
   "notes": "កំណត់ចំណាំ",
+  "noVisitsFound": "No visits found",
   "noVisitsToDisplay": "No visits to display",
   "orderDurationAndUnit": "សម្រាប់ {រយៈពេល} {ឯកតារយៈពេល}",
   "orderIndefiniteDuration": "រយៈពេលមិនកំណត់",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

I've provided various fixes to the active visits app in this PR, including:

- Ensuring that content in the `ContentSwitcher` component doesn't get truncated at smaller viewport sizes by setting its `min-width` property to `fit-content`. Ultimately, that bit of code should get added to the styleguide.
- Fixing the size of the table header in the `EncounterList` data table.
- Adding an empty state that gets displayed when there's no visit data to display. 

## Screenshots

> Before

![CleanShot 2023-10-21 at 8  06 27@2x](https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/097be3aa-8d1a-4192-97f3-e84e21f99586)

> After 

https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/530a4c3c-7178-4f1e-a350-996c26280611

## Related Issue

*None.*

## Other

*None.*
