### PR TITLE
(feat) Add ability to view patients after they have paid(if using bil…

### DIFF
--- a/packages/esm-service-queues-app/src/config-schema.ts
+++ b/packages/esm-service-queues-app/src/config-schema.ts
@@ -138,6 +138,16 @@ export const configSchema = {
     _default: '',
     _description: 'Custom label for patient chart button',
   },
+  hideEntriesWithUnpaidBills: {
+    _type: Type.Boolean,
+    _description: 'Whether to use the billing module to only show patients with paid bills in the queue table`',
+    _default: true,
+  },
+  customBillinguRL: {
+    _type: Type.String,
+    _default: '/ws/rest/v1/cashier/bill?v=full',
+    _description: 'Custom URL to fetch bills',
+  },
 };
 
 export interface ConfigObject {
@@ -170,6 +180,7 @@ export interface ConfigObject {
   customPatientIdUrl: string;
   defaultFacilityUrl: string;
   customPatientChartText: string;
+  hideEntriesWithUnpaidBills: boolean;
 }
 
 export interface OutpatientConfig {

--- a/packages/esm-service-queues-app/src/config-schema.ts
+++ b/packages/esm-service-queues-app/src/config-schema.ts
@@ -141,7 +141,7 @@ export const configSchema = {
   hideEntriesWithUnpaidBills: {
     _type: Type.Boolean,
     _description: 'Whether to use the billing module to only show patients with paid bills in the queue table`',
-    _default: true,
+    _default: false,
   },
   customBillinguRL: {
     _type: Type.String,


### PR DESCRIPTION
…ling)

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Add ability to view patients after they have paid, this prevents patients queuing before paying their bills

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
