### PR TITLE
(feat) Allow person searching by patient identifier when defining relationships

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships-section.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships-section.component.tsx
@@ -65,8 +65,7 @@ const RelationshipView: React.FC<RelationshipViewProps> = ({
 
   const searchPerson = async (query: string) => {
     const abortController = new AbortController();
-    const searchResults = await fetchPerson(query);
-    return searchResults.data.results;
+    return await fetchPerson(query, abortController);
   };
 
   const deleteRelationship = useCallback(() => {


### PR DESCRIPTION
## Summary
This PR introduces the capability to search for individuals based on patient attributes, such as the patient ID, when defining relationships within the patient registration page.
This is accomplished by first querying the patient's endpoint and then merging the results with the persons endpoint, instead of solely querying the persons endpoint. This enhancement enables the search function for patient attributes that are not originally available in the persons' endpoint.