### PR TITLE
(fix) 03-2455: Show delete confirmation modal upon deleting a patient list

### DIFF
--- a/e2e/pages/patient-lists-page.ts
+++ b/e2e/pages/patient-lists-page.ts
@@ -33,6 +33,6 @@ export class PatientListsPage {
 
   async deletePatientList() {
     await this.page.getByRole('button', { name: 'Actions' }).click();
-    await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+    await this.page.getByRole('menuitem', { name: 'Delete patient list' }).click();
   }
 }

--- a/e2e/pages/patient-lists-page.ts
+++ b/e2e/pages/patient-lists-page.ts
@@ -21,7 +21,7 @@ export class PatientListsPage {
 
   async editPatientList(listName: string, description: string) {
     await this.page.getByRole('button', { name: 'Actions' }).click();
-    await this.page.getByRole('menuitem', { name: 'Edit Name/ Description' }).click();
+    await this.page.getByRole('menuitem', { name: 'Edit Name or Description' }).click();
     await this.page.getByLabel('List name').fill(listName);
     await this.page.getByLabel('Describe the purpose of this list in a few words').fill(description);
     await this.page.getByRole('button', { name: 'Edit list' }).click();

--- a/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.component.tsx
@@ -128,12 +128,13 @@ const PatientListDetailComponent = () => {
               </>
             }>
             <OverflowMenuItem
+              className={styles.menuItem}
               itemText={t('editNameDescription', 'Edit Name or Description')}
               onClick={() => setEditPatientListDetailOverlay(true)}
             />
             <OverflowMenuItem
               className={styles.menuItem}
-              itemText={t('deletePatientList', 'Delete patient List')}
+              itemText={t('deletePatientList', 'Delete patient list')}
               onClick={handleDelete}
               isDelete
             />
@@ -180,7 +181,7 @@ const PatientListDetailComponent = () => {
             danger
             modalHeading={t(
               'confirmDeletePatientList',
-              'Are you sure you want to delete the patient list: {patientListName}?',
+              'Are you sure you want to delete {patientListName} patient list?',
               {
                 patientListName: patientListDetails?.name,
               },

--- a/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.component.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { navigate, formatDate, parseDate, showToast } from '@openmrs/esm-framework';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { OverflowMenuItem } from '@carbon/react';
+import { OverflowMenuItem, Modal } from '@carbon/react';
 import { OverflowMenuVertical } from '@carbon/react/icons';
 import CustomOverflowMenuComponent from '../overflow-menu/overflow-menu.component';
 import EditPatientListDetailsOverlay from '../create-edit-patient-list/create-edit-list.component';
@@ -34,6 +34,7 @@ const PatientListDetailComponent = () => {
     currentPageSize,
   );
   const [showEditPatientListDetailOverlay, setEditPatientListDetailOverlay] = useState(false);
+  const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] = useState(false);
 
   const patients: PatientListMemberRow[] = useMemo(
     () =>
@@ -83,6 +84,10 @@ const PatientListDetailComponent = () => {
   }, []);
 
   const handleDelete = useCallback(() => {
+    setShowDeleteConfirmationModal(true);
+  }, []);
+
+  const confirmDeletePatientList = useCallback(() => {
     deletePatientList(patientListUuid)
       .then(() =>
         showToast({
@@ -98,7 +103,8 @@ const PatientListDetailComponent = () => {
           description: t('errorDeleteList', "Couldn't delete patient list"),
           kind: 'error',
         }),
-      );
+      )
+      .finally(() => setShowDeleteConfirmationModal(false));
   }, [patientListUuid, patientListDetails, t]);
 
   return (
@@ -122,10 +128,15 @@ const PatientListDetailComponent = () => {
               </>
             }>
             <OverflowMenuItem
-              itemText={t('editNameDescription', 'Edit Name/ Description')}
+              itemText={t('editNameDescription', 'Edit Name or Description')}
               onClick={() => setEditPatientListDetailOverlay(true)}
             />
-            <OverflowMenuItem itemText={t('delete', 'Delete')} onClick={handleDelete} isDelete />
+            <OverflowMenuItem
+              className={styles.menuItem}
+              itemText={t('deletePatientList', 'Delete patient List')}
+              onClick={handleDelete}
+              isDelete
+            />
           </CustomOverflowMenuComponent>
         </div>
       </section>
@@ -162,6 +173,29 @@ const PatientListDetailComponent = () => {
             patientListDetails={patientListDetails}
             onSuccess={mutatePatientListDetails}
           />
+        )}
+        {showDeleteConfirmationModal && (
+          <Modal
+            open
+            danger
+            modalHeading={t(
+              'confirmDeletePatientList',
+              'Are you sure you want to delete the patient list: {patientListName}?',
+              {
+                patientListName: patientListDetails?.name,
+              },
+            )}
+            primaryButtonText="Delete"
+            secondaryButtonText="Cancel"
+            onRequestClose={() => setShowDeleteConfirmationModal(false)}
+            onRequestSubmit={confirmDeletePatientList}
+            primaryButtonDisabled={false}>
+            {patientListDetails?.size > 0 ? (
+              <p>{`This list has ${patientListDetails.size} patients.`}</p>
+            ) : (
+              <p>This list has no patients.</p>
+            )}
+          </Modal>
         )}
       </section>
     </main>

--- a/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.component.tsx
@@ -179,13 +179,7 @@ const PatientListDetailComponent = () => {
           <Modal
             open
             danger
-            modalHeading={t(
-              'confirmDeletePatientList',
-              'Are you sure you want to delete {patientListName} patient list?',
-              {
-                patientListName: patientListDetails?.name,
-              },
-            )}
+            modalHeading={t('confirmDeletePatientList', 'Are you sure you want to delete this patient list?')}
             primaryButtonText="Delete"
             secondaryButtonText="Cancel"
             onRequestClose={() => setShowDeleteConfirmationModal(false)}

--- a/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.scss
+++ b/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.scss
@@ -2,6 +2,10 @@
 @use '@carbon/styles/scss/type';
 @import '../style.scss';
 
+.menuItem {
+  max-width: none;
+}
+
 .container {
   display: flex;
   flex-direction: column;

--- a/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.scss
+++ b/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.scss
@@ -2,10 +2,6 @@
 @use '@carbon/styles/scss/type';
 @import '../style.scss';
 
-.menuItem {
-  max-width: none;
-}
-
 .container {
   display: flex;
   flex-direction: column;
@@ -29,6 +25,10 @@
 
 .marginTop {
   margin-top: spacing.$spacing-03;
+}
+
+.menuItem {
+  max-width: none;
 }
 
 .actionsButtonText {

--- a/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.test.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.test.tsx
@@ -82,11 +82,11 @@ describe('PatientListDetailComponent', () => {
     });
   });
 
-  it('opens edit overlay when "Edit Name/ Description" is clicked', () => {
+  it('opens edit overlay when "Edit Name or Description" is clicked', () => {
     render(<PatientListDetailComponent />);
 
     userEvent.click(screen.getByText('Actions'));
-    const editBtn = screen.getByText('Edit Name/ Description');
+    const editBtn = screen.getByText('Edit Name or Description');
     userEvent.click(editBtn);
   });
 
@@ -94,7 +94,19 @@ describe('PatientListDetailComponent', () => {
     render(<PatientListDetailComponent />);
 
     await waitFor(() => {
-      userEvent.click(screen.getByText('Delete'));
+      userEvent.click(screen.getByText('Actions'));
+      userEvent.click(screen.getByText('Delete patient List'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Are you sure you want to delete the patient list')).toBeInTheDocument();
+      expect(screen.getByText(`This list has ${mockedPatientListDetails.size} patients.`)).toBeInTheDocument();
+      expect(screen.getByText('Delete')).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+
+      expect(screen.getByText('Delete').closest('button')).not.toHaveAttribute('disabled');
+
+      userEvent.click(screen.getByText('Cancel'));
     });
 
     await waitFor(() => {

--- a/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.test.tsx
+++ b/packages/esm-patient-list-app/src/patient-list-detail/patient-list-detail.test.tsx
@@ -95,11 +95,11 @@ describe('PatientListDetailComponent', () => {
 
     await waitFor(() => {
       userEvent.click(screen.getByText('Actions'));
-      userEvent.click(screen.getByText('Delete patient List'));
+      userEvent.click(screen.getByText(/delete patient list/i));
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Are you sure you want to delete the patient list')).toBeInTheDocument();
+      expect(screen.getByText('Are you sure you want to delete this patient list?')).toBeInTheDocument();
       expect(screen.getByText(`This list has ${mockedPatientListDetails.size} patients.`)).toBeInTheDocument();
       expect(screen.getByText('Delete')).toBeInTheDocument();
       expect(screen.getByText('Cancel')).toBeInTheDocument();
@@ -110,8 +110,7 @@ describe('PatientListDetailComponent', () => {
     });
 
     await waitFor(() => {
-      expect(mockedDeletePatientList).toHaveBeenCalledTimes(1);
-      expect(showToast).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText('Are you sure you want to delete this patient list?')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/esm-patient-list-app/translations/am.json
+++ b/packages/esm-patient-list-app/translations/am.json
@@ -11,6 +11,7 @@
   "createPatientList": "Create patient list",
   "delete": "Delete",
   "deleted": "Deleted",
+  "deletePatientList": "Delete patient list",
   "deletedPatientList": "Deleted patient list",
   "editList": "Edit list",
   "editNameDescription": "Edit Name or Description",

--- a/packages/esm-patient-list-app/translations/am.json
+++ b/packages/esm-patient-list-app/translations/am.json
@@ -13,7 +13,7 @@
   "deleted": "Deleted",
   "deletedPatientList": "Deleted patient list",
   "editList": "Edit list",
-  "editNameDescription": "Edit Name/ Description",
+  "editNameDescription": "Edit Name or Description",
   "editPatientListHeader": "Edit patient list",
   "emptyStateText": "There are no {listType} patient lists to display",
   "error": "Error",

--- a/packages/esm-patient-list-app/translations/en.json
+++ b/packages/esm-patient-list-app/translations/en.json
@@ -13,7 +13,7 @@
   "deleted": "Deleted",
   "deletedPatientList": "Deleted patient list",
   "editList": "Edit list",
-  "editNameDescription": "Edit name/ description",
+  "editNameDescription": "Edit name or description",
   "editPatientListHeader": "Edit patient list",
   "emptyStateText": "There are no {listType} patient lists to display",
   "error": "Error",

--- a/packages/esm-patient-list-app/translations/en.json
+++ b/packages/esm-patient-list-app/translations/en.json
@@ -11,6 +11,7 @@
   "createPatientList": "Create patient list",
   "delete": "Delete",
   "deleted": "Deleted",
+  "deletePatientList": "Delete patient list",
   "deletedPatientList": "Deleted patient list",
   "editList": "Edit list",
   "editNameDescription": "Edit name or description",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
I added a show delete confirmation modal upon deleting a patient list. To achieve this, I added the showDeleteConfirmationModal state variable to control the visibility of the delete confirmation modal. The handleDelete function sets this state to true, and the modal is displayed when showDeleteConfirmationModal is true. The confirmDeletePatientList function handles the actual deletion and closes the modal when done.

## Screenshots
**Before Making changes**

https://github.com/openmrs/openmrs-esm-patient-management/assets/33891016/c8b1fdba-a00e-4933-895c-31e149ca9e7b

**After making changes**

https://github.com/openmrs/openmrs-esm-patient-management/assets/33891016/177e7d7b-0fec-4c41-bd81-96a4c81a536b






## Related Issues
https://issues.openmrs.org/browse/O3-2455

## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
