### PR TITLE
(feat)O3-2573: Using Snackbar in service-queue-app

### DIFF
--- a/packages/esm-service-queues-app/src/add-patient-toqueue/add-patient-toqueue-dialog.component.tsx
+++ b/packages/esm-service-queues-app/src/add-patient-toqueue/add-patient-toqueue-dialog.component.tsx
@@ -12,7 +12,7 @@ import {
   RadioButtonGroup,
   RadioButton,
 } from '@carbon/react';
-import { ConfigObject, showNotification, showToast, useConfig } from '@openmrs/esm-framework';
+import { ConfigObject, showSnackbar, useConfig } from '@openmrs/esm-framework';
 import {
   addQueueEntry,
   usePriority,
@@ -79,11 +79,11 @@ const AddVisitToQueue: React.FC<AddVisitToQueueDialogProps> = ({ visitDetails, c
     ).then(
       ({ status }) => {
         if (status === 201) {
-          showToast({
-            critical: true,
+          showSnackbar({
+            isLowContrast: true,
             title: t('addEntry', 'Add entry'),
             kind: 'success',
-            description: t('queueEntryAddedSuccessfully', 'Queue Entry Added Successfully'),
+            subtitle: t('queueEntryAddedSuccessfully', 'Queue Entry Added Successfully'),
           });
           closeModal();
           mutate();
@@ -91,11 +91,11 @@ const AddVisitToQueue: React.FC<AddVisitToQueueDialogProps> = ({ visitDetails, c
         }
       },
       (error) => {
-        showNotification({
+        showSnackbar({
           title: t('queueEntryAddFailed', 'Error adding queue entry status'),
           kind: 'error',
-          critical: true,
-          description: error?.message,
+          isLowContrast: false,
+          subtitle: error?.message,
         });
       },
     );

--- a/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.component.tsx
+++ b/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.component.tsx
@@ -12,7 +12,7 @@ import {
   Checkbox,
   Dropdown,
 } from '@carbon/react';
-import { showNotification, showToast } from '@openmrs/esm-framework';
+import { showSnackbar } from '@openmrs/esm-framework';
 import { useServices, useVisitQueueEntries } from '../active-visits/active-visits-table.resource';
 import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
 import {
@@ -95,11 +95,11 @@ const AddProviderQueueRoom: React.FC<AddProviderQueueRoomProps> = ({ providerUui
       updateProviderToQueueRoom(queueProviderMapUuid, queueRoomUuid, providerUuid).then(
         ({ status }) => {
           if (status === 200) {
-            showToast({
-              critical: true,
+            showSnackbar({
+              isLowContrast: true,
               title: t('updateRoom', 'Update room'),
               kind: 'success',
-              description: t('queueRoomUpdatedSuccessfully', 'Queue room updated successfully'),
+              subtitle: t('queueRoomUpdatedSuccessfully', 'Queue room updated successfully'),
             });
             closeModal();
             localStorage.setItem('lastUpdatedQueueRoomTimestamp', new Date().toString());
@@ -108,11 +108,11 @@ const AddProviderQueueRoom: React.FC<AddProviderQueueRoomProps> = ({ providerUui
           }
         },
         (error) => {
-          showNotification({
+          showSnackbar({
             title: t('queueRoomAddFailed', 'Error adding queue room'),
             kind: 'error',
-            critical: true,
-            description: error?.message,
+            isLowContrast: false,
+            subtitle: error?.message,
           });
           closeModal();
         },
@@ -121,11 +121,11 @@ const AddProviderQueueRoom: React.FC<AddProviderQueueRoomProps> = ({ providerUui
       addProviderToQueueRoom(queueRoomUuid, providerUuid).then(
         ({ status }) => {
           if (status === 201) {
-            showToast({
-              critical: true,
+            showSnackbar({
+              isLowContrast: true,
               title: t('addRoom', 'Add room'),
               kind: 'success',
-              description: t('queueRoomAddedSuccessfully', 'Queue room added successfully'),
+              subtitle: t('queueRoomAddedSuccessfully', 'Queue room added successfully'),
             });
             closeModal();
             localStorage.setItem('lastUpdatedQueueRoomTimestamp', new Date().toString());
@@ -134,11 +134,11 @@ const AddProviderQueueRoom: React.FC<AddProviderQueueRoomProps> = ({ providerUui
           }
         },
         (error) => {
-          showNotification({
+          showSnackbar({
             title: t('queueRoomAddFailed', 'Error adding queue room'),
             kind: 'error',
-            critical: true,
-            description: error?.message,
+            isLowContrast: false,
+            subtitle: error?.message,
           });
         },
       );

--- a/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.test.tsx
+++ b/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.test.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import AddProviderQueueRoom from './add-provider-queue-room.component';
-import { showToast } from '@openmrs/esm-framework';
+import { showSnackbar } from '@openmrs/esm-framework';
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   useCurrentProvider: jest.fn(() => ({
     currentProvider: { uuid: 'provider-uuid-1' },
   })),
-  showToast: jest.fn(),
-  showNotification: jest.fn(),
+  showSnackbar: jest.fn(),
 }));
 jest.mock('./add-provider-queue-room.resource', () => ({
   useProvidersQueueRoom: jest.fn(() => ({
@@ -92,7 +91,7 @@ describe('AddProviderQueueRoom', () => {
 
     await waitFor(() => {
       expect(mockCloseModal).toHaveBeenCalled();
-      expect(showToast).toHaveBeenCalled();
+      expect(showSnackbar).toHaveBeenCalled();
     });
   });
 });

--- a/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.component.tsx
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.component.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './clear-queue-entries-dialog.scss';
 import { Button, ButtonSkeleton, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
-import { showNotification, showToast } from '@openmrs/esm-framework';
+import { showSnackbar } from '@openmrs/esm-framework';
 import { batchClearQueueEntries } from './clear-queue-entries-dialog.resource';
 import { MappedVisitQueueEntry, useVisitQueueEntries } from '../active-visits/active-visits-table.resource';
 
@@ -21,20 +21,20 @@ const ClearQueueEntriesDialog: React.FC<ClearQueueEntriesDialogProps> = ({ visit
     batchClearQueueEntries(visitQueueEntries).then(
       (response) => {
         closeModal();
-        showToast({
-          critical: true,
+        showSnackbar({
+          isLowContrast: true,
           title: t('clearQueue', 'Clear queue'),
           kind: 'success',
-          description: t('queuesClearedSuccessfully', 'Queues cleared successfully'),
+          subtitle: t('queuesClearedSuccessfully', 'Queues cleared successfully'),
         });
         mutate();
       },
       (error) => {
-        showNotification({
+        showSnackbar({
           title: t('errorClearingQueues', 'Error clearing queues'),
           kind: 'error',
-          critical: true,
-          description: error?.message,
+          isLowContrast: false,
+          subtitle: error?.message,
         });
       },
     );

--- a/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.test.tsx
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.test.tsx
@@ -7,7 +7,7 @@ const mockBatchClearQueueEntries = batchClearQueueEntries as jest.Mock;
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
-  showToast: jest.fn(),
+  showSnackbar: jest.fn(),
 }));
 
 jest.mock('./clear-queue-entries-dialog.resource');

--- a/packages/esm-service-queues-app/src/patient-search/patient-scheduled-visits.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/patient-scheduled-visits.component.tsx
@@ -18,8 +18,7 @@ import {
   ErrorState,
   toOmrsIsoString,
   toDateObjectStrict,
-  showNotification,
-  showToast,
+  showSnackbar,
   useSession,
   useLocations,
   NewVisitPayload,
@@ -119,11 +118,11 @@ const ScheduledVisits: React.FC<{
 
       const abortController = new AbortController();
       if (currentVisit) {
-        showNotification({
+        showSnackbar({
           title: t('startVisitError', 'Error starting visit'),
           kind: 'error',
-          critical: true,
-          description: t('patientHasActiveVisit', 'The patient already has an active visit'),
+          isLowContrast: false,
+          subtitle: t('patientHasActiveVisit', 'The patient already has an active visit'),
         });
         setIsSubmitting(false);
       } else {
@@ -146,10 +145,10 @@ const ScheduledVisits: React.FC<{
                 ).then(
                   ({ status }) => {
                     if (status === 201) {
-                      showToast({
+                      showSnackbar({
                         kind: 'success',
                         title: t('startAVisit', 'Start a visit'),
-                        description: t(
+                        subtitle: t(
                           'startVisitQueueSuccessfully',
                           'Patient has been added to active visits list and queue.',
                           `${hours} : ${minutes}`,
@@ -161,11 +160,11 @@ const ScheduledVisits: React.FC<{
                     }
                   },
                   (error) => {
-                    showNotification({
+                    showSnackbar({
                       title: t('queueEntryError', 'Error adding patient to the queue'),
                       kind: 'error',
-                      critical: true,
-                      description: error?.message,
+                      isLowContrast: false,
+                      subtitle: error?.message,
                     });
                     setIsSubmitting(false);
                   },
@@ -173,11 +172,11 @@ const ScheduledVisits: React.FC<{
               }
             },
             (error) => {
-              showNotification({
+              showSnackbar({
                 title: t('startVisitError', 'Error starting visit'),
                 kind: 'error',
-                critical: true,
-                description: error?.message,
+                isLowContrast: false,
+                subtitle: error?.message,
               });
               setIsSubmitting(false);
             },

--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.test.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.test.tsx
@@ -5,8 +5,7 @@ import StartVisitQueueFields from './visit-form-queue-fields.component';
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   useLayoutType: () => 'desktop',
-  showNotification: jest.fn(),
-  showToast: jest.fn(),
+  showSnackbar: jest.fn(),
   useConfig: jest.fn(() => ({
     concepts: {
       defaultStatusConceptUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',

--- a/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.component.tsx
@@ -12,7 +12,7 @@ import {
   Button,
   InlineNotification,
 } from '@carbon/react';
-import { showNotification, showToast, useLayoutType } from '@openmrs/esm-framework';
+import { showSnackbar, useLayoutType } from '@openmrs/esm-framework';
 import styles from './queue-room.scss';
 import { SearchTypes } from '../types';
 import { mutate } from 'swr';
@@ -55,21 +55,21 @@ const QueueRoomForm: React.FC<QueueRoomFormProps> = ({ toggleSearchType, closePa
       saveQueueRoom(queueRoomName, queueRoomName, queueRoomService).then(
         ({ status }) => {
           if (status === 201) {
-            showToast({
+            showSnackbar({
               title: t('addQueueRoom', 'Add queue room'),
               kind: 'success',
-              description: t('queueRoomAddedSuccessfully', 'Queue room added successfully'),
+              subtitle: t('queueRoomAddedSuccessfully', 'Queue room added successfully'),
             });
             closePanel();
             mutate(`/ws/rest/v1/queueroom`);
           }
         },
         (error) => {
-          showNotification({
+          showSnackbar({
             title: t('errorAddingQueueRoom', 'Error adding queue room'),
             kind: 'error',
-            critical: true,
-            description: error?.message,
+            isLowContrast: false,
+            subtitle: error?.message,
           });
         },
       );

--- a/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.test.tsx
@@ -10,7 +10,7 @@ jest.mock('@openmrs/esm-framework', () => ({
   useQueueLocations: jest.fn(() => ({
     queueLocations: { uuid: 'e7786d9a-ab62-11ec-b909-0242ac120002', display: 'Location Test' },
   })),
-  showToast: jest.fn(),
+  showSnackbar: jest.fn(),
 }));
 
 jest.mock('./queue-room.resource', () => ({

--- a/packages/esm-service-queues-app/src/queue-services/queue-service-form.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-services/queue-service-form.component.tsx
@@ -12,7 +12,7 @@ import {
   Button,
   InlineNotification,
 } from '@carbon/react';
-import { showNotification, showToast, useLayoutType } from '@openmrs/esm-framework';
+import { showSnackbar, useLayoutType } from '@openmrs/esm-framework';
 import styles from './queue-service.scss';
 import { saveQueue, useServiceConcepts } from './queue-service.resource';
 import { SearchTypes } from '../types';
@@ -60,10 +60,10 @@ const QueueServiceForm: React.FC<QueueServiceFormProps> = ({ toggleSearchType, c
       saveQueue(queueName, queueConcept, queueName, userLocation).then(
         ({ status }) => {
           if (status === 201) {
-            showToast({
+            showSnackbar({
               title: t('addQueue', 'Add queue'),
               kind: 'success',
-              description: t('queueAddedSuccessfully', 'Queue addeded successfully'),
+              subtitle: t('queueAddedSuccessfully', 'Queue addeded successfully'),
             });
             closePanel();
             mutate(`/ws/rest/v1/queue?${userLocation}`);
@@ -71,11 +71,11 @@ const QueueServiceForm: React.FC<QueueServiceFormProps> = ({ toggleSearchType, c
           }
         },
         (error) => {
-          showNotification({
+          showSnackbar({
             title: t('errorAddingQueue', 'Error adding queue'),
             kind: 'error',
-            critical: true,
-            description: error?.message,
+            isLowContrast: false,
+            subtitle: error?.message,
           });
         },
       );

--- a/packages/esm-service-queues-app/src/queue-services/queue-service-form.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-services/queue-service-form.test.tsx
@@ -4,8 +4,7 @@ import QueueServiceForm from './queue-service-form.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
   useLayoutType: () => 'desktop',
-  showNotification: jest.fn(),
-  showToast: jest.fn(),
+  showSnackbar: jest.fn(),
 }));
 
 jest.mock('./queue-service.resource', () => ({

--- a/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.component.tsx
+++ b/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.component.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
-import {
-  parseDate,
-  showNotification,
-  showToast,
-  toDateObjectStrict,
-  toOmrsIsoString,
-  useVisit,
-} from '@openmrs/esm-framework';
+import { parseDate, showSnackbar, toDateObjectStrict, toOmrsIsoString, useVisit } from '@openmrs/esm-framework';
 import { MappedQueueEntry } from '../types';
 import { startOfDay } from '../constants';
 import { useCheckedInAppointments, voidQueueEntry } from './remove-queue-entry.resource';
@@ -48,18 +41,18 @@ const RemoveQueueEntryDialog: React.FC<RemoveQueueEntryDialogProps> = ({ queueEn
     ).then((response) => {
       closeModal();
       mutate();
-      showToast({
-        critical: true,
+      showSnackbar({
+        isLowContrast: true,
         kind: 'success',
-        description: t('queueEntryRemovedSuccessfully', `Queue entry removed successfully`),
+        subtitle: t('queueEntryRemovedSuccessfully', `Queue entry removed successfully`),
         title: t('queueEntryRemoved', 'Queue entry removed'),
       });
       (error) => {
-        showNotification({
+        showSnackbar({
           title: t('removeQueueEntryError', 'Error removing queue entry'),
           kind: 'error',
-          critical: true,
-          description: error?.message,
+          isLowContrast: false,
+          subtitle: error?.message,
         });
       };
     });

--- a/packages/esm-service-queues-app/src/transition-queue-entry/transition-queue-entry-dialog.component.tsx
+++ b/packages/esm-service-queues-app/src/transition-queue-entry/transition-queue-entry-dialog.component.tsx
@@ -8,8 +8,7 @@ import {
   formatDatetime,
   navigate,
   parseDate,
-  showNotification,
-  showToast,
+  showSnackbar,
   toDateObjectStrict,
   toOmrsIsoString,
   useConfig,
@@ -69,11 +68,11 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
         if (status === 201) {
           serveQueueEntry(queueEntry?.service, queueEntry?.visitQueueNumber, 'serving').then(({ status }) => {
             if (status === 200) {
-              showToast({
-                critical: true,
+              showSnackbar({
+                isLowContrast: true,
                 title: t('success', 'Success'),
                 kind: 'success',
-                description: t('patientAttendingService', 'Patient attending service'),
+                subtitle: t('patientAttendingService', 'Patient attending service'),
               });
               closeModal();
               mutate();
@@ -83,11 +82,11 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
         }
       },
       (error) => {
-        showNotification({
+        showSnackbar({
           title: t('queueEntryUpdateFailed', 'Error updating queue entry'),
           kind: 'error',
-          critical: true,
-          description: error?.message,
+          isLowContrast: false,
+          subtitle: error?.message,
         });
       },
     );
@@ -97,22 +96,22 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
     requeueQueueEntry(priorityComment.REQUEUED, queueEntry?.queueUuid, queueEntry?.queueEntryUuid).then(
       ({ status }) => {
         if (status === 200) {
-          showToast({
-            critical: true,
+          showSnackbar({
+            isLowContrast: true,
             title: t('success', 'Success'),
             kind: 'success',
-            description: t('patientRequeued', 'Patient has been requeued'),
+            subtitle: t('patientRequeued', 'Patient has been requeued'),
           });
           closeModal();
           mutate();
         }
       },
       (error) => {
-        showNotification({
+        showSnackbar({
           title: t('queueEntryUpdateFailed', 'Error updating queue entry'),
           kind: 'error',
-          critical: true,
-          description: error?.message,
+          isLowContrast: false,
+          subtitle: error?.message,
         });
       },
     );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. 
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Implemented the use of showSnackbar in esm-service-queue. This is done by replacing the showToast to showSnackbar.

## Screenshots

  Pending screenshots



## Related Issue

https://openmrs.atlassian.net/browse/O3-2631


