### PR TITLE
(feat) Prevent double submission while doing patient registration.

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext, useMemo, useRef } from 'react';
 import classNames from 'classnames';
-import { Button, Link } from '@carbon/react';
+import { Button, Link, InlineLoading } from '@carbon/react';
 import { XAxis } from '@carbon/react/icons';
 import { useLocation, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -170,8 +170,18 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
                   // Current session and identifiers are required for patient registration.
                   // If currentSession or identifierTypes are not available, then the
                   // user should be blocked to register the patient.
-                  disabled={!currentSession || !identifierTypes}>
-                  {inEditMode ? t('updatePatient', 'Update Patient') : t('registerPatient', 'Register Patient')}
+                  disabled={!currentSession || !identifierTypes || props.isSubmitting}>
+                  {props.isSubmitting ? (
+                    <InlineLoading
+                      status="active"
+                      iconDescription="submitting"
+                      description={t('submitting', 'Submiting...')}
+                    />
+                  ) : inEditMode ? (
+                    t('updatePatient', 'Update Patient')
+                  ) : (
+                    t('registerPatient', 'Register Patient')
+                  )}
                 </Button>
                 <Button className={styles.cancelButton} kind="tertiary" onClick={cancelRegistration}>
                   {t('cancel', 'Cancel')}

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -340,7 +340,7 @@ describe('patient registration component', () => {
 
       mockedSaveEncounter.mockResolvedValue({});
 
-      await user.click(screen.getByText('Register Patient'));
+      await waitFor(() => user.click(screen.getByText('Register Patient')));
       await waitFor(() => expect(mockedSavePatient).toHaveBeenCalledTimes(2));
       await waitFor(() => expect(mockedSaveEncounter).toHaveBeenCalledTimes(2));
       await waitFor(() =>

--- a/packages/esm-patient-registration-app/translations/am.json
+++ b/packages/esm-patient-registration-app/translations/am.json
@@ -82,6 +82,7 @@
   "sexFieldLabelText": "Sex",
   "source": "Source",
   "stroke": "Stroke",
+  "submitting": "Submiting...",
   "unableToFetch": "Unable to fetch person attribute type - {{personattributetype}}",
   "unknown": "Unknown",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/ar.json
+++ b/packages/esm-patient-registration-app/translations/ar.json
@@ -82,6 +82,7 @@
   "sexFieldLabelText": "الجنس",
   "source": "Source",
   "stroke": "جلطة",
+  "submitting": "Submiting...",
   "unableToFetch": "تعذر الجلب نوع السمة الشخصية - {{personattributetype}}",
   "unknown": "غير معروف",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/en.json
+++ b/packages/esm-patient-registration-app/translations/en.json
@@ -82,6 +82,7 @@
   "sexFieldLabelText": "Sex",
   "source": "Source",
   "stroke": "Stroke",
+  "submitting": "Submiting...",
   "unableToFetch": "Unable to fetch person attribute type {{personattributetype}}",
   "unknown": "Unknown",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/es.json
+++ b/packages/esm-patient-registration-app/translations/es.json
@@ -82,6 +82,7 @@
   "sexFieldLabelText": "Sexo",
   "source": "Source",
   "stroke": "Ictus",
+  "submitting": "Submiting...",
   "unableToFetch": "No se puede obtener el tipo de atributo de persona {{personattributetype}}",
   "unknown": "Desconocido",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/fr.json
+++ b/packages/esm-patient-registration-app/translations/fr.json
@@ -82,6 +82,7 @@
   "sexFieldLabelText": "Sexe",
   "source": "Source",
   "stroke": "Accident",
+  "submitting": "Submiting...",
   "unableToFetch": "Unable to fetch person attribute type - {{personattributetype}}",
   "unknown": "Inconnu",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/he.json
+++ b/packages/esm-patient-registration-app/translations/he.json
@@ -82,6 +82,7 @@
   "sexFieldLabelText": "מין",
   "source": "מקור",
   "stroke": "שבץ",
+  "submitting": "Submiting...",
   "unableToFetch": "אין אפשרות לאחזר סוג מאפיין אדם - {{personattributetype}}",
   "unknown": "לא ידוע",
   "unknownPatientAttributeType": "סוג המאפיין של המטופל לא ידוע {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/km.json
+++ b/packages/esm-patient-registration-app/translations/km.json
@@ -82,6 +82,7 @@
   "sexFieldLabelText": "ភេទ",
   "source": "ប្រភព",
   "stroke": "ជំងឺស្ទះសរសៃឈាមខួរក្បាល",
+  "submitting": "Submiting...",
   "unableToFetch": "មិនអាចទាញយកប្រភេទគុណលក្ខណៈតាមអ្នកជំងឺបានទេ - {{personattributetype}}",
   "unknown": "មិនដឹង",
   "unknownPatientAttributeType": "ប្រភេទនៃគុណលក្ខណៈរបស់អ្នកជំងឺគឺមិនស្គាល់។ {{personAttributeTypeFormat}}",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR disables the `Update` and `Register` patient button to prevent double registration especially when system is slow. In addition to indicate that an operation is currently underway.

## Screenshots
https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/117da309-b558-44dd-a545-aba30e82a332

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
