### PR TITLE
(fix) Style tweak for registration form submit button loading state

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -173,9 +173,10 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
                   disabled={!currentSession || !identifierTypes || props.isSubmitting}>
                   {props.isSubmitting ? (
                     <InlineLoading
-                      status="active"
+                      className={styles.spinner}
+                      description={`${t('submitting', 'Submitting')} ...`}
                       iconDescription="submitting"
-                      description={t('submitting', 'Submiting...')}
+                      status="active"
                     />
                   ) : inEditMode ? (
                     t('updatePatient', 'Update Patient')

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.scss
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.scss
@@ -93,6 +93,12 @@
   }
 }
 
+.spinner {
+  &:global(.cds--inline-loading) {
+    min-height: 1rem;
+  }
+}
+
 // Overriding styles for RTL support
 html[dir='rtl'] {
   .linkName {

--- a/packages/esm-patient-registration-app/translations/am.json
+++ b/packages/esm-patient-registration-app/translations/am.json
@@ -82,7 +82,7 @@
   "sexFieldLabelText": "Sex",
   "source": "Source",
   "stroke": "Stroke",
-  "submitting": "Submiting...",
+  "submitting": "Submitting",
   "unableToFetch": "Unable to fetch person attribute type - {{personattributetype}}",
   "unknown": "Unknown",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/ar.json
+++ b/packages/esm-patient-registration-app/translations/ar.json
@@ -82,7 +82,7 @@
   "sexFieldLabelText": "الجنس",
   "source": "Source",
   "stroke": "جلطة",
-  "submitting": "Submiting...",
+  "submitting": "Submitting",
   "unableToFetch": "تعذر الجلب نوع السمة الشخصية - {{personattributetype}}",
   "unknown": "غير معروف",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/en.json
+++ b/packages/esm-patient-registration-app/translations/en.json
@@ -82,7 +82,7 @@
   "sexFieldLabelText": "Sex",
   "source": "Source",
   "stroke": "Stroke",
-  "submitting": "Submiting...",
+  "submitting": "Submitting",
   "unableToFetch": "Unable to fetch person attribute type {{personattributetype}}",
   "unknown": "Unknown",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/es.json
+++ b/packages/esm-patient-registration-app/translations/es.json
@@ -82,7 +82,7 @@
   "sexFieldLabelText": "Sexo",
   "source": "Source",
   "stroke": "Ictus",
-  "submitting": "Submiting...",
+  "submitting": "Submitting",
   "unableToFetch": "No se puede obtener el tipo de atributo de persona {{personattributetype}}",
   "unknown": "Desconocido",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/fr.json
+++ b/packages/esm-patient-registration-app/translations/fr.json
@@ -82,7 +82,7 @@
   "sexFieldLabelText": "Sexe",
   "source": "Source",
   "stroke": "Accident",
-  "submitting": "Submiting...",
+  "submitting": "Submitting",
   "unableToFetch": "Unable to fetch person attribute type - {{personattributetype}}",
   "unknown": "Inconnu",
   "unknownPatientAttributeType": "Patient attribute type has unknown format {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/he.json
+++ b/packages/esm-patient-registration-app/translations/he.json
@@ -82,7 +82,7 @@
   "sexFieldLabelText": "מין",
   "source": "מקור",
   "stroke": "שבץ",
-  "submitting": "Submiting...",
+  "submitting": "Submitting",
   "unableToFetch": "אין אפשרות לאחזר סוג מאפיין אדם - {{personattributetype}}",
   "unknown": "לא ידוע",
   "unknownPatientAttributeType": "סוג המאפיין של המטופל לא ידוע {{personAttributeTypeFormat}}",

--- a/packages/esm-patient-registration-app/translations/km.json
+++ b/packages/esm-patient-registration-app/translations/km.json
@@ -82,7 +82,7 @@
   "sexFieldLabelText": "ភេទ",
   "source": "ប្រភព",
   "stroke": "ជំងឺស្ទះសរសៃឈាមខួរក្បាល",
-  "submitting": "Submiting...",
+  "submitting": "Submitting",
   "unableToFetch": "មិនអាចទាញយកប្រភេទគុណលក្ខណៈតាមអ្នកជំងឺបានទេ - {{personattributetype}}",
   "unknown": "មិនដឹង",
   "unknownPatientAttributeType": "ប្រភេទនៃគុណលក្ខណៈរបស់អ្នកជំងឺគឺមិនស្គាល់។ {{personAttributeTypeFormat}}",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

A follow-up to #898 with a styling fix for the loading spinner so that the button doesn't grow in size when rendering the spinner. Additionally, I've also amended the translation string for the submit button loading state.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/bb29f775-5fd8-43fa-b7cf-4585d0351b4a

## Related Issue

*None*

## Other

*None*