### PR TITLE
(fix) Scheduled Appointments should keep selected sub-tab when changing dates

### DIFF
--- a/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
@@ -69,10 +69,17 @@ const ScheduledAppointments: React.FC<ScheduledAppointmentsProps> = ({ visits, a
     }
   }, [allowedExtensions, currentTab]);
 
+  const panelsToShow = scheduledAppointmentPanels.filter(shouldShowPanel);
+
   return (
     <>
-      <ContentSwitcher className={styles.switcher} size="sm" onChange={({ name }) => setCurrentTab(name)}>
-        {scheduledAppointmentPanels.filter(shouldShowPanel).map((panel) => {
+      <ContentSwitcher
+        className={styles.switcher}
+        size="sm"
+        onChange={({ name }) => setCurrentTab(name)}
+        selectedIndex={panelsToShow.findIndex((panel) => panel.name == currentTab) ?? 0}
+        selectionMode="manual">
+        {panelsToShow.map((panel) => {
           return <Switch key={`panel-${panel.name}`} name={panel.name} text={t(panel.config.title)} />;
         })}
       </ContentSwitcher>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

https://openmrs.atlassian.net/browse/O3-2558

Depending on which date is selected in the appointments app, different sub-tabs are shown:
- Past Dates: Completed, Missed, Cancelled
- Today's Date: Expected, Checked-in, Completed, Cancelled
- Future Dates: Expected, Cancelled

When switching dates, we should keep the selected sub-tab if possible. (And also make sure that the selected `<Tab>`and the corresponding `<TabPanel>` is properly shown). If the selected sub-tab is no longer available after switching dates, we default to the first sub-tab.

## Screenshots
[See Video](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/f3f5213b-62cb-4437-a4ed-03418b338553)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
