### PR TITLE
(fix) Remove padding-block-start from icon only buttons

### DIFF
--- a/packages/esm-appointments-app/src/overlay.scss
+++ b/packages/esm-appointments-app/src/overlay.scss
@@ -75,10 +75,6 @@
 
 .closePanelButton {
   background-color: $ui-02;
-  padding-block-start: 0.75rem;
-  // FIXME: Why are carbon's default button styles not working?
-  height: 3rem;
-  width: 3rem;
 }
 
 /* Desktop */

--- a/packages/esm-patient-list-management-app/src/create-edit-patient-list/create-edit-list.component.tsx
+++ b/packages/esm-patient-list-management-app/src/create-edit-patient-list/create-edit-list.component.tsx
@@ -119,7 +119,7 @@ const CreateEditPatientList: React.FC<CreateEditPatientListProps> = ({
     <Overlay
       buttonsGroup={
         <ButtonSet className={styles.buttonsGroup}>
-          <Button onClick={close} kind="secondary" size="xl">
+          <Button className={styles.button} onClick={close} kind="secondary" size="xl">
             {t('cancel', 'Cancel')}
           </Button>
           <Button onClick={handleSubmit} size="xl" disabled={isSubmitting}>

--- a/packages/esm-patient-list-management-app/src/create-edit-patient-list/create-edit-patient-list.scss
+++ b/packages/esm-patient-list-management-app/src/create-edit-patient-list/create-edit-patient-list.scss
@@ -11,6 +11,14 @@
   margin-top: spacing.$spacing-07;
 }
 
+.button {
+  height: 4rem;
+  display: flex;
+  align-content: flex-start;
+  align-items: baseline;
+  min-width: 50%;
+}
+
 .buttonsGroup {
   width: 100%;
   display: grid;

--- a/packages/esm-patient-list-management-app/src/list-details-table/list-details-table.component.tsx
+++ b/packages/esm-patient-list-management-app/src/list-details-table/list-details-table.component.tsx
@@ -315,7 +315,6 @@ const ListDetailsTable: React.FC<ListDetailsTableProps> = ({
                           ))}
                           <TableCell className="cds--table-column-menu">
                             <Button
-                              className={styles.removeButton}
                               kind="ghost"
                               hasIconOnly
                               renderIcon={TrashCan}

--- a/packages/esm-patient-list-management-app/src/list-details-table/list-details-table.scss
+++ b/packages/esm-patient-list-management-app/src/list-details-table/list-details-table.scss
@@ -72,11 +72,6 @@ div#table-tool-bar {
   margin: spacing.$spacing-05;
 }
 
-.removeButton {
-  padding-block-start: 0.5rem;
-  padding-inline-end: 0;
-}
-
 .tile {
   text-align: center;
   border: 1px solid $ui-03;

--- a/packages/esm-patient-list-management-app/src/overlay.scss
+++ b/packages/esm-patient-list-management-app/src/overlay.scss
@@ -47,7 +47,7 @@
   align-items: center;
   background-color: $ui-03;
   border-bottom: 1px solid $text-03;
-  height: 2.5rem;
+  height: 3rem;
 }
 
 .headerContent {
@@ -60,10 +60,6 @@
   border: none;
   border-bottom: 1px solid $text-03;
   background-color: $ui-02;
-  padding-block-start: 0.75rem;
-  // FIXME: Why are carbon's default button styles not working?
-  height: 2.5rem;
-  width: 2.5rem;
 }
 
 .overlayContent {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

I've removed a style override that added logical block start padding to icon-only Carbon button components. This override is no longer necessary since https://github.com/openmrs/openmrs-esm-core/pull/850. Additionally, I've:

- Amended the button set styling for action buttons in the overlay to match the designs.
- Set the overlay header size to 3rem.

## Screenshots

![CleanShot 2023-12-16 at 11  19 30@2x](https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/b948ac35-0ede-43b4-b29e-d5109944af49)


## Related Issue

*None.*


## Other

*None.*
