### PR TITLE
(fix) Remove workaround for filtering patient lists

### DIFF
--- a/packages/esm-patient-list-app/src/api/hooks.ts
+++ b/packages/esm-patient-list-app/src/api/hooks.ts
@@ -139,14 +139,8 @@ export function usePatientListMembers(
     openmrsFetch,
   );
 
-  // FIXME: This is a workaround for removing a patient from a list
-  const filterList = (listMembers: Array<OpenmrsCohortMember>) =>
-    listMembers.filter((member) => !member.endDate && !member.voided);
-
-  const filteredListMembers = filterList(data?.data?.results ?? []);
-
   return {
-    listMembers: filteredListMembers,
+    listMembers: data?.data?.results ?? [],
     isLoadingListMembers: isLoading,
     error: error,
     mutateListMembers: mutate,

--- a/packages/esm-patient-list-app/src/patient-table/patient-table.component.tsx
+++ b/packages/esm-patient-list-app/src/patient-table/patient-table.component.tsx
@@ -297,7 +297,7 @@ const PatientTable: React.FC<PatientTableProps> = ({
                   </TableHead>
                   <TableBody>
                     {rows.map((row) => {
-                      const name = patients.find((patient) => patient.identifier === row.id)?.name;
+                      const currentPatient = patients.find((patient) => patient.identifier === row.id);
 
                       return (
                         <TableRow
@@ -317,8 +317,8 @@ const PatientTable: React.FC<PatientTableProps> = ({
                               size={isDesktop(layout) ? 'sm' : 'lg'}
                               tooltipPosition="left"
                               onClick={() => {
-                                setMembershipUuid(row.id);
-                                setPatientName(name);
+                                setMembershipUuid(currentPatient.membershipUuid);
+                                setPatientName(currentPatient.name);
                                 setShowConfirmationModal(true);
                               }}
                             />


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR removes a workaround in the Patient Lists feature code that would filter through the returned lists and remove lists which have truthy `voided` or `endDate` properties. The workaround was necessitated by a potential bug where removing a patient from a list (by setting an `endDate` property) doesn't currently work as expected.

## Screenshots

*None*

## Related Issue

*None*

## Other

*None*
