### PR TITLE
(fix) Phone field should be defined as a built-in field

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -11,14 +11,14 @@ export interface FieldDefinition {
   type: string;
   label?: string;
   uuid: string;
-  placeholder: string;
+  placeholder?: string;
   showHeading: boolean;
-  validation: {
+  validation?: {
     required: boolean;
     matches?: string;
   };
   answerConceptSetUuid?: string;
-  customConceptAnswers: Array<CustomConceptAnswer>;
+  customConceptAnswers?: Array<CustomConceptAnswer>;
 }
 export interface CustomConceptAnswer {
   uuid: string;
@@ -85,7 +85,8 @@ export const builtInSections: Array<SectionDefinition> = [
   { id: 'relationships', name: 'Relationships', fields: [] },
 ];
 
-export const builtInFields = ['name', 'gender', 'dob', 'address', 'id', 'phone & email'] as const;
+// These fields are handled specially in field.component.tsx
+export const builtInFields = ['name', 'gender', 'dob', 'id', 'address', 'phone'] as const;
 
 export const esmPatientRegistrationSchema = {
   sections: {
@@ -185,17 +186,8 @@ export const esmPatientRegistrationSchema = {
         _description: 'For coded questions only. Provide ability to add custom concept answers.',
       },
     },
-    _default: [
-      {
-        id: 'phone',
-        type: 'person attribute',
-        uuid: '14d4f066-15f5-102d-96e4-000c29c2a5d7',
-        showHeading: false,
-        validation: {
-          matches: '',
-        },
-      },
-    ],
+    // Do not add fields here. If you want to add a field in code, add it to built-in fields above.
+    _default: [],
     _description:
       'Definitions for custom fields that can be used in sectionDefinitions. Can also be used to override built-in fields.',
   },

--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -59,6 +59,9 @@ export interface RegistrationConfig {
         month: number;
       };
     };
+    phone: {
+      personAttributeUuid: string;
+    };
   };
   links: {
     submitButton: string;
@@ -310,6 +313,13 @@ export const esmPatientRegistrationSchema = {
           _description: 'The custom month to use on the estimated date of birth i.e 0 = Jan & 11 = Dec',
           _default: 0,
         },
+      },
+    },
+    phone: {
+      personAttributeUuid: {
+        _type: Type.UUID,
+        _default: '14d4f066-15f5-102d-96e4-000c29c2a5d7',
+        _description: 'The UUID of the phone number person attribute type',
       },
     },
   },

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.component.tsx
@@ -7,6 +7,7 @@ import { reportError, useConfig } from '@openmrs/esm-framework';
 import { builtInFields, type RegistrationConfig } from '../../config-schema';
 import { CustomField } from './custom-field.component';
 import { AddressComponent } from './address/address-field.component';
+import { PhoneField } from './phone/phone-field.component';
 
 export interface FieldProps {
   name: string;
@@ -38,6 +39,8 @@ export function Field({ name }: FieldProps) {
       return <AddressComponent />;
     case 'id':
       return <Identifiers />;
+    case 'phone':
+      return <PhoneField />;
     default:
       return <CustomField name={name} />;
   }

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
@@ -288,9 +288,7 @@ describe('Field', () => {
       error = err;
     }
 
-    expect(error).toBe(
-      "Invalid field name 'invalidField'. Valid options are 'weight', 'name', 'gender', 'dob', 'address', 'id', 'phone & email'.",
-    );
+    expect(error).toMatch(/Invalid field name 'invalidField'. Valid options are /);
     expect(screen.queryByTestId('invalid-field')).not.toBeInTheDocument();
 
     consoleError.mockRestore();

--- a/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/person-attribute-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/person-attribute-field.component.tsx
@@ -24,9 +24,9 @@ export function PersonAttributeField({ fieldDefinition }: PersonAttributeFieldPr
         return (
           <TextPersonAttributeField
             personAttributeType={personAttributeType}
-            validationRegex={fieldDefinition.validation.matches}
+            validationRegex={fieldDefinition.validation?.matches ?? ''}
             label={fieldDefinition.label}
-            required={fieldDefinition.validation.required}
+            required={fieldDefinition.validation?.required ?? false}
             id={fieldDefinition?.id}
           />
         );

--- a/packages/esm-patient-registration-app/src/patient-registration/field/phone/phone-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/phone/phone-field.component.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { PersonAttributeField } from '../person-attributes/person-attribute-field.component';
+
+export function PhoneField() {
+  const fieldDefinition = {
+    id: 'phone',
+    type: 'person attribute',
+    uuid: '14d4f066-15f5-102d-96e4-000c29c2a5d7',
+    showHeading: false,
+  };
+  return <PersonAttributeField fieldDefinition={fieldDefinition} />;
+}

--- a/packages/esm-patient-registration-app/src/patient-registration/field/phone/phone-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/phone/phone-field.component.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { PersonAttributeField } from '../person-attributes/person-attribute-field.component';
+import { useConfig } from '@openmrs/esm-framework';
+import { type RegistrationConfig } from '../../../config-schema';
 
 export function PhoneField() {
+  const config = useConfig<RegistrationConfig>();
+
   const fieldDefinition = {
     id: 'phone',
     type: 'person attribute',
-    uuid: '14d4f066-15f5-102d-96e4-000c29c2a5d7',
+    uuid: config.fieldConfigurations.phone.personAttributeUuid,
     showHeading: false,
   };
   return <PersonAttributeField fieldDefinition={fieldDefinition} />;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

The phone field was defined as a default in the fieldDefinitions config. This is wrong; this makes it so that an implementer who provides a custom field definition will wipe out the phone field.

Also it seems that the `phone & email` field is no more, so I got rid of that.

## Related Issue

Discovered while reproing https://openmrs.atlassian.net/issues/O3-1425
