### PR TITLE
(feat) Revert from using OpenmrsDatePicker component

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
-import { ContentSwitcher, Layer, Switch, TextInput } from '@carbon/react';
+import React, { ChangeEvent, useCallback, useContext } from 'react';
+import { ContentSwitcher, DatePicker, DatePickerInput, Layer, Switch, TextInput } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { useField } from 'formik';
 import { generateFormatting } from '../../date-util';
 import { PatientRegistrationContext } from '../../patient-registration-context';
-import { OpenmrsDatePicker, useConfig } from '@openmrs/esm-framework';
+import { useConfig } from '@openmrs/esm-framework';
 import { RegistrationConfig } from '../../../config-schema';
 import styles from '../field.scss';
 
@@ -35,42 +35,54 @@ export const DobField: React.FC = () => {
   const { format, placeHolder, dateFormat } = generateFormatting(['d', 'm', 'Y'], '/');
   const today = new Date();
 
-  const onToggle = (e) => {
-    setFieldValue('birthdateEstimated', e.name === 'unknown');
-    setFieldValue('birthdate', '');
-    setFieldValue('yearsEstimated', 0);
-    setFieldValue('monthsEstimated', '');
-  };
+  const onToggle = useCallback(
+    (e: { name?: string | number }) => {
+      setFieldValue('birthdateEstimated', e.name === 'unknown');
+      setFieldValue('birthdate', '');
+      setFieldValue('yearsEstimated', 0);
+      setFieldValue('monthsEstimated', '');
+    },
+    [setFieldValue],
+  );
 
-  const onDateChange = (birthdate) => {
-    setFieldValue('birthdate', birthdate);
-  };
+  const onDateChange = useCallback(
+    (birthdate: Date[]) => {
+      setFieldValue('birthdate', birthdate[0]);
+    },
+    [setFieldValue],
+  );
 
-  const onEstimatedYearsChange = (ev) => {
-    const years = +ev.target.value;
+  const onEstimatedYearsChange = useCallback(
+    (ev: ChangeEvent<HTMLInputElement>) => {
+      const years = +ev.target.value;
 
-    if (!isNaN(years) && years < 140 && years >= 0) {
-      setFieldValue('yearsEstimated', years);
-      setFieldValue('birthdate', calcBirthdate(years, monthsEstimateMeta.value, dateOfBirth));
-    }
-  };
+      if (!isNaN(years) && years < 140 && years >= 0) {
+        setFieldValue('yearsEstimated', years);
+        setFieldValue('birthdate', calcBirthdate(years, monthsEstimateMeta.value, dateOfBirth));
+      }
+    },
+    [setFieldValue, dateOfBirth, monthsEstimateMeta.value],
+  );
 
-  const onEstimatedMonthsChange = (e) => {
-    const months = +e.target.value;
+  const onEstimatedMonthsChange = useCallback(
+    (ev: ChangeEvent<HTMLInputElement>) => {
+      const months = +ev.target.value;
 
-    if (!isNaN(months)) {
-      setFieldValue('monthsEstimated', months);
-      setFieldValue('birthdate', calcBirthdate(yearsEstimateMeta.value, months, dateOfBirth));
-    }
-  };
+      if (!isNaN(months)) {
+        setFieldValue('monthsEstimated', months);
+        setFieldValue('birthdate', calcBirthdate(yearsEstimateMeta.value, months, dateOfBirth));
+      }
+    },
+    [setFieldValue, dateOfBirth, yearsEstimateMeta.value],
+  );
 
-  const updateBirthdate = () => {
+  const updateBirthdate = useCallback(() => {
     const months = +monthsEstimateMeta.value % 12;
     const years = +yearsEstimateMeta.value + Math.floor(monthsEstimateMeta.value / 12);
     setFieldValue('yearsEstimated', years);
     setFieldValue('monthsEstimated', months > 0 ? months : '');
     setFieldValue('birthdate', calcBirthdate(years, months, dateOfBirth));
-  };
+  }, [setFieldValue, monthsEstimateMeta, yearsEstimateMeta, dateOfBirth]);
 
   return (
     <div className={styles.halfWidthInDesktopView}>
@@ -89,20 +101,17 @@ export const DobField: React.FC = () => {
       <Layer>
         {!dobUnknown ? (
           <div className={styles.dobField}>
-            <OpenmrsDatePicker
-              id="birthdate"
-              {...birthdate}
-              dateFormat={dateFormat}
-              onChange={onDateChange}
-              maxDate={format(today)}
-              labelText={t('dateOfBirthLabelText', 'Date of Birth')}
-              invalid={!!(birthdateMeta.touched && birthdateMeta.error)}
-              invalidText={birthdateMeta.error && t(birthdateMeta.error)}
-              value={format(birthdate.value)}
-              carbonOptions={{
-                placeholder: placeHolder,
-              }}
-            />
+            <DatePicker dateFormat={dateFormat} datePickerType="single" onChange={onDateChange} maxDate={format(today)}>
+              <DatePickerInput
+                id="birthdate"
+                {...birthdate}
+                placeholder={placeHolder}
+                labelText={t('dateOfBirthLabelText', 'Date of Birth')}
+                invalid={!!(birthdateMeta.touched && birthdateMeta.error)}
+                invalidText={birthdateMeta.error && t(birthdateMeta.error)}
+                value={format(birthdate.value)}
+              />
+            </DatePicker>
           </div>
         ) : (
           <div className={styles.grid}>

--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
@@ -7,8 +7,7 @@ import '@testing-library/jest-dom';
 import { DobField } from './dob.component';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import { initialFormValues } from '../../patient-registration.component';
-import { FormValues } from '../../patient-registration-types';
-import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
+import { type FormValues } from '../../patient-registration.types';
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -22,18 +21,6 @@ jest.mock('@openmrs/esm-framework', () => {
         },
       },
     })),
-    getLocale: jest.fn().mockReturnValue('en'),
-    OpenmrsDatePicker: (datePickerProps) => (
-      <OpenmrsDatePicker
-        id={datePickerProps.id}
-        dateFormat={datePickerProps.dateFormat}
-        onChange={datePickerProps.onChange}
-        maxDate={datePickerProps.maxDate}
-        labelText={datePickerProps.labelText}
-        value={datePickerProps.value}
-        carbonOptions={datePickerProps.carbonOptions}
-      />
-    ),
   };
 });
 

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -11,7 +11,6 @@ import { PatientRegistration } from './patient-registration.component';
 import { RegistrationConfig } from '../config-schema';
 import { mockedAddressTemplate } from './field/address/tests/mocks';
 import { mockPatient } from '../../../../tools/test-helpers';
-import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
 
 const mockedUseConfig = useConfig as jest.Mock;
 const mockedUsePatient = usePatient as jest.Mock;
@@ -59,17 +58,6 @@ jest.mock('@openmrs/esm-framework', () => {
     ...originalModule,
     validator: jest.fn(),
     getLocale: jest.fn().mockReturnValue('en'),
-    OpenmrsDatePicker: (datePickerProps) => (
-      <OpenmrsDatePicker
-        id={datePickerProps.id}
-        dateFormat={datePickerProps.dateFormat}
-        onChange={datePickerProps.onChange}
-        maxDate={datePickerProps.maxDate}
-        labelText={datePickerProps.labelText}
-        value={datePickerProps.value}
-        carbonOptions={datePickerProps.carbonOptions}
-      />
-    ),
   };
 });
 
@@ -360,7 +348,7 @@ describe('patient registration component', () => {
       jest.clearAllMocks();
     });
 
-    fit('edits patient demographics', async () => {
+    it('edits patient demographics', async () => {
       const user = userEvent.setup();
 
       mockedSavePatient.mockResolvedValue({});
@@ -394,7 +382,7 @@ describe('patient registration component', () => {
       expect(givenNameInput.value).toBe('John');
       expect(familyNameInput.value).toBe('Wilson');
       expect(middleNameInput.value).toBeFalsy();
-      expect(dateOfBirthInput.value).toBe('04/04/1972');
+      expect(dateOfBirthInput.value).toBe('4/4/1972');
       expect(genderInput.value).toBe('Male');
 
       // do some edits

--- a/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
@@ -4,8 +4,7 @@ import { Formik, Form } from 'formik';
 import { initialFormValues } from '../../patient-registration.component';
 import { DemographicsSection } from './demographics-section.component';
 import { PatientRegistrationContext } from '../../patient-registration-context';
-import { FormValues } from '../../patient-registration-types';
-import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
+import { FormValues } from '../../patient-registration.types';
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -16,18 +15,6 @@ jest.mock('@openmrs/esm-framework', () => {
     useConfig: jest.fn().mockImplementation(() => ({
       fieldConfigurations: { dateOfBirth: { useEstimatedDateOfBirth: { enabled: true, dayOfMonth: 0, month: 0 } } },
     })),
-    getLocale: jest.fn().mockReturnValue('en'),
-    OpenmrsDatePicker: (datePickerProps) => (
-      <OpenmrsDatePicker
-        id={datePickerProps.id}
-        dateFormat={datePickerProps.dateFormat}
-        onChange={datePickerProps.onChange}
-        maxDate={datePickerProps.maxDate}
-        labelText={datePickerProps.labelText}
-        value={datePickerProps.value}
-        carbonOptions={datePickerProps.carbonOptions}
-      />
-    ),
   };
 });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This basically just reverts #813 so that we can redesign the styleguide component into something workable. For now, we'll just use the default Carbon component.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
