### PR TITLE
(feat) O3-2559 make patient chart link in appointments table configurable

### DIFF
--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
@@ -19,7 +19,7 @@ import {
   TableToolbarSearch,
   Button,
 } from '@carbon/react';
-import { ConfigurableLink, formatDatetime, usePagination, formatDate } from '@openmrs/esm-framework';
+import { ConfigurableLink, formatDatetime, usePagination, formatDate, useConfig } from '@openmrs/esm-framework';
 import startCase from 'lodash-es/startCase';
 import { Download } from '@carbon/react/icons';
 import AppointmentDetails from '../details/appointment-details.component';
@@ -31,6 +31,7 @@ import { MappedAppointment } from '../../types';
 import { getPageSizes, useSearchResults } from '../utils';
 import AppointmentActions from './appointments-actions.component';
 import styles from './appointments-table.scss';
+import { ConfigObject } from '../../config-schema';
 
 interface AppointmentsTableProps {
   appointments: Array<MappedAppointment>;
@@ -53,6 +54,9 @@ const AppointmentsTable: React.FC<AppointmentsTableProps> = ({
   const [searchString, setSearchString] = useState('');
   const searchResults = useSearchResults(appointments, searchString);
   const { results, goTo, currentPage } = usePagination(searchResults, pageSize);
+  const config: ConfigObject = useConfig();
+
+  const { patientChartUrl } = config;
 
   const headerData = [
     {
@@ -79,7 +83,8 @@ const AppointmentsTable: React.FC<AppointmentsTableProps> = ({
     patientName: (
       <ConfigurableLink
         style={{ textDecoration: 'none', maxWidth: '50%' }}
-        to={`\${openmrsSpaBase}/patient/${appointment.patientUuid}/chart`}>
+        to={patientChartUrl}
+        templateParams={{ patientUuid: appointment.patientUuid }}>
         {appointment.name}
       </ConfigurableLink>
     ),

--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.test.tsx
@@ -44,6 +44,9 @@ jest.mock('@openmrs/esm-framework', () => {
   return {
     ...originalModule,
     openmrsFetch: jest.fn(),
+    useConfig: jest.fn(() => ({
+      patientChartUrl: 'someUrl',
+    })),
   };
 });
 

--- a/packages/esm-appointments-app/src/appointments/unscheduled/unscheduled-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/unscheduled/unscheduled-appointments.component.tsx
@@ -18,7 +18,7 @@ import {
   Button,
 } from '@carbon/react';
 import { Download } from '@carbon/react/icons';
-import { ConfigurableLink, usePagination } from '@openmrs/esm-framework';
+import { ConfigObject, ConfigurableLink, useConfig, usePagination } from '@openmrs/esm-framework';
 import { useUnscheduledAppointments } from '../../hooks/useUnscheduledAppointments';
 import { downloadUnscheduledAppointments } from '../../helpers/excel';
 import { EmptyState } from '../../empty-state/empty-state.component';
@@ -31,6 +31,10 @@ const UnscheduledAppointments: React.FC = () => {
   const [searchString, setSearchString] = useState('');
   const { data: unscheduledAppointments, isLoading, error } = useUnscheduledAppointments();
   const searchResults = useSearchResults(unscheduledAppointments, searchString);
+
+  const config: ConfigObject = useConfig();
+  const { patientChartUrl } = config;
+
   const headerData = [
     {
       header: 'Patient Name',
@@ -55,7 +59,7 @@ const UnscheduledAppointments: React.FC = () => {
   const rowData = results?.map((visit) => ({
     id: `${visit.uuid}`,
     name: (
-      <ConfigurableLink style={{ textDecoration: 'none' }} to={`\${openmrsSpaBase}/patient/${visit.uuid}/chart`}>
+      <ConfigurableLink style={{ textDecoration: 'none' }} to={patientChartUrl}>
         {visit.name}
       </ConfigurableLink>
     ),

--- a/packages/esm-appointments-app/src/appointments/unscheduled/unscheduled-appointments.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/unscheduled/unscheduled-appointments.test.tsx
@@ -19,6 +19,9 @@ jest.mock('@openmrs/esm-framework', () => {
   return {
     ...originalModule,
     openmrsFetch: jest.fn(),
+    useConfig: jest.fn(() => ({
+      patientChartUrl: 'someUrl',
+    })),
   };
 });
 

--- a/packages/esm-appointments-app/src/config-schema.ts
+++ b/packages/esm-appointments-app/src/config-schema.ts
@@ -66,6 +66,11 @@ export const configSchema = {
     _default: '/ws/rest/v1/kenyaemr/default-facility',
     _description: 'Custom URL to load default facility if it is not in the session',
   },
+  patientChartUrl: {
+    _type: Type.String,
+    _description: 'Custom URL to the patient chart',
+    _default: '${openmrsSpaBase}/patient/${patientUuid}/chart',
+  },
   patientIdentifierType: {
     _type: Type.String,
     _description: 'The name of the patient identifier type to be used for the patient identifier field',
@@ -87,5 +92,6 @@ export interface ConfigObject {
   hiddenFormFields: Array<string>;
   showServiceQueueFields: boolean;
   defaultFacilityUrl: string;
+  patientChartUrl: string;
   patientIdentifierType: string;
 }

--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.component.tsx
@@ -26,6 +26,7 @@ import {
   usePagination,
   useSession,
   userHasAccess,
+  ConfigObject,
 } from '@openmrs/esm-framework';
 import { ActionsMenu } from './appointment-actions.component';
 import { EmptyDataIllustration } from './empty-data-illustration.component';
@@ -104,6 +105,9 @@ const AppointmentsBaseTable = () => {
 
   const fullView = userHasAccess(fullViewPrivilege, user) || !useFullViewPrivilege;
 
+  const config: ConfigObject = useConfig();
+  const { patientChartUrl } = config;
+
   const filteredAppointments = !fullView
     ? appointments.filter((appointment) => appointment.status === 'Scheduled')
     : appointments;
@@ -173,7 +177,7 @@ const AppointmentsBaseTable = () => {
     name: {
       content: (
         <div className={styles.nameContainer}>
-          <ConfigurableLink to={`\${openmrsSpaBase}/patient/${appointment.patientUuid}/chart`}>
+          <ConfigurableLink to={patientChartUrl} templateParams={{ patientUuid: appointment.patientUuid }}>
             {appointment.name}
           </ConfigurableLink>
         </div>

--- a/packages/esm-appointments-app/src/home-appointments/appointments-list.test.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/appointments-list.test.tsx
@@ -17,6 +17,7 @@ jest.mock('@openmrs/esm-framework', () => ({
     useBahmniAppointmentsUI: false,
     useFullViewPrivilege: false,
     fullViewPrivilege: 'somePrivilege',
+    patientChartUrl: 'someUrl',
   })),
   userHasAccess: jest.fn(() => true),
 }));


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

https://openmrs.atlassian.net/browse/O3-2559

Adds a new configuration to customize the patient chart links in the appointments app, so it can be configured to link to the O2 version.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
