### PR TITLE
(fix) Display correct count of search results in the compact patient search

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
@@ -84,7 +84,7 @@ const PatientSearch = React.forwardRef<HTMLDivElement, PatientSearchProps>(
           <div className={styles.searchResults}>
             <p className={styles.resultsText}>
               {t('searchResultsCount', '{{count}} search result', {
-                count: searchResults.length,
+                count: totalResults,
               })}
             </p>
             <PatientSearchResults patients={searchResults} selectPatientAction={selectPatientAction} ref={ref} />


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR fixes the count of search results shown in the compact patient search. Previously, the count shown at the top of the search UI used `searchResults.length` to compute the total count. This was incorrect as only 10 results would be shown at any time until the user scrolled to trigger fetching the next 10 patients. Deriving the count from `totalResults` shows the correct number of matching patients from a search without the need for scrolling through the entire list.

## Screenshots

> Before

![CleanShot 2023-10-28 at 9  54 23@2x](https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/9306327c-6130-430c-81fd-68dda1f8ac44)

> After

![CleanShot 2023-10-28 at 9  54 05@2x](https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/e956640b-83cd-4d5a-9fd2-ff14947cace8)

## Related Issue

*None*

## Other

*None*
