### PR TITLE
 (feat) In Appointments App, filter out location dropdowns to only show appointment locations

### DIFF
--- a/packages/esm-appointments-app/src/admin/appointment-services/appointment-services.component.tsx
+++ b/packages/esm-appointments-app/src/admin/appointment-services/appointment-services.component.tsx
@@ -8,6 +8,7 @@ import { showNotification, showToast, useLocations } from '@openmrs/esm-framewor
 import type { AppointmentService } from '../../types';
 import { closeOverlay } from '../../hooks/useOverlay';
 import styles from './appointment-services.scss';
+import { appointmentLocationTagName } from '../../constants';
 
 interface AppointmentServicesProps {}
 
@@ -15,7 +16,7 @@ const AppointmentServices: React.FC<AppointmentServicesProps> = () => {
   const { t } = useTranslation();
   const { appointmentServiceInitialValue, addNewAppointmentService } = useAppointmentServices();
 
-  const locations = useLocations();
+  const locations = useLocations(appointmentLocationTagName);
   const handleSubmit = async (values: AppointmentService, helpers: FormikHelpers<AppointmentService>) => {
     const payload = {
       name: values.name,

--- a/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-form.component.tsx
@@ -28,7 +28,6 @@ import {
   Toggle,
 } from '@carbon/react';
 import {
-  type ConfigObject,
   ExtensionSlot,
   showNotification,
   showToast,
@@ -55,6 +54,8 @@ import { useInitialAppointmentFormValue, type PatientAppointment } from '../useI
 import LocationSelectOption from '../../common-components/location-select-option.component';
 import WorkloadCard from '../workload.component';
 import styles from './appointments-form.scss';
+import { appointmentLocationTagName } from '../../../constants';
+import { type ConfigObject } from '../../../config-schema';
 
 interface AppointmentFormProps {
   appointment?: MappedAppointment;
@@ -67,7 +68,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment, patientU
   const { defaultFacility, isLoading: loadingDefaultFacility } = useDefaultLoginLocation();
   const { providers } = useProviders();
   const { services } = useServices();
-  const locations = useLocations();
+  const locations = useLocations(appointmentLocationTagName);
   const sessionUser = useSession();
   const isTablet = useLayoutType() === 'tablet';
   const initialAppointmentFormValues = useInitialAppointmentFormValue(appointment, patientUuid);

--- a/packages/esm-appointments-app/src/constants.ts
+++ b/packages/esm-appointments-app/src/constants.ts
@@ -2,3 +2,4 @@ export const spaRoot = window['getOpenmrsSpaBase'];
 export const basePath = '/appointments';
 export const spaBasePath = `${window.spaBase}/home`;
 export const omrsDateFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZZ';
+export const appointmentLocationTagName = 'Appointment Location';

--- a/packages/esm-appointments-app/src/patient-queue/visit-form/visit-form.component.tsx
+++ b/packages/esm-appointments-app/src/patient-queue/visit-form/visit-form.component.tsx
@@ -45,6 +45,7 @@ import { useAppointments } from '../../appointments/appointments-table.resource'
 import { useDefaultLoginLocation } from '../../hooks/useDefaultLocation';
 import { useVisits } from '../../hooks/useVisits';
 import styles from './visit-form.scss';
+import { appointmentLocationTagName } from '../../constants';
 
 interface VisitFormProps {
   patientUuid: string;
@@ -56,7 +57,7 @@ const VisitForm: React.FC<VisitFormProps> = ({ patientUuid, appointment }) => {
   const { currentAppointmentDate } = useAppointmentDate();
   const isTablet = useLayoutType() === 'tablet';
   const sessionUser = useSession();
-  const locations = useLocations();
+  const locations = useLocations(appointmentLocationTagName);
   const [isMissingVisitType, setIsMissingVisitType] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedLocation, setSelectedLocation] = useState(sessionUser?.sessionLocation?.uuid ?? '');


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

When scheduling a new appointment, we want to have the location selection dropdown be restricted to "Appointment Locations". There is already existing backend endpoint to query locations by tag name, so we just need to use that wherever we do location selection dropdown.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

I did `yarn up @openmrs/esm-framework@next` to get the latest version of esm-framework, but it also upgraded a bunch of other stuff in yarn.lock. I hope that's ok.
