### PR TITLE
(test) Remove async waitFor and fireEvent from tests

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.test.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import ActiveVisitsTable from './active-visits.component';
-import { useConfig, usePagination } from '@openmrs/esm-framework';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { usePagination } from '@openmrs/esm-framework';
 import { useActiveVisits } from './active-visits.resource';
+import ActiveVisitsTable from './active-visits.component';
 
 const mockedUsePagination = usePagination as jest.Mock;
 const mockActiveVisits = useActiveVisits as jest.Mock;
@@ -52,7 +53,9 @@ describe('ActiveVisitsTable', () => {
     expect(patientNameLink.tagName).toBe('A');
   });
 
-  it.skip('filters active visits based on search input', () => {
+  it.skip('filters active visits based on search input', async () => {
+    const user = userEvent.setup();
+
     mockActiveVisits.mockImplementationOnce(() => ({
       activeVisits: [
         { id: '1', name: 'John Doe', visitType: 'Checkup', patientUuid: 'uuid1' },
@@ -65,7 +68,7 @@ describe('ActiveVisitsTable', () => {
     render(<ActiveVisitsTable />);
 
     const searchInput = screen.getByPlaceholderText('Filter table');
-    fireEvent.change(searchInput, { target: { value: 'John' } });
+    await user.type(searchInput, 'John');
 
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.queryByText('Some One')).toBeNull();

--- a/packages/esm-appointments-app/src/appointments-calendar/daily/daily-view-workload.test.tsx
+++ b/packages/esm-appointments-app/src/appointments-calendar/daily/daily-view-workload.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
 import dayjs from 'dayjs';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { navigate } from '@openmrs/esm-framework';
-import DailyWorkloadView from './daily-view-workload.component';
 import { spaBasePath } from '../../constants';
 import { CalendarType } from '../../types';
+import DailyWorkloadView from './daily-view-workload.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
@@ -36,10 +37,12 @@ describe('DailyWorkloadView Component', () => {
     expect(screen.getByText('Lab testing')).toBeInTheDocument();
   });
 
-  it('navigates when a service area is clicked', () => {
+  it('navigates when a service area is clicked', async () => {
+    const user = userEvent.setup();
+
     render(<DailyWorkloadView {...mockData} />);
 
-    fireEvent.click(screen.getByText('HIV'));
+    await user.click(screen.getByText('HIV'));
 
     expect(navigate).toHaveBeenCalledWith({
       to: `${spaBasePath}/appointments/list/Fri, 18 Aug 2023 00:00:00 GMT/HIV`,

--- a/packages/esm-appointments-app/src/appointments-calendar/weekly/weekly-view-workload.test.tsx
+++ b/packages/esm-appointments-app/src/appointments-calendar/weekly/weekly-view-workload.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
 import dayjs from 'dayjs';
-import WeeklyWorkloadView from './weekly-view-workload.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { CalendarType } from '../../types';
 import { spaBasePath } from '../../constants';
 import { navigate } from '@openmrs/esm-framework';
+import WeeklyWorkloadView from './weekly-view-workload.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
@@ -37,10 +38,12 @@ describe('WeeklyWorkloadView Component', () => {
     expect(screen.getByText('Lab testing')).toBeInTheDocument();
   });
 
-  it('navigates when a service area is clicked', () => {
+  it('navigates when a service area is clicked', async () => {
+    const user = userEvent.setup();
+
     render(<WeeklyWorkloadView {...mockData} />);
 
-    fireEvent.click(screen.getByText('HIV'));
+    await user.click(screen.getByText('HIV'));
 
     expect(navigate).toHaveBeenCalledWith({
       to: `${spaBasePath}/appointments/list/Thu, 17 Aug 2023 00:00:00 GMT/HIV`,

--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
@@ -22,16 +22,16 @@ import {
 import { ConfigurableLink, formatDatetime, usePagination, formatDate, useConfig } from '@openmrs/esm-framework';
 import startCase from 'lodash-es/startCase';
 import { Download } from '@carbon/react/icons';
-import AppointmentDetails from '../details/appointment-details.component';
 import { EmptyState } from '../../empty-state/empty-state.component';
 import { downloadAppointmentsAsExcel } from '../../helpers/excel';
 import { launchOverlay } from '../../hooks/useOverlay';
-import PatientSearch from '../../patient-search/patient-search.component';
 import { MappedAppointment } from '../../types';
 import { getPageSizes, useSearchResults } from '../utils';
-import AppointmentActions from './appointments-actions.component';
-import styles from './appointments-table.scss';
 import { ConfigObject } from '../../config-schema';
+import AppointmentDetails from '../details/appointment-details.component';
+import AppointmentActions from './appointments-actions.component';
+import PatientSearch from '../../patient-search/patient-search.component';
+import styles from './appointments-table.scss';
 
 interface AppointmentsTableProps {
   appointments: Array<MappedAppointment>;

--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import AppointmentsTable from './appointments-table.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { MappedAppointment } from '../../types';
 import { usePagination } from '@openmrs/esm-framework';
 import { downloadAppointmentsAsExcel } from '../../helpers/excel';
 import { launchOverlay } from '../../hooks/useOverlay';
+import AppointmentsTable from './appointments-table.component';
 import PatientSearch from '../../patient-search/patient-search.component';
 
 // Define mock appointments data for testing purposes
@@ -59,19 +60,26 @@ describe('AppointmentsBaseTable', () => {
     scheduleType: 'Scheduled',
   };
 
-  it('should render empty state if appointments are not provided', () => {
+  it('should render empty state if appointments are not provided', async () => {
+    const user = userEvent.setup();
+
     render(<AppointmentsTable {...props} />);
-    expect(screen.getByText(/Scheduled appointments/)).toBeInTheDocument();
+
+    await screen.findByRole('heading', { name: /scheduled appointment/i });
+
     const emptyScreenText = screen.getByText(/There are no scheduled appointments to display/);
     expect(emptyScreenText).toBeInTheDocument();
 
     const launchAppointmentsForm = screen.getByRole('button', { name: /Create appointment/ });
-    fireEvent.click(launchAppointmentsForm);
+
+    await user.click(launchAppointmentsForm);
+
     expect(mockLaunchOverlay).toHaveBeenCalledWith('Search', <PatientSearch />);
   });
 
   it('should render loading state when loading data', () => {
     render(<AppointmentsTable {...props} isLoading={true} />);
+
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
@@ -83,41 +91,60 @@ describe('AppointmentsBaseTable', () => {
     });
 
     render(<AppointmentsTable {...props} appointments={appointments} />);
-    await waitFor(() => {
-      expect(screen.getByText('Patient name')).toBeInTheDocument();
-      expect(screen.getByText('Identifier')).toBeInTheDocument();
-      expect(screen.getByText('Service Type')).toBeInTheDocument();
-      expect(screen.getByText('Actions')).toBeInTheDocument();
-      const patient = screen.getByText('John Smith');
-      expect(patient).toBeInTheDocument();
-      expect(patient).toHaveAttribute('href', 'someUrl');
-      expect(screen.getByText('12345')).toBeInTheDocument();
-      expect(screen.getByText('Service')).toBeInTheDocument();
-    });
+
+    await screen.findByRole('heading', { name: /scheduled appointment/i });
+
+    expect(screen.getByText('Patient name')).toBeInTheDocument();
+    expect(screen.getByText('Identifier')).toBeInTheDocument();
+    expect(screen.getByText('Service Type')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+    const patient = screen.getByText('John Smith');
+    expect(patient).toBeInTheDocument();
+    expect(patient).toHaveAttribute('href', 'someUrl');
+    expect(screen.getByText('12345')).toBeInTheDocument();
+    expect(screen.getByText('Service')).toBeInTheDocument();
   });
 
-  it('should update search string when search input is changed', () => {
+  it('should update search string when search input is changed', async () => {
+    const user = userEvent.setup();
+
     render(<AppointmentsTable {...props} appointments={appointments} />);
+
+    await screen.findByRole('heading', { name: /scheduled appointment/i });
+
     const searchInput = screen.getByRole('searchbox');
-    fireEvent.change(searchInput, { target: { value: 'John' } });
+
+    await user.type(searchInput, 'John');
     expect(searchInput).toHaveValue('John');
   });
 
-  it("should contain the title 'Scheduled appointments' and Total count", () => {
+  it("should contain the title 'Scheduled appointments' and Total count", async () => {
     render(<AppointmentsTable {...props} appointments={appointments} />);
+
+    await screen.findByRole('heading', { name: /scheduled appointment/i });
+
     expect(screen.getByText(/Scheduled appointment/)).toBeInTheDocument();
     expect(screen.getByText(/Total 1/)).toBeInTheDocument();
   });
 
-  it('should execute the download function when download button is clicked', () => {
+  it('should execute the download function when download button is clicked', async () => {
+    const user = userEvent.setup();
+
     render(<AppointmentsTable {...props} appointments={appointments} />);
+
+    await screen.findByRole('heading', { name: /scheduled appointment/i });
+
     const downloadButton = screen.getByRole('button', { name: /Download/ });
-    fireEvent.click(downloadButton);
+
+    await user.click(downloadButton);
+
     expect(downloadButton).toBeInTheDocument();
     expect(mockDownloadAppointmentsAsExcel).toHaveBeenCalledWith(appointments, expect.anything());
   });
 
-  it('should have pagination when there are more than 25 appointments', () => {
+  it('should have pagination when there are more than 25 appointments', async () => {
+    const user = userEvent.setup();
+
     const mockAppointments = Array.from({ length: 100 }, (_, i) => ({
       patientUuid: `${i}`,
       name: `Patient ${i}`,
@@ -145,17 +172,22 @@ describe('AppointmentsBaseTable', () => {
     });
 
     render(<AppointmentsTable {...props} appointments={mockAppointments} />);
+
+    await screen.findByRole('heading', { name: /scheduled appointment/i });
+
     expect(screen.getByText(/1–25 of 100 items/)).toBeInTheDocument();
     const nextPageButton = screen.getByRole('button', { name: /Next page/ });
     const previousPageButton = screen.getByRole('button', { name: /Previous page/ });
 
     // Clicking the next page button should call the goTo function with the next page number
-    fireEvent.click(nextPageButton);
+    await user.click(nextPageButton);
+
     expect(mockGoToPage).toHaveBeenCalledWith(2);
     expect(screen.getByText(/26–50 of 100 items/)).toBeInTheDocument();
 
     // Clicking the previous page button should call the goTo function with the previous page number
-    fireEvent.click(previousPageButton);
+    await user.click(previousPageButton);
+
     expect(mockGoToPage).toHaveBeenCalledWith(1);
 
     expect(screen.getByText(/1–25 of 100 items/)).toBeInTheDocument();

--- a/packages/esm-appointments-app/src/appointments/forms/cancel-form/cancel-appointment.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/cancel-form/cancel-appointment.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { screen, render, waitFor } from '@testing-library/react';
-import CancelAppointment from './cancel-appointment.component';
-import { mockMappedAppointmentsData } from '../../../../../../__mocks__/appointments.mock';
 import userEvent from '@testing-library/user-event';
+import { screen, render } from '@testing-library/react';
+import { mockMappedAppointmentsData } from '../../../../../../__mocks__/appointments.mock';
 import { showNotification, showToast } from '@openmrs/esm-framework';
 import { cancelAppointment } from '../forms.resource';
+import CancelAppointment from './cancel-appointment.component';
 
 const testProps = {
   appointment: mockMappedAppointmentsData.data[0],
@@ -39,8 +39,8 @@ describe('Cancel appointment form', () => {
 
     renderCancelAppointment();
 
-    await waitFor(() => user.click(screen.getByRole('textbox', { name: /reason for changes/i })));
-    await waitFor(() => user.click(screen.getByRole('button', { name: /cancel appointment/i })));
+    await user.click(screen.getByRole('textbox', { name: /reason for changes/i }));
+    await user.click(screen.getByRole('button', { name: /cancel appointment/i }));
 
     expect(mockShowToast).toHaveBeenCalledTimes(1);
     expect(mockShowToast).toHaveBeenCalledWith({
@@ -50,6 +50,7 @@ describe('Cancel appointment form', () => {
       description: 'It has been cancelled successfully',
     });
   });
+
   it('should display an error message when rest api call to cancel appointment fails', async () => {
     const user = userEvent.setup();
     mockCancelAppointment.mockResolvedValueOnce({
@@ -59,8 +60,8 @@ describe('Cancel appointment form', () => {
 
     renderCancelAppointment();
 
-    await waitFor(() => user.click(screen.getByRole('textbox', { name: /reason for changes/i })));
-    await waitFor(() => user.click(screen.getByRole('button', { name: /cancel appointment/i })));
+    await user.click(screen.getByRole('textbox', { name: /reason for changes/i }));
+    await user.click(screen.getByRole('button', { name: /cancel appointment/i }));
     expect(mockShowNotification).toHaveBeenCalledTimes(1);
     expect(mockShowNotification).toHaveBeenCalledWith({
       critical: true,

--- a/packages/esm-appointments-app/src/appointments/unscheduled/unscheduled-appointments.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/unscheduled/unscheduled-appointments.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { useUnscheduledAppointments } from '../../hooks/useUnscheduledAppointments';
 import { downloadUnscheduledAppointments } from '../../helpers/excel';
 import { usePagination } from '@openmrs/esm-framework';
@@ -78,6 +79,8 @@ describe('UnscheduledAppointments component', () => {
   });
 
   it('allows the user to search for appointments', async () => {
+    const user = userEvent.setup();
+
     mockUseUnscheduledAppointments.mockReturnValue({
       isLoading: false,
       data: mockUnscheduledAppointments,
@@ -92,7 +95,7 @@ describe('UnscheduledAppointments component', () => {
     render(<UnscheduledAppointments />);
 
     const searchInput = await screen.findByRole('searchbox');
-    fireEvent.change(searchInput, { target: { value: 'Another' } });
+    await user.type(searchInput, 'Another');
 
     const patientName = screen.getByText('Another Patient');
     expect(patientName).toBeInTheDocument();
@@ -108,6 +111,8 @@ describe('UnscheduledAppointments component', () => {
   });
 
   it('allows the user to download a list of unscheduled appointments', async () => {
+    const user = userEvent.setup();
+
     mockUseUnscheduledAppointments.mockReturnValue({
       isLoading: false,
       data: mockUnscheduledAppointments,
@@ -124,7 +129,7 @@ describe('UnscheduledAppointments component', () => {
     const downloadButton = await screen.findByText('Download');
     expect(downloadButton).toBeInTheDocument();
 
-    fireEvent.click(downloadButton);
+    await user.click(downloadButton);
 
     expect(mockDownloadAppointmentsAsExcel).toHaveBeenCalledWith(mockUnscheduledAppointments);
   });

--- a/packages/esm-appointments-app/src/home-appointments/appointment-actions.test.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/appointment-actions.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { ActionsMenu } from './appointment-actions.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -30,7 +31,9 @@ describe('ActionsMenu', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the actions menu with correct options and handlers', () => {
+  it('renders the actions menu with correct options and handlers', async () => {
+    const user = userEvent.setup();
+
     const mockAppointment = {
       id: '123',
       recurring: false,
@@ -39,12 +42,12 @@ describe('ActionsMenu', () => {
 
     renderActionsMenu({ appointment: mockAppointment, useBahmniUI: 'true' });
 
-    fireEvent.click(screen.getByText(/Edit Appointment/i));
-    fireEvent.click(screen.getByText(/Check In/i));
-    fireEvent.click(screen.getByText(/Complete/i));
-    fireEvent.click(screen.getByText(/Missed/i));
-    fireEvent.click(screen.getByText(/Cancel/i));
-    fireEvent.click(screen.getByText(/Add new appointment/i));
+    await user.click(screen.getByText(/Edit Appointment/i));
+    await user.click(screen.getByText(/Check In/i));
+    await user.click(screen.getByText(/Complete/i));
+    await user.click(screen.getByText(/Missed/i));
+    await user.click(screen.getByText(/Cancel/i));
+    await user.click(screen.getByText(/Add new appointment/i));
 
     expect(screen.getByText(/Edit Appointment/i)).toBeInTheDocument();
     expect(screen.getByText(/Check In/i)).toBeInTheDocument();
@@ -54,7 +57,9 @@ describe('ActionsMenu', () => {
     expect(screen.getByText(/Add new appointment/i)).toBeInTheDocument();
   });
 
-  it('renders the actions menu with correct options and handlers in non-BahmniUI mode', () => {
+  it('renders the actions menu with correct options and handlers in non-BahmniUI mode', async () => {
+    const user = userEvent.setup();
+
     const mockAppointment = {
       id: '456',
       recurring: true,
@@ -63,12 +68,12 @@ describe('ActionsMenu', () => {
 
     renderActionsMenu({ appointment: mockAppointment, useBahmniUI: undefined });
 
-    fireEvent.click(screen.getByText(/Edit Appointment/i));
-    fireEvent.click(screen.getByText(/Check In/i));
-    fireEvent.click(screen.getByText(/Complete/i));
-    fireEvent.click(screen.getByText(/Missed/i));
-    fireEvent.click(screen.getByText(/Cancel/i));
-    fireEvent.click(screen.getByText(/Add new appointment/i));
+    await user.click(screen.getByText(/Edit Appointment/i));
+    await user.click(screen.getByText(/Check In/i));
+    await user.click(screen.getByText(/Complete/i));
+    await user.click(screen.getByText(/Missed/i));
+    await user.click(screen.getByText(/Cancel/i));
+    await user.click(screen.getByText(/Add new appointment/i));
 
     expect(screen.getByText('Edit Appointment')).toBeInTheDocument();
     expect(screen.getByText('Check In')).toBeInTheDocument();

--- a/packages/esm-appointments-app/src/home-appointments/check-in-modal/check-in-modal.test.tsx
+++ b/packages/esm-appointments-app/src/home-appointments/check-in-modal/check-in-modal.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import CheckInAppointmentModal from './check-in-modal.component';
-import { showActionableNotification, showNotification } from '@openmrs/esm-framework';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { updateAppointmentStatus } from '../appointments-table.resource';
+import { showActionableNotification, showNotification } from '@openmrs/esm-framework';
+import CheckInAppointmentModal from './check-in-modal.component';
 
 const mockUpdateAppointmentStatus = updateAppointmentStatus as jest.Mock;
 const appointmentUuid = '7cd38a6d-377e-491b-8284-b04cf8b8c6d8';
@@ -16,40 +17,44 @@ describe('CheckInAppointmentModal', () => {
   });
 
   it('submits and displays success notification', async () => {
+    const user = await userEvent.setup();
+
     mockUpdateAppointmentStatus.mockResolvedValue({ status: 200 });
     const closeCheckInModal = jest.fn();
 
     render(<CheckInAppointmentModal closeCheckInModal={closeCheckInModal} appointmentUuid={appointmentUuid} />);
 
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: '10:30' } });
-    fireEvent.click(screen.getByText('Yes'));
+    await user.type(screen.getByRole('textbox'), '10:30');
+    await user.click(screen.getByText('Yes'));
 
-    await waitFor(() => {
-      expect(closeCheckInModal).toHaveBeenCalled();
-      expect(showActionableNotification).toHaveBeenCalled();
-    });
+    expect(closeCheckInModal).toHaveBeenCalled();
+    expect(showActionableNotification).toHaveBeenCalled();
   });
 
   it('displays error notification on submit failure', async () => {
+    const user = userEvent.setup();
+
     mockUpdateAppointmentStatus.mockResolvedValue({ status: 400 });
     const closeCheckInModal = jest.fn();
 
     render(<CheckInAppointmentModal closeCheckInModal={closeCheckInModal} appointmentUuid={appointmentUuid} />);
 
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: '10:30' } });
-    fireEvent.click(screen.getByText('Yes'));
+    const input = screen.getByRole('textbox');
 
-    await waitFor(() => {
-      expect(showNotification).toHaveBeenCalled();
-    });
+    await user.type(input, '10:30');
+    await user.click(screen.getByText('Yes'));
+
+    expect(showNotification).toHaveBeenCalled();
   });
 
-  it('closes modal on "No" button click', () => {
+  it('closes modal on "No" button click', async () => {
+    const user = userEvent.setup();
+
     const closeCheckInModal = jest.fn();
 
     render(<CheckInAppointmentModal closeCheckInModal={closeCheckInModal} appointmentUuid={appointmentUuid} />);
 
-    fireEvent.click(screen.getByText('No'));
+    await user.click(screen.getByText('No'));
 
     expect(closeCheckInModal).toHaveBeenCalled();
   });

--- a/packages/esm-patient-list-management-app/src/add-patient-to-patient-list-menu-item.test.tsx
+++ b/packages/esm-patient-list-management-app/src/add-patient-to-patient-list-menu-item.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import AddPatientToPatientListMenuItem from './add-patient-to-patient-list-menu-item.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { showModal } from '@openmrs/esm-framework';
+import AddPatientToPatientListMenuItem from './add-patient-to-patient-list-menu-item.component';
 
 const mockedShowModal = showModal as jest.Mock;
 
@@ -20,10 +21,12 @@ describe('AddPatientToPatientListMenuItem', () => {
   });
 
   it('should open the modal on button click', async () => {
+    const user = userEvent.setup();
+
     render(<AddPatientToPatientListMenuItem patientUuid={patientUuid} />);
     const button = screen.getByRole('menuitem');
 
-    fireEvent.click(button);
+    await user.click(button);
 
     expect(mockedShowModal).toHaveBeenCalledWith('add-patient-to-patient-list-modal', expect.any(Object));
   });

--- a/packages/esm-patient-list-management-app/src/overlay.test.tsx
+++ b/packages/esm-patient-list-management-app/src/overlay.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import Overlay from './overlay.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { useLayoutType, isDesktop } from '@openmrs/esm-framework';
+import Overlay from './overlay.component';
 
 const mockUseLayoutType = useLayoutType as jest.Mock;
 const mockIsDesktop = isDesktop as jest.Mock;
@@ -40,8 +41,10 @@ describe('Overlay', () => {
     expect(backButton).toBeInTheDocument();
   });
 
-  it('calls the close function when close button is clicked', () => {
+  it('calls the close function when close button is clicked', async () => {
+    const user = userEvent.setup();
     const mockClose = jest.fn();
+
     mockUseLayoutType.mockImplementation(() => 'desktop');
     render(
       <Overlay close={mockClose} header="Test Header">
@@ -50,7 +53,7 @@ describe('Overlay', () => {
     );
 
     const closeButton = screen.getByRole('button', { name: 'Close overlay' });
-    fireEvent.click(closeButton);
+    await user.click(closeButton);
 
     expect(mockClose).toHaveBeenCalled();
   });

--- a/packages/esm-patient-registration-app/src/add-patient-link.test.tsx
+++ b/packages/esm-patient-registration-app/src/add-patient-link.test.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
-import * as esmFramework from '@openmrs/esm-framework';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
+import { navigate } from '@openmrs/esm-framework';
 import Root from './add-patient-link';
 
+const mockedNavigate = navigate as jest.Mock;
+
 describe('Add patient link component', () => {
-  it('renders an "Add Patient" button and triggers navigation on click', () => {
-    const navigateMock = jest.fn();
-    jest.spyOn(esmFramework, 'navigate').mockImplementation(navigateMock);
+  it('renders an "Add Patient" button and triggers navigation on click', async () => {
+    const user = userEvent.setup();
 
     const { getByRole } = render(<Root />);
     const addButton = getByRole('button', { name: /add patient/i });
 
-    fireEvent.click(addButton);
+    await user.click(addButton);
 
-    expect(navigateMock).toHaveBeenCalledWith({ to: '${openmrsSpaBase}/patient-registration' });
+    expect(mockedNavigate).toHaveBeenCalledWith({ to: '${openmrsSpaBase}/patient-registration' });
   });
 });

--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/tests/address-search-component.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/tests/address-search-component.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { Formik, Form, useFormikContext } from 'formik';
 import { Resources, ResourcesContext } from '../../../../offline.resources';
 import { PatientRegistrationContext } from '../../../patient-registration-context';
@@ -7,7 +8,6 @@ import { useConfig } from '@openmrs/esm-framework';
 import { useAddressHierarchy, useOrderedAddressHierarchyLevels } from '../address-hierarchy.resource';
 import { mockedAddressTemplate, mockedAddressOptions, mockedOrderedFields } from './mocks';
 import AddressSearchComponent from '../address-search.component';
-import userEvent from '@testing-library/user-event';
 
 useAddressHierarchy;
 jest.mock('@openmrs/esm-framework', () => ({
@@ -60,7 +60,6 @@ const setFieldValue = jest.fn();
 
 describe('Testing address search bar', () => {
   beforeEach(() => {
-    cleanup();
     (useConfig as jest.Mock).mockImplementation(() => ({
       fieldConfigurations: {
         address: {
@@ -88,23 +87,31 @@ describe('Testing address search bar', () => {
       error: null,
       isLoading: false,
     }));
+
     renderAddressHierarchy();
+
     const searchbox = screen.getByRole('searchbox');
     expect(searchbox).toBeInTheDocument();
+
     const ul = screen.queryByRole('list');
     expect(ul).not.toBeInTheDocument();
   });
 
   it("should render only the results for the search term matched address' parents", async () => {
+    const user = userEvent.setup();
+
     (useAddressHierarchy as jest.Mock).mockImplementation(() => ({
       addresses: mockedAddressOptions,
       error: null,
       isLoading: false,
     }));
+
     renderAddressHierarchy();
+
     const searchString = 'nea';
     const separator = ' > ';
     const options: Set<string> = new Set();
+
     mockedAddressOptions.forEach((address) => {
       const values = address.split(separator);
       values.forEach((val, index) => {
@@ -118,10 +125,10 @@ describe('Testing address search bar', () => {
     addressOptions.forEach(async (address) => {
       const optionElement = screen.getByText(address);
       expect(optionElement).toBeInTheDocument();
-      fireEvent.click(optionElement);
+      await user.click(optionElement);
       const values = address.split(separator);
       allFields.map(({ name }, index) => {
-        waitFor(() => expect(setFieldValue).toBeCalledWith(`address.${name}`, values?.[index]));
+        expect(setFieldValue).toBeCalledWith(`address.${name}`, values?.[index]);
       });
     });
   });

--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { Formik, Form } from 'formik';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-import '@testing-library/jest-dom';
 import { DobField } from './dob.component';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import { initialFormValues } from '../../patient-registration.component';

--- a/packages/esm-patient-registration-app/src/patient-registration/field/gender/gender-field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/gender/gender-field.test.tsx
@@ -1,9 +1,7 @@
-import React, { useContext } from 'react';
-import { render, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-import '@testing-library/jest-dom';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { Formik, Form } from 'formik';
-
+import { render } from '@testing-library/react';
 import { GenderField } from './gender-field.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -50,17 +48,15 @@ describe('GenderField', () => {
     );
   };
 
-  it('renders', () => {
-    expect(renderComponent()).not.toBeNull();
-  });
-
   it('has a label', () => {
     expect(renderComponent().getAllByText('Sex')).toBeTruthy();
   });
 
-  it('checks an option', () => {
+  it('checks an option', async () => {
+    const user = userEvent.setup();
     const component = renderComponent();
-    fireEvent.click(component.getByLabelText('Male'));
+
+    await user.click(component.getByLabelText('Male'));
     expect(component.getByLabelText('Male')).toBeChecked();
   });
 });

--- a/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { Identifiers } from './id-field.component';
 import { Resources, ResourcesContext } from '../../../offline.resources';
 import { Form, Formik } from 'formik';
@@ -76,7 +77,9 @@ describe('Identifiers', () => {
     expect(configureButton).toBeEnabled();
   });
 
-  it('should open identifier selection overlay when "Configure" button is clicked', () => {
+  it('should open identifier selection overlay when "Configure" button is clicked', async () => {
+    const user = userEvent.setup();
+
     render(
       <ResourcesContext.Provider value={mockResourcesContextValue}>
         <Formik initialValues={{}} onSubmit={null}>
@@ -98,7 +101,7 @@ describe('Identifiers', () => {
     );
 
     const configureButton = screen.getByRole('button', { name: 'Configure' });
-    fireEvent.click(configureButton);
+    await user.click(configureButton);
 
     expect(screen.getByRole('button', { name: 'Close overlay' })).toBeInTheDocument();
   });

--- a/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/select/select-input.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/select/select-input.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Formik, Form } from 'formik';
 import { SelectInput } from './select-input.component';
@@ -28,7 +28,7 @@ describe('the select input', () => {
 
     await user.selectOptions(input, expected);
 
-    await waitFor(() => expect(input.value).toEqual(expected));
+    await expect(input.value).toEqual(expected);
   });
 
   it('should show optional label if the input is not required', async () => {
@@ -40,7 +40,7 @@ describe('the select input', () => {
       </Formik>,
     );
 
-    await waitFor(() => expect(screen.findByRole('combobox')));
+    await expect(screen.findByRole('combobox'));
 
     const selectInput = screen.getByRole('combobox', { name: 'Select (optional)' }) as HTMLSelectElement;
     expect(selectInput.labels).toHaveLength(1);

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.component.tsx
@@ -5,6 +5,7 @@ import styles from './autosuggest.scss';
 
 // FIXME Temporarily included types from Carbon
 type InputPropsBase = Omit<HTMLAttributes<HTMLInputElement>, 'onChange'>;
+
 interface SearchProps extends InputPropsBase {
   /**
    * Specify an optional value for the `autocomplete` property on the underlying
@@ -136,6 +137,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const query = e.target.value;
     onSuggestionSelected(name, undefined);
+
     if (query) {
       getSearchResults(query).then((suggestions) => {
         setSuggestions(suggestions);

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Autosuggest } from './autosuggest.component';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import '@testing-library/jest-dom/extend-expect';
-import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 const mockPersons = [
   {
@@ -24,97 +23,110 @@ const mockPersons = [
   },
 ];
 
-const mockGetSearchResults = async (query: string) => {
+const mockedGetSearchResults = async (query: string) => {
   return mockPersons.filter((person) => {
     return person.display.toUpperCase().includes(query.toUpperCase());
   });
 };
 
-const handleSuggestionSelected = jest.fn((field, value) => [field, value]);
+const mockedHandleSuggestionSelected = jest.fn((field, value) => [field, value]);
 
-describe('autosuggest', () => {
-  const setup = () => {
-    render(
-      <BrowserRouter>
-        <Autosuggest
-          labelText=""
-          id="person"
-          placeholder="Find Person"
-          onSuggestionSelected={handleSuggestionSelected}
-          getSearchResults={mockGetSearchResults}
-          getDisplayValue={(item) => item.display}
-          getFieldValue={(item) => item.uuid}
-        />
-      </BrowserRouter>,
-    );
-  };
+describe('Autosuggest', () => {
+  afterEach(() => mockedHandleSuggestionSelected.mockClear());
 
-  it('should render a search box', () => {
-    setup();
+  it('renders a search box', () => {
+    renderAutosuggest();
+
     expect(screen.getByRole('searchbox')).toBeInTheDocument();
     expect(screen.queryByRole('list')).toBeNull();
   });
 
-  it('should show the search results in a list', async () => {
-    setup();
+  it('renders matching search results in a list when the user types a query', async () => {
+    const user = userEvent.setup();
+
+    renderAutosuggest();
+
     const searchbox = screen.getByRole('searchbox');
-    fireEvent.change(searchbox, { target: { value: 'john' } });
-    const list = await waitFor(() => screen.getByRole('list'));
+    await user.type(searchbox, 'john');
+
+    const list = screen.getByRole('list');
+
     expect(list).toBeInTheDocument();
     expect(list.children).toHaveLength(2);
+    expect(screen.getAllByRole('listitem')[0]).toHaveTextContent('John Doe');
+    expect(screen.getAllByRole('listitem')[1]).toHaveTextContent('John Smith');
   });
 
-  it('should creates the li items whose inner text is gotten through getDisplayValue', async () => {
-    setup();
-    const searchbox = screen.getByRole('searchbox');
-    fireEvent.change(searchbox, { target: { value: 'john' } });
-    const list = await waitFor(() => screen.getAllByRole('listitem'));
-    expect(list[0].textContent).toBe('John Doe');
-    expect(list[1].textContent).toBe('John Smith');
-  });
+  it('clears the list of suggestions when a suggestion is selected', async () => {
+    const user = userEvent.setup();
 
-  it('should trigger the onSuggestionSelected with correct values when li is clicked', async () => {
-    setup();
-    const searchbox = screen.getByRole('searchbox');
-    fireEvent.change(searchbox, { target: { value: 'john' } });
-    const listitems = await waitFor(() => screen.getAllByRole('listitem'));
-    fireEvent.click(listitems[0]);
-    expect(handleSuggestionSelected).toHaveBeenNthCalledWith(4, 'person', 'randomuuid1');
-  });
+    renderAutosuggest();
 
-  it('should clear the suggestions when a suggestion is selected', async () => {
-    setup();
     let list = screen.queryByRole('list');
     expect(list).toBeNull();
+
     const searchbox = screen.getByRole('searchbox');
-    fireEvent.change(searchbox, { target: { value: 'john' } });
-    list = await waitFor(() => screen.getByRole('list'));
+    await user.type(searchbox, 'john');
+
+    list = screen.getByRole('list');
     expect(list).toBeInTheDocument();
+
     const listitems = screen.getAllByRole('listitem');
-    fireEvent.click(listitems[0]);
+    await user.click(listitems[0]);
+
+    expect(mockedHandleSuggestionSelected).toHaveBeenLastCalledWith('person', 'randomuuid1');
+
     list = screen.queryByRole('list');
     expect(list).toBeNull();
   });
 
-  it('should change suggestions when a search input is changed', async () => {
-    setup();
+  it('changes suggestions when a search input is changed', async () => {
+    const user = userEvent.setup();
+
+    renderAutosuggest();
+
     let list = screen.queryByRole('list');
     expect(list).toBeNull();
+
     const searchbox = screen.getByRole('searchbox');
-    fireEvent.change(searchbox, { target: { value: 'john' } });
+    await user.type(searchbox, 'john');
+
     const suggestion = await screen.findByText('John Doe');
     expect(suggestion).toBeInTheDocument();
-    fireEvent.change(searchbox, { target: { value: '' } });
+
+    await user.clear(searchbox);
+
     list = screen.queryByRole('list');
     expect(list).toBeNull();
   });
 
-  it('should hide suggestions when clicked outside of component', async () => {
-    setup();
+  it('hides the list of suggestions when the user clicks outside of the component', async () => {
+    const user = userEvent.setup();
+
+    renderAutosuggest();
+
     const input = screen.getByRole('searchbox');
-    fireEvent.change(input, { target: { value: 'john' } });
+
+    await user.type(input, 'john');
     await screen.findByText('John Doe');
-    fireEvent.mouseDown(document.body);
+    await user.click(document.body);
+
     expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
   });
 });
+
+function renderAutosuggest() {
+  render(
+    <BrowserRouter>
+      <Autosuggest
+        getSearchResults={mockedGetSearchResults}
+        getDisplayValue={(item) => item.display}
+        getFieldValue={(item) => item.uuid}
+        id="person"
+        labelText=""
+        onSuggestionSelected={mockedHandleSuggestionSelected}
+        placeholder="Find Person"
+      />
+    </BrowserRouter>,
+  );
+}

--- a/packages/esm-patient-registration-app/src/patient-registration/input/dummy-data/dummy-data-input.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/dummy-data/dummy-data-input.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { DummyDataInput, dummyFormValues } from './dummy-data-input.component';
 import { initialFormValues } from '../../patient-registration.component';
 import { FormValues } from '../../patient-registration-types';
@@ -33,11 +34,10 @@ describe('dummy data input', () => {
   });
 
   it('can input data on button click', async () => {
+    const user = userEvent.setup();
     const input = await setupInput();
 
-    fireEvent.click(input);
-    waitFor(() => {
-      expect(formValues).toEqual(dummyFormValues);
-    });
+    await user.click(input);
+    expect(formValues).toEqual(dummyFormValues);
   });
 });

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { BrowserRouter as Router, useParams } from 'react-router-dom';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { Encounter } from './patient-registration.types';
 import { showSnackbar, useConfig, usePatient } from '@openmrs/esm-framework';
 import { FormManager } from './form-manager';
 import { saveEncounter, savePatient } from './patient-registration.resource';
-import type { Encounter } from './patient-registration.types';
 import { Resources, ResourcesContext } from '../offline.resources';
 import { PatientRegistration } from './patient-registration.component';
 import { RegistrationConfig } from '../config-schema';
@@ -158,6 +158,7 @@ configWithObs.fieldDefinitions = [
     answerConceptSetUuid: null,
   },
 ];
+
 configWithObs.sectionDefinitions?.push({
   id: 'custom',
   name: 'Custom',
@@ -182,271 +183,264 @@ const fillRequiredFields = async () => {
   user.click(genderInput);
 };
 
-describe('patient registration component', () => {
-  describe('when registering a new patient', () => {
-    beforeEach(() => {
-      mockedUseConfig.mockReturnValue(mockOpenmrsConfig);
-      mockedSavePatient.mockReturnValue({ data: { uuid: 'new-pt-uuid' }, ok: true });
-      mockedSaveEncounter.mockClear();
-      mockedShowSnackbar.mockClear();
-      jest.clearAllMocks();
-    });
-
-    it('renders without crashing', () => {
-      render(
-        <ResourcesContext.Provider value={mockResourcesContextValue}>
-          <Router>
-            <PatientRegistration isOffline={false} savePatientForm={jest.fn()} />
-          </Router>
-          ,
-        </ResourcesContext.Provider>,
-      );
-    });
-
-    it('has the expected sections', async () => {
-      render(
-        <ResourcesContext.Provider value={mockResourcesContextValue}>
-          <Router>
-            <PatientRegistration isOffline={false} savePatientForm={jest.fn()} />
-          </Router>
-        </ResourcesContext.Provider>,
-      );
-      await waitFor(() => expect(screen.getByLabelText(/Demographics Section/)).not.toBeNull());
-      expect(screen.getByLabelText(/Contact Info Section/)).not.toBeNull();
-    });
-
-    it('saves the patient without extra info', async () => {
-      const user = userEvent.setup();
-
-      render(
-        <ResourcesContext.Provider value={mockResourcesContextValue}>
-          <Router>
-            <PatientRegistration isOffline={false} savePatientForm={FormManager.savePatientFormOnline} />
-          </Router>
-        </ResourcesContext.Provider>,
-      );
-
-      await fillRequiredFields();
-      await user.click(await screen.findByText('Register Patient'));
-      await waitFor(() => {
-        expect(mockedSavePatient).toHaveBeenCalledWith(
-          expect.objectContaining({
-            identifiers: [], //TODO when the identifer story is finished: { identifier: '', identifierType: '05a29f94-c0ed-11e2-94be-8c13b969e334', location: '' },
-            person: {
-              addresses: expect.arrayContaining([expect.any(Object)]),
-              attributes: [],
-              birthdate: '1993-8-2',
-              birthdateEstimated: false,
-              gender: 'M',
-              names: [{ givenName: 'Paul', middleName: '', familyName: 'Gaihre', preferred: true, uuid: undefined }],
-              dead: false,
-              uuid: expect.anything(),
-            },
-            uuid: expect.anything(),
-          }),
-          undefined,
-        );
-      });
-    });
-
-    it('should not save the patient if validation fails', async () => {
-      const user = userEvent.setup();
-
-      const mockedSavePatientForm = jest.fn();
-      render(
-        <ResourcesContext.Provider value={mockResourcesContextValue}>
-          <Router>
-            <PatientRegistration isOffline={false} savePatientForm={mockedSavePatientForm} />
-          </Router>
-        </ResourcesContext.Provider>,
-      );
-
-      const givenNameInput = (await screen.findByLabelText('First Name')) as HTMLInputElement;
-
-      await user.type(givenNameInput, '5');
-      await user.click(screen.getByText('Register Patient'));
-
-      expect(mockedSavePatientForm).not.toHaveBeenCalled();
-    });
-
-    it('renders and saves registration obs', async () => {
-      const user = userEvent.setup();
-
-      mockedSaveEncounter.mockResolvedValue({});
-      mockedUseConfig.mockReturnValue(configWithObs);
-
-      render(
-        <ResourcesContext.Provider value={mockResourcesContextValue}>
-          <Router>
-            <PatientRegistration isOffline={false} savePatientForm={FormManager.savePatientFormOnline} />
-          </Router>
-        </ResourcesContext.Provider>,
-      );
-
-      await fillRequiredFields();
-      const customSection = screen.getByLabelText('Custom Section');
-      const weight = within(customSection).getByLabelText('Weight (kg) (optional)');
-      await user.type(weight, '50');
-      const complaint = within(customSection).getByLabelText('Chief Complaint (optional)');
-      await user.type(complaint, 'sad');
-      const nationality = within(customSection).getByLabelText('Nationality');
-      await user.selectOptions(nationality, 'USA');
-
-      await user.click(screen.getByText('Register Patient'));
-
-      await waitFor(() => expect(mockedSavePatient).toHaveBeenCalled());
-      await waitFor(() =>
-        expect(mockedSaveEncounter).toHaveBeenCalledWith(
-          expect.objectContaining<Partial<Encounter>>({
-            encounterType: 'reg-enc-uuid',
-            patient: 'new-pt-uuid',
-            obs: [
-              { concept: 'weight-uuid', value: 50 },
-              { concept: 'chief-complaint-uuid', value: 'sad' },
-              { concept: 'nationality-uuid', value: 'usa' },
-            ],
-          }),
-        ),
-      );
-    });
-
-    it('retries saving registration obs after a failed attempt', async () => {
-      const user = userEvent.setup();
-
-      mockedUseConfig.mockReturnValue(configWithObs);
-
-      render(
-        <ResourcesContext.Provider value={mockResourcesContextValue}>
-          <Router>
-            <PatientRegistration isOffline={false} savePatientForm={FormManager.savePatientFormOnline} />
-          </Router>
-        </ResourcesContext.Provider>,
-      );
-
-      await fillRequiredFields();
-      const customSection = screen.getByLabelText('Custom Section');
-      const weight = within(customSection).getByLabelText('Weight (kg) (optional)');
-      await user.type(weight, '-999');
-
-      mockedSaveEncounter.mockRejectedValue({ status: 400, responseBody: { error: { message: 'an error message' } } });
-
-      await user.click(screen.getByText('Register Patient'));
-
-      await waitFor(() => expect(mockedSavePatient).toHaveBeenCalledTimes(1));
-      await waitFor(() => expect(mockedSaveEncounter).toHaveBeenCalledTimes(1));
-      await waitFor(() =>
-        expect(mockedShowSnackbar).toHaveBeenCalledWith(expect.objectContaining({ subtitle: 'an error message' })),
-      );
-
-      mockedSaveEncounter.mockResolvedValue({});
-
-      await waitFor(() => user.click(screen.getByText('Register Patient')));
-      await waitFor(() => expect(mockedSavePatient).toHaveBeenCalledTimes(2));
-      await waitFor(() => expect(mockedSaveEncounter).toHaveBeenCalledTimes(2));
-      await waitFor(() =>
-        expect(mockedShowSnackbar).toHaveBeenCalledWith(expect.objectContaining({ kind: 'success' })),
-      );
-    });
+describe('Registering a new patient', () => {
+  beforeEach(() => {
+    mockedUseConfig.mockReturnValue(mockOpenmrsConfig);
+    mockedSavePatient.mockReturnValue({ data: { uuid: 'new-pt-uuid' }, ok: true });
+    mockedSaveEncounter.mockClear();
+    mockedShowSnackbar.mockClear();
+    jest.clearAllMocks();
   });
 
-  describe('when updating an existing patient details', () => {
-    beforeEach(() => {
-      mockedUseConfig.mockReturnValue(mockOpenmrsConfig);
-      mockedSavePatient.mockReturnValue({ data: { uuid: 'new-pt-uuid' }, ok: true });
-      mockedSaveEncounter.mockClear();
-      mockedShowSnackbar.mockClear();
-      jest.clearAllMocks();
+  it('renders without crashing', () => {
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Router>
+          <PatientRegistration isOffline={false} savePatientForm={jest.fn()} />
+        </Router>
+        ,
+      </ResourcesContext.Provider>,
+    );
+  });
+
+  it('has the expected sections', async () => {
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Router>
+          <PatientRegistration isOffline={false} savePatientForm={jest.fn()} />
+        </Router>
+      </ResourcesContext.Provider>,
+    );
+
+    expect(screen.getByLabelText(/Demographics Section/)).not.toBeNull();
+    expect(screen.getByLabelText(/Contact Info Section/)).not.toBeNull();
+  });
+
+  it('saves the patient without extra info', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Router>
+          <PatientRegistration isOffline={false} savePatientForm={FormManager.savePatientFormOnline} />
+        </Router>
+      </ResourcesContext.Provider>,
+    );
+
+    await fillRequiredFields();
+    await user.click(await screen.findByText('Register Patient'));
+    expect(mockedSavePatient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identifiers: [], //TODO when the identifer story is finished: { identifier: '', identifierType: '05a29f94-c0ed-11e2-94be-8c13b969e334', location: '' },
+        person: {
+          addresses: expect.arrayContaining([expect.any(Object)]),
+          attributes: [],
+          birthdate: '1993-8-2',
+          birthdateEstimated: false,
+          gender: 'M',
+          names: [{ givenName: 'Paul', middleName: '', familyName: 'Gaihre', preferred: true, uuid: undefined }],
+          dead: false,
+          uuid: expect.anything(),
+        },
+        uuid: expect.anything(),
+      }),
+      undefined,
+    );
+  });
+
+  it('should not save the patient if validation fails', async () => {
+    const user = userEvent.setup();
+
+    const mockedSavePatientForm = jest.fn();
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Router>
+          <PatientRegistration isOffline={false} savePatientForm={mockedSavePatientForm} />
+        </Router>
+      </ResourcesContext.Provider>,
+    );
+
+    const givenNameInput = (await screen.findByLabelText('First Name')) as HTMLInputElement;
+
+    await user.type(givenNameInput, '5');
+    await user.click(screen.getByText('Register Patient'));
+
+    expect(mockedSavePatientForm).not.toHaveBeenCalled();
+  });
+
+  it('renders and saves registration obs', async () => {
+    const user = userEvent.setup();
+
+    mockedSaveEncounter.mockResolvedValue({});
+    mockedUseConfig.mockReturnValue(configWithObs);
+
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Router>
+          <PatientRegistration isOffline={false} savePatientForm={FormManager.savePatientFormOnline} />
+        </Router>
+      </ResourcesContext.Provider>,
+    );
+
+    await fillRequiredFields();
+    const customSection = screen.getByLabelText('Custom Section');
+    const weight = within(customSection).getByLabelText('Weight (kg) (optional)');
+    await user.type(weight, '50');
+    const complaint = within(customSection).getByLabelText('Chief Complaint (optional)');
+    await user.type(complaint, 'sad');
+    const nationality = within(customSection).getByLabelText('Nationality');
+    await user.selectOptions(nationality, 'USA');
+
+    await user.click(screen.getByText('Register Patient'));
+
+    expect(mockedSavePatient).toHaveBeenCalled();
+
+    expect(mockedSaveEncounter).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<Encounter>>({
+        encounterType: 'reg-enc-uuid',
+        patient: 'new-pt-uuid',
+        obs: [
+          { concept: 'weight-uuid', value: 50 },
+          { concept: 'chief-complaint-uuid', value: 'sad' },
+          { concept: 'nationality-uuid', value: 'usa' },
+        ],
+      }),
+    );
+  });
+
+  it('retries saving registration obs after a failed attempt', async () => {
+    const user = userEvent.setup();
+
+    mockedUseConfig.mockReturnValue(configWithObs);
+
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Router>
+          <PatientRegistration isOffline={false} savePatientForm={FormManager.savePatientFormOnline} />
+        </Router>
+      </ResourcesContext.Provider>,
+    );
+
+    await fillRequiredFields();
+    const customSection = screen.getByLabelText('Custom Section');
+    const weight = within(customSection).getByLabelText('Weight (kg) (optional)');
+    await user.type(weight, '-999');
+
+    mockedSaveEncounter.mockRejectedValue({ status: 400, responseBody: { error: { message: 'an error message' } } });
+
+    const registerPatientButton = screen.getByText('Register Patient');
+
+    await user.click(registerPatientButton);
+
+    expect(mockedSavePatient).toHaveBeenCalledTimes(1);
+    expect(mockedSaveEncounter).toHaveBeenCalledTimes(1);
+
+    expect(mockedShowSnackbar).toHaveBeenCalledWith(expect.objectContaining({ subtitle: 'an error message' })),
+      mockedSaveEncounter.mockResolvedValue({});
+
+    await user.click(registerPatientButton);
+    expect(mockedSavePatient).toHaveBeenCalledTimes(2);
+    expect(mockedSaveEncounter).toHaveBeenCalledTimes(2);
+
+    expect(mockedShowSnackbar).toHaveBeenCalledWith(expect.objectContaining({ kind: 'success' }));
+  });
+});
+
+describe('Updating an existing patient record', () => {
+  beforeEach(() => {
+    mockedUseConfig.mockReturnValue(mockOpenmrsConfig);
+    mockedSavePatient.mockReturnValue({ data: { uuid: 'new-pt-uuid' }, ok: true });
+    mockedSaveEncounter.mockClear();
+    mockedShowSnackbar.mockClear();
+    jest.clearAllMocks();
+  });
+
+  it('edits patient demographics', async () => {
+    const user = userEvent.setup();
+
+    mockedSavePatient.mockResolvedValue({});
+
+    const mockedUseParams = useParams as jest.Mock;
+
+    mockedUseParams.mockReturnValue({ patientUuid: mockPatient.id });
+
+    mockedUsePatient.mockReturnValue({
+      isLoading: false,
+      patient: mockPatient,
+      patientUuid: mockPatient.id,
+      error: null,
     });
 
-    it('edits patient demographics', async () => {
-      const user = userEvent.setup();
+    render(
+      <ResourcesContext.Provider value={mockResourcesContextValue}>
+        <Router>
+          <PatientRegistration isOffline={false} savePatientForm={mockedSavePatient} />
+        </Router>
+      </ResourcesContext.Provider>,
+    );
 
-      mockedSavePatient.mockResolvedValue({});
+    const givenNameInput: HTMLInputElement = screen.getByLabelText(/First Name/);
+    const familyNameInput: HTMLInputElement = screen.getByLabelText(/Family Name/);
+    const middleNameInput: HTMLInputElement = screen.getByLabelText(/Middle Name/);
+    const dateOfBirthInput: HTMLInputElement = screen.getByLabelText('Date of Birth');
+    const genderInput: HTMLInputElement = screen.getByLabelText(/Male/);
 
-      const mockedUseParams = useParams as jest.Mock;
+    // assert initial values
+    expect(givenNameInput.value).toBe('John');
+    expect(familyNameInput.value).toBe('Wilson');
+    expect(middleNameInput.value).toBeFalsy();
+    expect(dateOfBirthInput.value).toBe('4/4/1972');
+    expect(genderInput.value).toBe('Male');
 
-      mockedUseParams.mockReturnValue({ patientUuid: mockPatient.id });
+    // do some edits
+    await user.clear(givenNameInput);
+    await user.clear(middleNameInput);
+    await user.clear(familyNameInput);
+    await user.type(givenNameInput, 'Eric');
+    await user.type(middleNameInput, 'Johnson');
+    await user.type(familyNameInput, 'Smith');
+    await user.click(screen.getByText('Update Patient'));
 
-      mockedUsePatient.mockReturnValue({
-        isLoading: false,
-        patient: mockPatient,
-        patientUuid: mockPatient.id,
-        error: null,
-      });
-
-      render(
-        <ResourcesContext.Provider value={mockResourcesContextValue}>
-          <Router>
-            <PatientRegistration isOffline={false} savePatientForm={mockedSavePatient} />
-          </Router>
-        </ResourcesContext.Provider>,
-      );
-
-      const givenNameInput: HTMLInputElement = screen.getByLabelText(/First Name/);
-      const familyNameInput: HTMLInputElement = screen.getByLabelText(/Family Name/);
-      const middleNameInput: HTMLInputElement = screen.getByLabelText(/Middle Name/);
-      const dateOfBirthInput: HTMLInputElement = screen.getByLabelText('Date of Birth');
-      const genderInput: HTMLInputElement = screen.getByLabelText(/Male/);
-
-      // assert initial values
-      expect(givenNameInput.value).toBe('John');
-      expect(familyNameInput.value).toBe('Wilson');
-      expect(middleNameInput.value).toBeFalsy();
-      expect(dateOfBirthInput.value).toBe('4/4/1972');
-      expect(genderInput.value).toBe('Male');
-
-      // do some edits
-      await user.clear(givenNameInput);
-      await user.clear(middleNameInput);
-      await user.clear(familyNameInput);
-      await user.type(givenNameInput, 'Eric');
-      await user.type(middleNameInput, 'Johnson');
-      await user.type(familyNameInput, 'Smith');
-      await user.click(screen.getByText('Update Patient'));
-
-      await waitFor(() =>
-        expect(mockedSavePatient).toHaveBeenCalledWith(
-          false,
-          {
-            '0': {
-              oldIdentificationNumber: '100732HE',
-            },
-            '1': {
-              openMrsId: '100GEJ',
-            },
-            addNameInLocalLanguage: undefined,
-            additionalFamilyName: '',
-            additionalGivenName: '',
-            additionalMiddleName: '',
-            address: {},
-            birthdate: new Date('1972-04-04T00:00:00.000Z'),
-            birthdateEstimated: false,
-            deathCause: '',
-            deathDate: '',
-            familyName: 'Smith',
-            gender: 'Male',
-            givenName: 'Eric',
-            identifiers: {},
-            isDead: false,
-            middleName: 'Johnson',
-            monthsEstimated: 0,
-            patientUuid: '8673ee4f-e2ab-4077-ba55-4980f408773e',
-            relationships: [],
-            telephoneNumber: '',
-            unidentifiedPatient: undefined,
-            yearsEstimated: 0,
-          },
-          expect.anything(),
-          expect.anything(),
-          null,
-          undefined,
-          expect.anything(),
-          expect.anything(),
-          expect.anything(),
-          { patientSaved: false },
-          expect.anything(),
-        ),
-      );
-    });
+    expect(mockedSavePatient).toHaveBeenCalledWith(
+      false,
+      {
+        '0': {
+          oldIdentificationNumber: '100732HE',
+        },
+        '1': {
+          openMrsId: '100GEJ',
+        },
+        addNameInLocalLanguage: undefined,
+        additionalFamilyName: '',
+        additionalGivenName: '',
+        additionalMiddleName: '',
+        address: {},
+        birthdate: new Date('1972-04-04T00:00:00.000Z'),
+        birthdateEstimated: false,
+        deathCause: '',
+        deathDate: '',
+        familyName: 'Smith',
+        gender: 'Male',
+        givenName: 'Eric',
+        identifiers: {},
+        isDead: false,
+        middleName: 'Johnson',
+        monthsEstimated: 0,
+        patientUuid: '8673ee4f-e2ab-4077-ba55-4980f408773e',
+        relationships: [],
+        telephoneNumber: '',
+        unidentifiedPatient: undefined,
+        yearsEstimated: 0,
+      },
+      expect.anything(),
+      expect.anything(),
+      null,
+      undefined,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      { patientSaved: false },
+      expect.anything(),
+    );
   });
 });

--- a/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.test.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { screen, render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { screen, render } from '@testing-library/react';
 import CancelPatientEdit from './cancel-patient-edit.component';
 
 describe('CancelPatientEdit component', () => {
@@ -10,15 +11,17 @@ describe('CancelPatientEdit component', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the modal and triggers close and onConfirm functions', () => {
+  it('renders the modal and triggers close and onConfirm functions', async () => {
+    const user = userEvent.setup();
+
     render(<CancelPatientEdit close={mockClose} onConfirm={mockOnConfirm} />);
 
     const cancelButton = screen.getByRole('button', { name: /Cancel/i });
-    fireEvent.click(cancelButton);
+    await user.click(cancelButton);
     expect(mockClose).toHaveBeenCalledTimes(1);
 
     const discardButton = screen.getByRole('button', { name: /discard/i });
-    fireEvent.click(discardButton);
+    await user.click(discardButton);
     expect(mockOnConfirm).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/esm-patient-registration-app/src/widgets/delete-identifier-confirmation-modal.test.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/delete-identifier-confirmation-modal.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import DeleteIdentifierConfirmationModal from './delete-identifier-confirmation-modal';
 
 describe('DeleteIdentifierConfirmationModal component', () => {
@@ -11,7 +12,9 @@ describe('DeleteIdentifierConfirmationModal component', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the modal and triggers deleteIdentifier function', () => {
+  it('renders the modal and triggers deleteIdentifier function', async () => {
+    const user = userEvent.setup();
+
     render(
       <DeleteIdentifierConfirmationModal
         deleteIdentifier={mockDeleteIdentifier}
@@ -21,11 +24,11 @@ describe('DeleteIdentifierConfirmationModal component', () => {
     );
 
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
-    fireEvent.click(cancelButton);
+    await user.click(cancelButton);
     expect(mockDeleteIdentifier).toHaveBeenCalledWith(false);
 
     const removeButton = screen.getByRole('button', { name: /remove identifier/i });
-    fireEvent.click(removeButton);
+    await user.click(removeButton);
     expect(mockDeleteIdentifier).toHaveBeenCalledWith(true);
   });
 });

--- a/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.test.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/edit-patient-details-button.test.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import EditPatientDetailsButton from './edit-patient-details-button.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { navigate } from '@openmrs/esm-framework';
 import { mockPatient } from '../../../../__mocks__/appointments.mock';
+import EditPatientDetailsButton from './edit-patient-details-button.component';
 
 describe('EditPatientDetailsButton', () => {
   const patientUuid = mockPatient.uuid;
-  it('should navigate to the edit page when clicked', () => {
+
+  it('should navigate to the edit page when clicked', async () => {
+    const user = userEvent.setup();
     const mockNavigate = navigate as jest.Mock;
 
     jest.mock('@openmrs/esm-framework', () => {
@@ -19,17 +22,19 @@ describe('EditPatientDetailsButton', () => {
     render(<EditPatientDetailsButton patientUuid={patientUuid} />);
 
     const button = screen.getByRole('menuitem');
-    fireEvent.click(button);
+    await user.click(button);
 
     expect(mockNavigate).toHaveBeenCalledWith({ to: expect.stringContaining(`/patient/${patientUuid}/edit`) });
   });
 
-  it('should call the onTransition function when provided', () => {
+  it('should call the onTransition function when provided', async () => {
+    const user = userEvent.setup();
+
     const onTransitionMock = jest.fn();
     render(<EditPatientDetailsButton patientUuid={patientUuid} onTransition={onTransitionMock} />);
 
     const button = screen.getByRole('menuitem');
-    fireEvent.click(button);
+    await user.click(button);
 
     expect(onTransitionMock).toHaveBeenCalled();
   });

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import PatientSearchResults from './compact-patient-banner.component';
 import { useConfig } from '@openmrs/esm-framework';
@@ -43,11 +44,12 @@ describe('Compact Patient Search Results', () => {
   });
 
   // Fix this test later
-  // it('should call selectPatientAction when a patient is clicked', () => {
+  // const user = userEvent.setup();
+  // it('should call selectPatientAction when a patient is clicked', async () => {
   //   const selectPatientActionMock = jest.fn();
   //   render(<PatientSearchResults patients={patients} selectPatientAction={selectPatientActionMock} />);
 
-  //   fireEvent.click(screen.getByText('John Doe Smith'));
+  //   user.click(screen.getByText('John Doe Smith'));
   //   expect(selectPatientActionMock).toBeCalledWith(patients[0]);
   // });
 });

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CompactPatientSearchComponent from './compact-patient-search.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -25,50 +26,46 @@ describe('CompactPatientSearchComponent', () => {
   });
 
   it('updates search term on input change', async () => {
+    const user = userEvent.setup();
     render(<CompactPatientSearchComponent isSearchPage={true} initialSearchTerm="" />);
     const searchInput: HTMLInputElement = screen.getByRole('searchbox');
 
-    fireEvent.change(searchInput, { target: { value: 'John' } });
+    await user.type(searchInput, 'John');
 
-    await waitFor(() => {
-      expect(searchInput.value).toBe('John');
-    });
+    expect(searchInput.value).toBe('John');
   });
 
   it('clears search term on clear button click', async () => {
+    const user = userEvent.setup();
     render(<CompactPatientSearchComponent isSearchPage={true} initialSearchTerm="" />);
     const searchInput: HTMLInputElement = screen.getByRole('searchbox');
     const clearButton = screen.getByRole('button', { name: 'Clear' });
 
-    fireEvent.change(searchInput, { target: { value: 'John' } });
-    fireEvent.click(clearButton);
+    await user.type(searchInput, 'John');
+    await user.click(clearButton);
 
-    await waitFor(() => {
-      expect(searchInput.value).toBe('');
-    });
+    expect(searchInput.value).toBe('');
   });
 
   it('renders search results when search term is not empty', async () => {
+    const user = userEvent.setup();
     render(<CompactPatientSearchComponent isSearchPage={false} initialSearchTerm="" />);
     const searchInput = screen.getByRole('searchbox');
 
-    fireEvent.change(searchInput, { target: { value: 'John' } });
+    await user.type(searchInput, 'John');
 
-    await waitFor(() => {
-      const searchResultsContainer = screen.getByTestId('floatingSearchResultsContainer');
-      expect(searchResultsContainer).toBeInTheDocument();
-    });
+    const searchResultsContainer = screen.getByTestId('floatingSearchResultsContainer');
+    expect(searchResultsContainer).toBeInTheDocument();
   });
 
-  it('renders recent patient search when search term is empty', async () => {
+  it('renders a list of recently searched patients when a search term is not provided', async () => {
+    const user = userEvent.setup();
     render(<CompactPatientSearchComponent isSearchPage={false} initialSearchTerm="" />);
     const searchInput = screen.getByRole('searchbox');
 
-    fireEvent.change(searchInput, { target: { value: '' } });
+    await user.clear(searchInput);
 
-    await waitFor(() => {
-      const searchResultsContainer = screen.getByTestId('floatingSearchResultsContainer');
-      expect(searchResultsContainer).toBeInTheDocument();
-    });
+    const searchResultsContainer = screen.getByTestId('floatingSearchResultsContainer');
+    expect(searchResultsContainer).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import PatientSearchBar from './patient-search-bar.component';
 
 describe('PatientSearchBar', () => {
@@ -22,37 +23,43 @@ describe('PatientSearchBar', () => {
     expect(searchInput.value).toBe(initialSearchTerm);
   });
 
-  it('calls onChange callback on input change', () => {
+  it('calls onChange callback on input change', async () => {
+    const user = userEvent.setup();
     const onChangeMock = jest.fn();
+
     render(<PatientSearchBar onChange={onChangeMock} onClear={jest.fn()} onSubmit={jest.fn()} />);
 
     const searchInput = screen.getByPlaceholderText('Search for a patient by name or identifier number');
 
-    fireEvent.change(searchInput, { target: { value: 'New Value' } });
+    await user.type(searchInput, 'New Value');
 
     expect(onChangeMock).toHaveBeenCalledWith('New Value');
   });
 
-  it('calls onClear callback on clear button click', () => {
+  it('calls onClear callback on clear button click', async () => {
+    const user = userEvent.setup();
     const onClearMock = jest.fn();
+
     render(<PatientSearchBar onClear={onClearMock} onSubmit={jest.fn()} />);
 
     const clearButton = screen.getByRole('button', { name: 'Clear' });
 
-    fireEvent.click(clearButton);
+    await user.click(clearButton);
 
     expect(onClearMock).toHaveBeenCalled();
   });
 
-  it('calls onSubmit callback on form submission', () => {
+  it('calls onSubmit callback on form submission', async () => {
+    const user = userEvent.setup();
     const onSubmitMock = jest.fn();
+
     render(<PatientSearchBar onSubmit={onSubmitMock} onClear={jest.fn()} />);
 
     const searchInput = screen.getByPlaceholderText('Search for a patient by name or identifier number');
     const searchButton = screen.getByRole('button', { name: 'Search' });
 
-    fireEvent.change(searchInput, { target: { value: 'Search Term' } });
-    fireEvent.click(searchButton);
+    await user.type(searchInput, 'Search Term');
+    await user.click(searchButton);
 
     expect(onSubmitMock).toHaveBeenCalledWith('Search Term');
   });

--- a/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import PatientSearchButton from './patient-search-button.component';
 
 describe('PatientSearchButton', () => {
@@ -19,12 +20,14 @@ describe('PatientSearchButton', () => {
     expect(customButton).toBeInTheDocument();
   });
 
-  it('displays overlay when button is clicked', () => {
+  it('displays overlay when button is clicked', async () => {
+    const user = userEvent.setup();
+
     render(<PatientSearchButton />);
 
     const searchButton = screen.getByLabelText('Search Patient Button');
 
-    fireEvent.click(searchButton);
+    await user.click(searchButton);
 
     const overlayHeader = screen.getByText('Search results');
 

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import PatientSearchLaunch from './patient-search-icon.component';
 import { isDesktop } from '@openmrs/esm-framework';
 
@@ -30,24 +31,30 @@ describe('PatientSearchLaunch', () => {
     expect(screen.getByRole('button', { name: 'Search Patient' })).toBeInTheDocument();
   });
 
-  it('toggles search input when search button is clicked', () => {
+  it('toggles search input when search button is clicked', async () => {
+    const user = userEvent.setup();
+
     render(<PatientSearchLaunch />);
+
     const searchButton = screen.getByTestId('searchPatientIcon');
 
-    fireEvent.click(searchButton);
+    await user.click(searchButton);
     const searchInput = screen.getByText('Search results');
     expect(searchInput).toBeInTheDocument();
 
-    fireEvent.click(searchButton);
+    await user.click(searchButton);
     expect(searchInput).not.toBeInTheDocument();
   });
 
-  it('displays search input in overlay on mobile', () => {
+  it('displays search input in overlay on mobile', async () => {
+    const user = userEvent.setup();
     isDesktopMock.mockReturnValue(false);
+
     render(<PatientSearchLaunch />);
+
     const searchButton = screen.getByTestId('searchPatientIcon');
 
-    fireEvent.click(searchButton);
+    await user.click(searchButton);
     const overlay = screen.getByText('Search results');
     expect(overlay).toBeInTheDocument();
   });

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/ui-components/overflow-menu.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import CustomOverflowMenuComponent from './overflow-menu.component';
 
 describe('CustomOverflowMenuComponent', () => {
@@ -8,7 +9,9 @@ describe('CustomOverflowMenuComponent', () => {
     expect(screen.getByRole('button', { name: 'Test Menu' })).toBeInTheDocument();
   });
 
-  it('should toggle menu on trigger button click', () => {
+  it('should toggle menu on trigger button click', async () => {
+    const user = userEvent.setup();
+
     render(
       <CustomOverflowMenuComponent menuTitle="Menu" dropDownMenu={false}>
         <li>Option 1</li>
@@ -18,10 +21,10 @@ describe('CustomOverflowMenuComponent', () => {
 
     const triggerButton = screen.getByRole('button', { name: /menu/i });
 
-    fireEvent.click(triggerButton);
+    await user.click(triggerButton);
     expect(triggerButton.getAttribute('aria-expanded')).toBe('true');
 
-    fireEvent.click(triggerButton);
+    await user.click(triggerButton);
     expect(triggerButton.getAttribute('aria-expanded')).toBe('false');
   });
 });

--- a/packages/esm-patient-search-app/src/ui-components/pagination/pagination.test.tsx
+++ b/packages/esm-patient-search-app/src/ui-components/pagination/pagination.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import Pagination from './pagination.component';
 
 describe('Pagination', () => {
@@ -15,46 +15,58 @@ describe('Pagination', () => {
 
   it('should disable previous button on first page', () => {
     render(<Pagination totalPages={5} currentPage={1} setCurrentPage={() => {}} hasMore={true} />);
+
     const previousButton = screen.getByLabelText(/previous page/i);
     expect(previousButton).toBeDisabled();
   });
 
   it('should disable next button on last page when hasMore is false', () => {
     render(<Pagination totalPages={5} currentPage={5} setCurrentPage={() => {}} hasMore={false} />);
+
     const nextButton = screen.getByLabelText(/next page/i);
     expect(nextButton).toBeDisabled();
   });
 
-  it('should increment the page when next button is clicked', () => {
+  it('should increment the page when next button is clicked', async () => {
+    const user = userEvent.setup();
     const setCurrentPageMock = jest.fn();
+
     render(<Pagination totalPages={5} currentPage={1} setCurrentPage={setCurrentPageMock} hasMore={true} />);
 
     const nextButton = screen.getByLabelText(/next page/i);
-    fireEvent.click(nextButton);
+
+    await user.click(nextButton);
     expect(setCurrentPageMock).toHaveBeenCalledWith(2);
   });
 
-  it('should decrement the page when previous button is clicked', () => {
+  it('should decrement the page when previous button is clicked', async () => {
+    const user = userEvent.setup();
     const setCurrentPageMock = jest.fn();
+
     render(<Pagination totalPages={5} currentPage={3} setCurrentPage={setCurrentPageMock} hasMore={true} />);
 
     const previousButton = screen.getByLabelText(/previous page/i);
-    fireEvent.click(previousButton);
+
+    await user.click(previousButton);
     expect(setCurrentPageMock).toHaveBeenCalledWith(2);
   });
 
-  it('should call setCurrentPage when page button is clicked', () => {
+  it('should call setCurrentPage when page button is clicked', async () => {
+    const user = userEvent.setup();
     const setCurrentPageMock = jest.fn();
+
     render(<Pagination totalPages={5} currentPage={3} setCurrentPage={setCurrentPageMock} hasMore={true} />);
 
     const pageButton = screen.getByRole('button', { name: '4' });
-    fireEvent.click(pageButton);
+    await user.click(pageButton);
     expect(setCurrentPageMock).toHaveBeenCalledWith(4);
   });
 
   it('should render empty component when totalPages is 1', () => {
     render(<Pagination totalPages={1} currentPage={1} setCurrentPage={() => {}} hasMore={true} />);
+
     const pagination = screen.queryByRole('button', { name: 'next page' });
+
     expect(pagination).not.toBeInTheDocument();
   });
 });

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.test.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { ConfigObject, useConfig, usePagination, useSession } from '@openmrs/esm-framework';
 import { of } from 'rxjs';
 import { renderWithSwr } from '../../../../tools/test-helpers';
@@ -103,7 +103,7 @@ describe('ActiveVisitsTable: ', () => {
 
     renderActiveVisitsTable();
 
-    await waitFor(() => screen.getByRole('table'));
+    await screen.findByRole('table');
 
     expect(screen.getByText(/patients currently in queue/i)).toBeInTheDocument();
     expect(screen.queryByText(/no patients to display/i)).not.toBeInTheDocument();

--- a/packages/esm-service-queues-app/src/active-visits/change-status-dialog.test.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/change-status-dialog.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { screen, render, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { screen, render, within } from '@testing-library/react';
 import { mockServices } from '../../__mocks__/active-visits.mock';
 import { mockPriorities, mockStatus } from '../../../../__mocks__/metrics.mock';
 import { mockSession } from '../../../../__mocks__/session.mock';
 import { mockLocations } from '../../../../__mocks__/locations.mock';
 import { ConfigObject, showToast, useConfig, showNotification } from '@openmrs/esm-framework';
-import ChangeStatus from './change-status-dialog.component';
 import { mockQueueEntry } from '../../../../__mocks__/queue-entry.mock';
-import userEvent from '@testing-library/user-event';
 import { updateQueueEntry } from './active-visits-table.resource';
+import ChangeStatus from './change-status-dialog.component';
 
 const mockedUseConfig = useConfig as jest.Mock;
 const mockShowToast = showToast as jest.Mock;
@@ -61,7 +61,7 @@ describe('Queue entry details', () => {
     expect(screen.getByText(/queue service/i)).toBeInTheDocument();
     expect(screen.getByText(/queue priority/i)).toBeInTheDocument();
 
-    await waitFor(() => user.click(screen.getByRole('button', { name: /move to next service/i })));
+    await user.click(screen.getByRole('button', { name: /move to next service/i }));
 
     expect(mockShowToast).toHaveBeenCalledTimes(1);
     expect(mockShowToast).toHaveBeenCalledWith({
@@ -93,7 +93,7 @@ describe('Queue entry details', () => {
     expect(within(queueServiceTypes).getAllByRole('option')[0]).toHaveValue('176052c7-5fd4-4b33-89cc-7bae6848c65a');
     expect(within(queueServiceTypes).getAllByRole('option')[1]).toHaveValue('d80ff12a-06a7-11ed-b939-0242ac120002');
 
-    await waitFor(() => user.click(screen.getByRole('button', { name: /move to next service/i })));
+    await user.click(screen.getByRole('button', { name: /move to next service/i }));
 
     expect(mockShowNotification).toHaveBeenCalledWith({
       description: 'Internal Server Error',

--- a/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.test.tsx
+++ b/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import AddProviderQueueRoom from './add-provider-queue-room.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { showSnackbar } from '@openmrs/esm-framework';
+import AddProviderQueueRoom from './add-provider-queue-room.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
@@ -61,37 +62,39 @@ describe('AddProviderQueueRoom', () => {
     expect(screen.getByText('Save')).toBeInTheDocument();
   });
 
-  it('updates queue room selection', () => {
+  it('updates the queue room selection', async () => {
+    const user = userEvent.setup();
     render(<AddProviderQueueRoom providerUuid={providerUuid} closeModal={jest.fn()} />);
 
     const selectQueueRoom: HTMLInputElement = screen.getByRole('combobox');
-    fireEvent.change(selectQueueRoom, { target: { value: 'room-uuid-1' } });
+    await user.selectOptions(selectQueueRoom, 'Room 1');
 
     expect(selectQueueRoom.value).toBe('6b3e233d-2b44-40ca-b0c8-c5a57a8c51b6');
   });
 
-  it('should update the retain location checkbox', () => {
+  it('should update the retain location checkbox', async () => {
+    const user = userEvent.setup();
     render(<AddProviderQueueRoom providerUuid={providerUuid} closeModal={jest.fn()} />);
 
     const retainLocationCheckbox: HTMLInputElement = screen.getByRole('checkbox');
-    fireEvent.click(retainLocationCheckbox);
+    await user.click(retainLocationCheckbox);
 
     expect(retainLocationCheckbox.checked).toBe(true);
   });
 
   it('should submit the form and add provider to queue room when all fields are filled', async () => {
+    const user = userEvent.setup();
     const mockCloseModal = jest.fn();
+
     render(<AddProviderQueueRoom providerUuid={providerUuid} closeModal={mockCloseModal} />);
 
     const queueRoomSelect = screen.getByRole('combobox');
     const submitButton = screen.getByText('Save');
 
-    fireEvent.change(queueRoomSelect, { target: { value: '6b3e233d-2b44-40ca-b0c8-c5a57a8c51b6' } });
-    fireEvent.click(submitButton);
+    await user.selectOptions(queueRoomSelect, '6b3e233d-2b44-40ca-b0c8-c5a57a8c51b6');
+    await user.click(submitButton);
 
-    await waitFor(() => {
-      expect(mockCloseModal).toHaveBeenCalled();
-      expect(showSnackbar).toHaveBeenCalled();
-    });
+    expect(mockCloseModal).toHaveBeenCalled();
+    expect(showSnackbar).toHaveBeenCalled();
   });
 });

--- a/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.test.tsx
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import ClearQueueEntriesDialog from './clear-queue-entries-dialog.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { batchClearQueueEntries } from './clear-queue-entries-dialog.resource';
+import ClearQueueEntriesDialog from './clear-queue-entries-dialog.component';
 
 const mockBatchClearQueueEntries = batchClearQueueEntries as jest.Mock;
 
@@ -31,11 +32,13 @@ describe('ClearQueueEntriesDialog Component', () => {
   });
 
   it('should close modal when clicked on cancel', async () => {
+    const user = userEvent.setup();
     const closeModalMock = jest.fn();
+
     mockBatchClearQueueEntries.mockImplementationOnce(() => Promise.resolve());
     render(<ClearQueueEntriesDialog visitQueueEntries={visitQueueEntriesMock} closeModal={closeModalMock} />);
 
-    fireEvent.click(screen.getByText('Cancel'));
+    await user.click(screen.getByText('Cancel'));
 
     expect(closeModalMock).toHaveBeenCalled();
   });

--- a/packages/esm-service-queues-app/src/current-visit/current-visit-summary.test.tsx
+++ b/packages/esm-service-queues-app/src/current-visit/current-visit-summary.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import CurrentVisit from './current-visit-summary.component';
+import { render, screen } from '@testing-library/react';
 import { useVisit } from './current-visit.resource';
 import { mockPastVisit } from '../../__mocks__/visits.mock';
+import CurrentVisit from './current-visit-summary.component';
 
 const useVisitMock = useVisit as jest.Mock;
 
@@ -24,12 +24,10 @@ describe('CurrentVisit', () => {
   it('renders visit details correctly', async () => {
     render(<CurrentVisit patientUuid={patientUuid} visitUuid={visitUuid} />);
 
-    await waitFor(() => {
-      expect(screen.queryByRole('progressbar')).toBeNull();
-      expect(screen.getByText('Visit Type')).toBeInTheDocument();
-      expect(screen.getByText('Scheduled for today')).toBeInTheDocument();
-      expect(screen.getByText('On time')).toBeInTheDocument();
-    });
+    expect(screen.queryByRole('progressbar')).toBeNull();
+    expect(screen.getByText('Visit Type')).toBeInTheDocument();
+    expect(screen.getByText('Scheduled for today')).toBeInTheDocument();
+    expect(screen.getByText('On time')).toBeInTheDocument();
   });
   it('should render skeleton when loading', async () => {
     useVisitMock.mockImplementationOnce(() => ({
@@ -40,8 +38,6 @@ describe('CurrentVisit', () => {
 
     render(<CurrentVisit patientUuid={patientUuid} visitUuid={visitUuid} />);
 
-    await waitFor(() => {
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
-    });
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 });

--- a/packages/esm-service-queues-app/src/overlay.test.tsx
+++ b/packages/esm-service-queues-app/src/overlay.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import Overlay from './overlay.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { useLayoutType, isDesktop } from '@openmrs/esm-framework';
+import Overlay from './overlay.component';
 
 const mockUseLayoutType = useLayoutType as jest.Mock;
 const mockIsDesktop = isDesktop as jest.Mock;
@@ -11,7 +12,8 @@ jest.mock('@openmrs/esm-framework');
 const headerText = 'Test Header';
 
 describe('Overlay Component', () => {
-  it('renders desktop layout with close button', () => {
+  it('renders desktop layout with close button', async () => {
+    const user = userEvent.setup();
     const closePanelMock = jest.fn();
 
     mockIsDesktop.mockImplementation(() => true);
@@ -24,7 +26,7 @@ describe('Overlay Component', () => {
     expect(headerContent).toBeInTheDocument();
     expect(closeButton).toBeInTheDocument();
 
-    fireEvent.click(closeButton);
+    await user.click(closeButton);
     expect(closePanelMock).toHaveBeenCalled();
   });
 

--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.test.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import StartVisitQueueFields from './visit-form-queue-fields.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -46,20 +47,22 @@ describe('StartVisitQueueFields', () => {
     expect(getByLabelText('Sort weight')).toBeInTheDocument();
   });
 
-  it('updates the selected queue location', () => {
+  it('updates the selected queue location', async () => {
+    const user = userEvent.setup();
     const { getByLabelText } = render(<StartVisitQueueFields />);
 
     const selectQueueLocation = getByLabelText('Select a queue location') as HTMLInputElement;
-    fireEvent.change(selectQueueLocation, { target: { value: '1' } });
+    await user.type(selectQueueLocation, '1');
 
     expect(selectQueueLocation.value).toBe('1');
   });
 
-  it('updates the selected service', () => {
+  it('updates the selected service', async () => {
+    const user = userEvent.setup();
     const { getByLabelText } = render(<StartVisitQueueFields />);
 
     const selectService = getByLabelText('Select a service') as HTMLInputElement;
-    fireEvent.change(selectService, { target: { value: 'service-1' } });
+    await user.type(selectService, 'service-1');
 
     expect(selectService.value).toBe('e2ec9cf0-ec38-4d2b-af6c-59c82fa30b90');
   });

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/base-visit-type.test.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/base-visit-type.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import BaseVisitType from './base-visit-type.component';
+import { render, screen } from '@testing-library/react';
 import { mockVisitTypes } from '../../../__mocks__/visits.mock';
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -21,21 +22,25 @@ describe('BaseVisitType', () => {
     });
   });
 
-  it('handles search input correctly', () => {
+  it('handles search input correctly', async () => {
+    const user = userEvent.setup();
+
     render(<BaseVisitType onChange={() => {}} visitTypes={mockVisitTypes} />);
 
     const searchInput: HTMLInputElement = screen.getByRole('searchbox');
-    fireEvent.change(searchInput, { target: { value: 'Visit Type 1' } });
+    await user.type(searchInput, 'Visit Type 1');
 
     expect(searchInput.value).toBe('Visit Type 1');
   });
 
-  it('calls onChange when a visit type is selected', () => {
+  it('calls onChange when a visit type is selected', async () => {
+    const user = userEvent.setup();
+
     const mockOnChange = jest.fn();
     render(<BaseVisitType onChange={mockOnChange} visitTypes={mockVisitTypes} />);
 
     const radioButton: HTMLInputElement = screen.getByLabelText(mockVisitTypes[0].display);
-    fireEvent.click(radioButton);
+    await user.click(radioButton);
     expect(radioButton.checked).toBe(true);
   });
 });

--- a/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist-filter.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist-filter.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import QueueLinelistFilter from './queue-linelist-filter.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { mockVisitTypes } from '../../__mocks__/visits.mock';
+import QueueLinelistFilter from './queue-linelist-filter.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
@@ -9,7 +10,6 @@ jest.mock('@openmrs/esm-framework', () => ({
   useVisitTypes: jest.fn(() => mockVisitTypes),
   toOpemrsIsoString: jest.fn(),
 }));
-// Additional mock functions if needed
 
 describe('QueueLinelistFilter', () => {
   it('renders the form with filter elements', () => {
@@ -26,50 +26,62 @@ describe('QueueLinelistFilter', () => {
     expect(screen.getByText('Apply filters')).toBeInTheDocument();
   });
 
-  it('calls closePanel function when cancel button is clicked', () => {
+  it('calls closePanel function when cancel button is clicked', async () => {
+    const user = userEvent.setup();
     const closePanelMock = jest.fn();
+
     render(<QueueLinelistFilter closePanel={closePanelMock} />);
 
     const cancelButton = screen.getByText('Cancel');
-    fireEvent.click(cancelButton);
+    await user.click(cancelButton);
 
     expect(closePanelMock).toHaveBeenCalledTimes(1);
   });
 
-  it('updates gender state when a radio button is selected', () => {
+  it('updates gender state when a radio button is selected', async () => {
+    const user = userEvent.setup();
+
     render(<QueueLinelistFilter closePanel={jest.fn()} />);
 
     const maleRadioButton = screen.getByLabelText('Male');
-    fireEvent.click(maleRadioButton);
+    await user.click(maleRadioButton);
 
     expect(maleRadioButton).toBeChecked();
   });
 
-  it('updates startAge state when a number is entered', () => {
+  it('updates startAge state when a number is entered', async () => {
+    const user = userEvent.setup();
     render(<QueueLinelistFilter closePanel={jest.fn()} />);
 
     const startAgeInput = screen.getByLabelText('Between');
-    fireEvent.change(startAgeInput, { target: { value: '10' } });
+    await user.type(startAgeInput, '10');
 
     expect(startAgeInput).toHaveValue(10);
   });
 
-  it('updates returnDate state when date input changes', () => {
+  it('updates returnDate state when date input changes', async () => {
+    const user = userEvent.setup();
+
     render(<QueueLinelistFilter closePanel={jest.fn()} />);
 
     const returnDateInput = screen.getByLabelText('Date');
-    fireEvent.change(returnDateInput, { target: { value: '2023-08-20' } });
+
+    await user.clear(returnDateInput);
+    await user.type(returnDateInput, '2023-08-20');
 
     expect(returnDateInput).toHaveValue('2023-08-20');
   });
 
-  it('should open the visit type dropdown and close after selection', () => {
+  it('should open the visit type dropdown and close after selection', async () => {
+    const user = userEvent.setup();
+
     render(<QueueLinelistFilter closePanel={jest.fn()} />);
 
     const visitTypeDropdown = screen.getByRole('button', { name: /Select visit type/i });
-    fireEvent.click(visitTypeDropdown);
+    await user.click(visitTypeDropdown);
+
     const type1Option = screen.getByText('Outpatient Visit');
-    fireEvent.click(type1Option);
+    await user.click(type1Option);
 
     expect(visitTypeDropdown).toHaveTextContent('Open menu');
   });

--- a/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import QueueLinelist from './queue-linelist.component';
 
 describe('QueueLinelist', () => {
@@ -10,11 +11,13 @@ describe('QueueLinelist', () => {
     expect(filterContent).toBeInTheDocument();
   });
 
-  it('toggles between filter content and null', () => {
+  it('toggles between filter content and null', async () => {
+    const user = userEvent.setup();
+
     render(<QueueLinelist closePanel={jest.fn()} />);
 
     const closeButton = screen.getByText('Close overlay');
-    fireEvent.click(closeButton);
+    await user.click(closeButton);
 
     const filterContent = screen.queryByTestId('filter-content');
     expect(filterContent).not.toBeInTheDocument();

--- a/packages/esm-service-queues-app/src/queue-patient-linelists/scheduled-appointments-table.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/scheduled-appointments-table.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import AppointmentsTable from './scheduled-appointments-table.component';
 import { mockAppointmentsData } from '../../__mocks__/appointments-data.mock';
 
@@ -30,11 +31,14 @@ describe('AppointmentsTable', () => {
     expect(appointmentName).toBeInTheDocument();
   });
 
-  it('filters appointments based on status selection', () => {
+  it('filters appointments based on status selection', async () => {
+    const user = userEvent.setup();
+
     render(<AppointmentsTable />);
 
     const statusDropdown = screen.getAllByLabelText('Status:');
-    fireEvent.change(statusDropdown[0], { target: { value: 'Completed' } });
+
+    await user.type(statusDropdown[0], 'Completed');
 
     const filteredAppointmentName = screen.getByText('Hungai Kevin');
     expect(filteredAppointmentName).toBeInTheDocument();

--- a/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import QueueRoomForm from './queue-room-form.component';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { mockServices } from '../../__mocks__/active-visits.mock';
+import QueueRoomForm from './queue-room-form.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
@@ -28,37 +29,47 @@ describe('QueueRoomForm', () => {
     expect(screen.getByText('Save')).toBeInTheDocument();
   });
 
-  it('displays error notification if queue room name is missing on submission', () => {
+  it('displays error notification if queue room name is missing on submission', async () => {
+    const user = userEvent.setup();
+
     render(<QueueRoomForm toggleSearchType={jest.fn()} closePanel={jest.fn()} />);
 
-    fireEvent.click(screen.getByText('Save'));
+    await user.click(screen.getByText('Save'));
 
     expect(screen.getByText('Missing queue room name')).toBeInTheDocument();
   });
 
-  it('displays error notification if queue room service is missing on submission', () => {
+  it('displays error notification if queue room service is missing on submission', async () => {
+    const user = userEvent.setup();
+
     render(<QueueRoomForm toggleSearchType={jest.fn()} closePanel={jest.fn()} />);
 
-    fireEvent.change(screen.getByLabelText('Queue room name'), { target: { value: 'Room 123' } });
-    fireEvent.click(screen.getByText('Save'));
+    const queueRoomNameInput = screen.getByLabelText('Queue room name');
+
+    await user.type(queueRoomNameInput, 'Room 123');
+    await user.click(screen.getByText('Save'));
 
     expect(screen.getByText('Missing queue room service')).toBeInTheDocument();
   });
 
-  it('calls closePanel when Cancel button is clicked', () => {
+  it('calls closePanel when Cancel button is clicked', async () => {
+    const user = userEvent.setup();
+
     const closePanelMock = jest.fn();
     render(<QueueRoomForm toggleSearchType={jest.fn()} closePanel={closePanelMock} />);
 
-    fireEvent.click(screen.getByText('Cancel'));
+    await user.click(screen.getByText('Cancel'));
 
     expect(closePanelMock).toHaveBeenCalledTimes(1);
   });
 
-  it('updates queue room name state when a value is entered', () => {
+  it('updates queue room name state when a value is entered', async () => {
+    const user = userEvent.setup();
+
     render(<QueueRoomForm toggleSearchType={jest.fn()} closePanel={jest.fn()} />);
 
     const queueRoomNameInput = screen.getByLabelText('Queue room name');
-    fireEvent.change(queueRoomNameInput, { target: { value: 'Room 123' } });
+    await user.type(queueRoomNameInput, 'Room 123');
 
     expect(queueRoomNameInput).toHaveValue('Room 123');
   });

--- a/packages/esm-service-queues-app/src/queue-services/queue-service-form.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-services/queue-service-form.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import QueueServiceForm from './queue-service-form.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -28,25 +29,29 @@ jest.mock('../patient-search/hooks/useQueueLocations', () => ({
 
 describe('QueueServiceForm', () => {
   it('should display required error messages when form is submitted with missing fields', async () => {
+    const user = userEvent.setup();
+
     render(<QueueServiceForm toggleSearchType={() => {}} closePanel={() => {}} />);
 
     const submitButton = screen.getByText('Save');
 
-    fireEvent.click(submitButton);
+    await user.click(submitButton);
 
     expect(screen.getByText('Missing queue name')).toBeInTheDocument();
   });
 
   it('should submit the form when all fields are filled', async () => {
+    const user = userEvent.setup();
+
     render(<QueueServiceForm toggleSearchType={() => {}} closePanel={() => {}} />);
 
     const queueNameInput = screen.getByLabelText('Queue name');
     const serviceSelect = screen.getByLabelText('Select a service type');
     const locationSelect = screen.getByLabelText('Select a location');
 
-    fireEvent.change(queueNameInput, { target: { value: 'Test Queue' } });
-    fireEvent.change(serviceSelect, { target: { value: '6f017eb0-b035-4acd-b284-da45f5067502' } });
-    fireEvent.change(locationSelect, { target: { value: '34567eb0-b035-4acd-b284-da45f5067502' } });
+    await user.type(queueNameInput, 'Test Queue');
+    await user.selectOptions(serviceSelect, '6f017eb0-b035-4acd-b284-da45f5067502');
+    await user.selectOptions(locationSelect, '34567eb0-b035-4acd-b284-da45f5067502');
 
     expect(queueNameInput).toHaveValue('Test Queue');
     expect(serviceSelect).toHaveValue('6f017eb0-b035-4acd-b284-da45f5067502');

--- a/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.test.tsx
+++ b/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import RemoveQueueEntryDialog from './remove-queue-entry.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -31,11 +32,13 @@ describe('RemoveQueueEntryDialog', () => {
     expect(screen.getByText('End visit')).toBeInTheDocument();
   });
 
-  it('calls closeModal when Cancel button is clicked', () => {
+  it('calls closeModal when Cancel button is clicked', async () => {
+    const user = userEvent.setup();
     const closeModal = jest.fn();
+
     render(<RemoveQueueEntryDialog queueEntry={queueEntry} closeModal={closeModal} />);
 
-    fireEvent.click(screen.getByText('Cancel'));
+    await user.click(screen.getByText('Cancel'));
 
     expect(closeModal).toHaveBeenCalledTimes(1);
   });

--- a/packages/esm-service-queues-app/src/transition-queue-entry/transition-queue-entry-dialog.test.tsx
+++ b/packages/esm-service-queues-app/src/transition-queue-entry/transition-queue-entry-dialog.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import TransitionQueueEntryModal from './transition-queue-entry-dialog.component';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { navigate } from '@openmrs/esm-framework';
 import { serveQueueEntry, updateQueueEntry } from '../active-visits/active-visits-table.resource';
 import { requeueQueueEntry } from './transition-queue-entry.resource';
+import TransitionQueueEntryModal from './transition-queue-entry-dialog.component';
 
 const mockedNavigate = navigate as jest.Mock;
 
@@ -70,26 +71,26 @@ describe('TransitionQueueEntryModal', () => {
   });
 
   it('handles requeueing patient', async () => {
+    const user = userEvent.setup();
+
     const closeModal = jest.fn();
     render(<TransitionQueueEntryModal queueEntry={queueEntry} closeModal={closeModal} />);
 
-    fireEvent.click(screen.getByText('Requeue'));
+    await user.click(screen.getByText('Requeue'));
 
-    await waitFor(() => {
-      expect(requeueQueueEntry).toHaveBeenCalledWith('Requeued', queueEntry.queueUuid, queueEntry.queueEntryUuid);
-    });
+    expect(requeueQueueEntry).toHaveBeenCalledWith('Requeued', queueEntry.queueUuid, queueEntry.queueEntryUuid);
   });
 
   it('handles serving patient', async () => {
+    const user = userEvent.setup();
+
     const closeModal = jest.fn();
     render(<TransitionQueueEntryModal queueEntry={queueEntry} closeModal={closeModal} />);
 
-    fireEvent.click(screen.getByText('Serve'));
+    await user.click(screen.getByText('Serve'));
 
-    await waitFor(() => {
-      expect(updateQueueEntry).toHaveBeenCalled();
-      expect(serveQueueEntry).toHaveBeenCalled();
-      expect(mockedNavigate).toHaveBeenCalled();
-    });
+    expect(updateQueueEntry).toHaveBeenCalled();
+    expect(serveQueueEntry).toHaveBeenCalled();
+    expect(mockedNavigate).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

I've removed the asynchronous `waitFor` function from tests in this repo to try and fix test failures that are likely owing to its non-deterministic behaviour. `waitFor` has a default timeout of 1000ms. Cumulative delays in the tests can cause this timeout to be exceeded, resulting in a test failure. 

I've also replaced usages of `fireEvent` with `userEvent`. `userEvent` is a wrapper around `fireEvent` that simulates user behaviour more accurately. For example, `userEvent.click` will fire a `mousedown` event, followed by a `mouseup` event, followed by a `click` event. `fireEvent.click` will only fire a `click` event. Additionally, `userEvent` will wait for the DOM to update after firing an event, whereas `fireEvent` will not.

These changes aim to improve the stability and reliability of our test suite. By removing asynchronous waitFor and adopting userEvent, we make our tests less susceptible to timing-related issues, resulting in a more robust and maintainable testing process.

## Screenshots

*None*

## Related Issue

*None*

## Other

*None*

