### PR TITLE
(feat) O3-2645 Add Config in Appointments App to disable Unscheduled Appointments Tab

### DIFF
--- a/packages/esm-appointments-app/src/appointments/appointment-tabs.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-tabs.component.tsx
@@ -6,6 +6,8 @@ import { useVisits } from '../hooks/useVisits';
 import ScheduledAppointments from './scheduled/scheduled-appointments.component';
 import UnscheduledAppointments from './unscheduled/unscheduled-appointments.component';
 import styles from './appointment-tabs.scss';
+import { ConfigObject } from '../config-schema';
+import { useConfig } from '@openmrs/esm-framework';
 
 interface AppointmentTabsProps {
   appointmentServiceType: string;
@@ -17,26 +19,32 @@ const AppointmentTabs: React.FC<AppointmentTabsProps> = ({ appointmentServiceTyp
 
   const { isLoading = false, visits = [], mutateVisit } = useVisits();
 
+  const { showUnscheduledAppointmentsTab } = useConfig<ConfigObject>();
+
   const handleTabChange = ({ selectedIndex }: { selectedIndex: number }) => {
     setActiveTabIndex(selectedIndex);
   };
 
   return (
     <div className={styles.appointmentList} data-testid="appointment-list">
-      <Tabs selectedIndex={activeTabIndex} onChange={handleTabChange} className={styles.tabs}>
-        <TabList style={{ paddingLeft: '1rem' }} aria-label="Appointment tabs" contained>
-          <Tab className={styles.tab}>{t('scheduled', 'Scheduled')}</Tab>
-          <Tab className={styles.tab}>{t('unscheduled', 'Unscheduled')}</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel className={styles.tabPanel}>
-            <ScheduledAppointments {...{ visits, isLoading, appointmentServiceType, mutateVisit }} />
-          </TabPanel>
-          <TabPanel className={styles.tabPanel}>
-            <UnscheduledAppointments />
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
+      {showUnscheduledAppointmentsTab ? (
+        <Tabs selectedIndex={activeTabIndex} onChange={handleTabChange} className={styles.tabs}>
+          <TabList style={{ paddingLeft: '1rem' }} aria-label="Appointment tabs" contained>
+            <Tab className={styles.tab}>{t('scheduled', 'Scheduled')}</Tab>
+            <Tab className={styles.tab}>{t('unscheduled', 'Unscheduled')}</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel className={styles.tabPanel}>
+              <ScheduledAppointments {...{ visits, isLoading, appointmentServiceType, mutateVisit }} />
+            </TabPanel>
+            <TabPanel className={styles.tabPanel}>
+              <UnscheduledAppointments />
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      ) : (
+        <ScheduledAppointments {...{ visits, isLoading, appointmentServiceType, mutateVisit }} />
+      )}
     </div>
   );
 };

--- a/packages/esm-appointments-app/src/config-schema.ts
+++ b/packages/esm-appointments-app/src/config-schema.ts
@@ -77,6 +77,12 @@ export const configSchema = {
     _description: 'The name of the patient identifier type to be used for the patient identifier field',
     _default: 'OpenMRS ID',
   },
+  showUnscheduledAppointmentsTab: {
+    _type: Type.Boolean,
+    _description:
+      'Whether to show the Unscheduled Appointments tab. Note that configuring this to true requires a custom unscheduledAppointment endpoint not currently available',
+    _default: false,
+  },
 };
 
 export interface ConfigObject {
@@ -95,4 +101,5 @@ export interface ConfigObject {
   defaultFacilityUrl: string;
   customPatientChartUrl: string;
   patientIdentifierType: string;
+  showUnscheduledAppointmentsTab: boolean;
 }


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

@mogoodrich has confirmed PIH does not need this feature in the near future, and wants a way to hide the Unscheduled Appointments tab.

Note that if the Unscheduled Tab is disabled, there is only one tab left (Scheduled Tab). The UX for just 1 tab is a bit confusing, so I made it so there are no tabs altogether if that is the case.

@CynthiaKamau notes that with this implementation, palladium will need to explicitly configure this to `true` to see the Unscheduled Tab. Let me know if you'd like me to change that.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

Initial discussion in https://openmrs.atlassian.net/browse/O3-2458
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
