### PR TITLE
(fix) Remove cruft related to fromPage local storage item

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.component.tsx
@@ -25,18 +25,12 @@ import {
   useConfig,
   usePagination,
   ExtensionSlot,
-  interpolateUrl,
-  navigate,
   ErrorState,
+  ConfigurableLink,
 } from '@openmrs/esm-framework';
 import { EmptyDataIllustration } from './empty-data-illustration.component';
 import { useActiveVisits, getOriginFromPathName } from './active-visits.resource';
 import styles from './active-visits.scss';
-
-interface NameLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  to: string;
-  from: string;
-}
 
 function ComputeExpensiveValue(t, config) {
   let headersIndex = 0;
@@ -99,19 +93,6 @@ function ComputeExpensiveValue(t, config) {
   return headers;
 }
 
-const PatientNameLink: React.FC<NameLinkProps> = ({ from, to, children }) => {
-  const handleNameClick = (event: MouseEvent, to: string) => {
-    event.preventDefault();
-    navigate({ to });
-    localStorage.setItem('fromPage', from);
-  };
-  return (
-    <a onClick={(e) => handleNameClick(e, to)} href={interpolateUrl(to)}>
-      {children}
-    </a>
-  );
-};
-
 const ActiveVisitsTable = () => {
   const { t } = useTranslation();
   const config = useConfig();
@@ -120,10 +101,6 @@ const ActiveVisitsTable = () => {
   const [pageSize, setPageSize] = useState(config?.activeVisits?.pageSize ?? 10);
   const { activeVisits, isLoading, isValidating, error } = useActiveVisits();
   const [searchString, setSearchString] = useState('');
-
-  const currentPathName = window.location.pathname;
-  const fromPage = getOriginFromPathName(currentPathName);
-
   const headerData = useMemo(() => ComputeExpensiveValue(t, config), [config, t]);
 
   const searchResults = useMemo(() => {
@@ -261,9 +238,7 @@ const ActiveVisitsTable = () => {
                           {row.cells.map((cell) => (
                             <TableCell key={cell.id} data-testid={cell.id}>
                               {cell.info.header === 'name' && visit.patientUuid ? (
-                                <PatientNameLink from={fromPage} to={patientLink}>
-                                  {cell.value}
-                                </PatientNameLink>
+                                <ConfigurableLink to={patientLink}>{cell.value}</ConfigurableLink>
                               ) : (
                                 cell.value
                               )}

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, type MouseEvent, type AnchorHTMLAttributes, useCallback, useEffect } from 'react';
+import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -7,7 +7,6 @@ import {
   DataTableSkeleton,
   DefinitionTooltip,
   Dropdown,
-  Layer,
   Tab,
   Table,
   TableBody,
@@ -33,8 +32,6 @@ import {
 import { Add } from '@carbon/react/icons';
 import {
   useLayoutType,
-  navigate,
-  interpolateUrl,
   isDesktop,
   ExtensionSlot,
   usePagination,
@@ -42,13 +39,9 @@ import {
   type ConfigObject,
   useSession,
   showModal,
+  ConfigurableLink,
 } from '@openmrs/esm-framework';
-import {
-  useVisitQueueEntries,
-  useServices,
-  getOriginFromPathName,
-  type MappedVisitQueueEntry,
-} from './active-visits-table.resource';
+import { useVisitQueueEntries, useServices, type MappedVisitQueueEntry } from './active-visits-table.resource';
 import { SearchTypes } from '../types';
 import {
   updateSelectedServiceName,
@@ -88,29 +81,11 @@ type FilterProps = {
   getCellId: (row, key) => string;
 };
 
-interface NameLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  to: string;
-  from: string;
-}
-
 interface PaginationData {
   goTo: (page: number) => void;
   results: Array<MappedVisitQueueEntry>;
   currentPage: number;
 }
-
-const PatientNameLink: React.FC<NameLinkProps> = ({ from, to, children }) => {
-  const handleNameClick = (event: MouseEvent, to: string) => {
-    event.preventDefault();
-    navigate({ to });
-    localStorage.setItem('fromPage', from);
-  };
-  return (
-    <a onClick={(e) => handleNameClick(e, to)} href={interpolateUrl(to)}>
-      {children}
-    </a>
-  );
-};
 
 function ActiveVisitsTable() {
   const { t } = useTranslation();
@@ -136,9 +111,6 @@ function ActiveVisitsTable() {
   const { rooms, isLoading: loading } = useQueueRooms(queueLocations[0]?.id, currentServiceUuid);
 
   const isPermanentProviderQueueRoom = useIsPermanentProviderQueueRoom();
-  const currentPathName: string = window.location.pathname;
-  const fromPage: string = getOriginFromPathName(currentPathName);
-
   const pageSizes = [10, 20, 30, 40, 50];
   const [currentPageSize, setPageSize] = useState(10);
   const [overlayHeader, setOverlayTitle] = useState('');
@@ -196,9 +168,7 @@ function ActiveVisitsTable() {
       ...entry,
       name: {
         content: (
-          <PatientNameLink to={`\${openmrsSpaBase}/patient/${entry.patientUuid}/chart`} from={fromPage}>
-            {entry.name}
-          </PatientNameLink>
+          <ConfigurableLink to={`\${openmrsSpaBase}/patient/${entry.patientUuid}/chart`}>{entry.name}</ConfigurableLink>
         ),
       },
       queueNumber: {

--- a/packages/esm-service-queues-app/src/visits-missing-inqueue/visits-missing-inqueue.component.tsx
+++ b/packages/esm-service-queues-app/src/visits-missing-inqueue/visits-missing-inqueue.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useState, useCallback, type MouseEvent, type AnchorHTMLAttributes } from 'react';
+import React, { useMemo, useEffect, useState, useCallback, type AnchorHTMLAttributes } from 'react';
 import classNames from 'classnames';
 import {
   DataTable,
@@ -30,9 +30,8 @@ import {
   ExtensionSlot,
   formatDatetime,
   parseDate,
-  interpolateUrl,
-  navigate,
   showModal,
+  ConfigurableLink,
 } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import styles from './visits-missing-inqueue.scss';
@@ -45,23 +44,6 @@ interface PaginationData {
   results: Array<ActiveVisit>;
   currentPage: number;
 }
-interface NameLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  to: string;
-  from: string;
-}
-
-const PatientNameLink: React.FC<NameLinkProps> = ({ from, to, children }) => {
-  const handleNameClick = (event: MouseEvent, to: string) => {
-    event.preventDefault();
-    navigate({ to });
-    localStorage.setItem('fromPage', from);
-  };
-  return (
-    <a onClick={(e) => handleNameClick(e, to)} href={interpolateUrl(to)}>
-      {children}
-    </a>
-  );
-};
 
 function AddMenu({ visitDetails }: { visitDetails: ActiveVisit }) {
   const { t } = useTranslation();
@@ -91,9 +73,6 @@ const MissingQueueEntries = () => {
   const pageSizes = config?.activeVisits?.pageSizes ?? [10, 20, 30, 40, 50];
   const [currentPageSize, setPageSize] = useState(config?.activeVisits?.pageSize ?? 10);
   const [searchString, setSearchString] = useState('');
-
-  const currentPathName = window.location.pathname;
-  const fromPage = getOriginFromPathName(currentPathName);
 
   const headerData = useMemo(
     () => [
@@ -213,11 +192,10 @@ const MissingQueueEntries = () => {
                         {row.cells.map((cell) => (
                           <TableCell key={cell.id}>
                             {cell.info.header === 'name' ? (
-                              <PatientNameLink
-                                from={fromPage}
+                              <ConfigurableLink
                                 to={`\${openmrsSpaBase}/patient/${paginatedActiveVisits?.[index]?.patientUuid}/chart/`}>
                                 {cell.value}
-                              </PatientNameLink>
+                              </ConfigurableLink>
                             ) : (
                               cell.value
                             )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,9 +2881,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-api@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-api@npm:5.3.3-pre.1319"
+"@openmrs/esm-api@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-api@npm:5.3.3-pre.1347"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -2891,17 +2891,17 @@ __metadata:
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 2cb94047f58bf7c331c0549cf7d1f1c677acf20e79946d76270bb0ba7c6381f82bc5a5e205eaed93ff3e70a6ec3ac1cd3adf8b9a0bee8b23b22495a79bc24215
+  checksum: 8ab11d94262b17e1ffd1b17f9275dc4ee72a49ab92fb62b5fc1714d02044204f9c7600afbc0907d3e324dee0cadf54fb2c7c101e9bf10fdf47178a34e299e833
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-app-shell@npm:5.3.3-pre.1319"
+"@openmrs/esm-app-shell@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-app-shell@npm:5.3.3-pre.1347"
   dependencies:
     "@carbon/react": "npm:~1.37.0"
-    "@openmrs/esm-framework": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-styleguide": "npm:5.3.3-pre.1319"
+    "@openmrs/esm-framework": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-styleguide": "npm:5.3.3-pre.1347"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -2926,7 +2926,7 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 3f1cc668c71c378266a43464c139adfcbe28a79991014933bec98f7ca670e1fde60d3967d50063a035dab8fcd3baf0f428835699867aa3a518fc53b7fdebfc55
+  checksum: f596ee10bdcf6507ec4b73d428ed4dec5ad168b5da0f81c87a91e144280489634357c88ba0f5346c8fcb2182eadf649d62a5169d07252b299394beb6f71ca047
   languageName: node
   linkType: hard
 
@@ -2948,51 +2948,51 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-breadcrumbs@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-breadcrumbs@npm:5.3.3-pre.1319"
+"@openmrs/esm-breadcrumbs@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-breadcrumbs@npm:5.3.3-pre.1347"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: 97bccaac50b1b0b8899056d54d512cbe9b0faf393f7e38fcb6377aedb5bf96c095cc34c89873bf4a8fab574ac7686f48019974c2bf015c2338f426b096d25078
+  checksum: b649bf3220618a1ca2412f14cac644633fe868e0dc161d89b0446826d27c534bcc2d5363a5d7944b309b54bf64072b48d9bd613785fad8592f974f81d3c92a10
   languageName: node
   linkType: hard
 
-"@openmrs/esm-config@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-config@npm:5.3.3-pre.1319"
+"@openmrs/esm-config@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-config@npm:5.3.3-pre.1347"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: d2496e975d2cfc942e9b43bef6396aab53372cc75baefaae2df5232531d463608f58d30da87086c3e39c45a5d94fda08c5e91922ff03716b9f1b7cf68d2a899c
+  checksum: 0c2e693721826b8b03ded63dbec82eb00848642e0edab234dd571bb9143a94536b1081986d7012df8fc7b85b3bfb11b9841d22d775d0081f707df960f7869b5b
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1319"
+"@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1347"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 5716de25d592e04bc6fafdc821a446a5de3d77412abbc548f05e96ebdedfcf7462179d218a2db4ca926ca062d6cb61cd858dd758ee0036a2a32fd156318ec467
+  checksum: 75b108e36a34484a4034fa54d3c68a7753035ebfc11d52d4a5e3affbcb6904e825df114b34023ba7de3d092c7ddc12a3af5da28f1a10ffb1882ba1366c95ef73
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-error-handling@npm:5.3.3-pre.1319"
+"@openmrs/esm-error-handling@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-error-handling@npm:5.3.3-pre.1347"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 70b1d6ce606fe1174e2a101d62bf5b4f804d4ffcf64289ee6a953ea65654a181941eaf441667cfbf9eb1466db6cb4dfb15842afc8fa339cc0a1e89b697879f58
+  checksum: 9316c45d128aa852dc597cf1d4be044fb64d2d03c0344a4efa26469d1dff4c16945fa187560e3733b689afd3c559221a312351fb38def073be77a5cd42cdc54e
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-extensions@npm:5.3.3-pre.1319"
+"@openmrs/esm-extensions@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-extensions@npm:5.3.3-pre.1347"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -3001,41 +3001,41 @@ __metadata:
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 038f20e98595549060994ea7b242d283a19a4b1e6b309b23bf8df5896e75636296f3e37339bf35875408c12a86a87d1f29bba442335be7e8b4d5c567697455f7
+  checksum: bab90957f01555f50f57d9c74a3f450bd2d74aed9b27ef7d1bfe63c72f997950454253d3fba75e12340ff23e05a080141df4d3a801856af497eaee153d9d3a50
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-feature-flags@npm:5.3.3-pre.1319"
+"@openmrs/esm-feature-flags@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-feature-flags@npm:5.3.3-pre.1347"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: da011651372299ac00db8017a43746c9ff2675d6ef69679c6d05b03bdd7159a797419ba1c70d3e57a7d56383aa99b3cae34d1d6ba64216496940c7da14b184ac
+  checksum: 084efd8f3852bb953fe96365d5a92d5eaa6f20b1690fa2304e0dba3be457b56461a94d58884877996a43acb5dbc5972a8f9fb5bd4e2b233cc9380bcf42b7b254
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:5.3.3-pre.1319, @openmrs/esm-framework@npm:next":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-framework@npm:5.3.3-pre.1319"
+"@openmrs/esm-framework@npm:5.3.3-pre.1347, @openmrs/esm-framework@npm:next":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-framework@npm:5.3.3-pre.1347"
   dependencies:
-    "@openmrs/esm-api": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-breadcrumbs": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-config": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-dynamic-loading": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-error-handling": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-extensions": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-feature-flags": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-globals": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-offline": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-react-utils": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-routes": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-state": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-styleguide": "npm:5.3.3-pre.1319"
-    "@openmrs/esm-utils": "npm:5.3.3-pre.1319"
+    "@openmrs/esm-api": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-breadcrumbs": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-config": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-dynamic-loading": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-error-handling": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-extensions": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-feature-flags": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-globals": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-offline": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-react-utils": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-routes": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-state": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-styleguide": "npm:5.3.3-pre.1347"
+    "@openmrs/esm-utils": "npm:5.3.3-pre.1347"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
@@ -3046,22 +3046,22 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: c37fde51c304e7e542e9a3c104872ff78f0b34aa43cd0ddcd41dd976b4db5d8a5ed02f1af7956c1f5c065db928826919248a94e51034f8f633c306a0ba95faf4
+  checksum: 67ef16b68c01cbc9fd64e6aad89614da8145d5b6f815e137adb2226453d30cdff73ecad573052f1bf1a88395a80c66eeee94d787a905db6f51ce09883f85d8b3
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-globals@npm:5.3.3-pre.1319"
+"@openmrs/esm-globals@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-globals@npm:5.3.3-pre.1347"
   peerDependencies:
     single-spa: 5.x
-  checksum: 640d88338b5c9e00a74d91f7e68db4873aa1a56f7d93f145634032651b183eb857619608510e352e3325490c7d6a4af911900bd7010f78415569e0fb787338e2
+  checksum: 5749209aca0b12fe8955f27131f9d2fa7fb381484acef97a488b85654725b30488c639086d7b085515ea714d7ebe0cffed515fc658b05544945c75ebf496481a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-offline@npm:5.3.3-pre.1319"
+"@openmrs/esm-offline@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-offline@npm:5.3.3-pre.1347"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -3073,7 +3073,7 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: 3a8ea130052ce189a6dd3c11ad18adee6f452928e64228c617cca51ebf04e0f8aa736634f7e8aac84c6c099a67b75fac9f10d4d34c4de5bffccb1025ff1cf0b5
+  checksum: f6a3581387516715915af38258247168f082ce186ac9c252d43d3a41c256be898938e0e388b83b6417dd6dac4937d83577bea347f210457516c6ee13ac3cc77b
   languageName: node
   linkType: hard
 
@@ -3195,9 +3195,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-react-utils@npm:5.3.3-pre.1319"
+"@openmrs/esm-react-utils@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-react-utils@npm:5.3.3-pre.1347"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:~5.0.0"
@@ -3214,17 +3214,17 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: a0f9c1a8fcfb1b0c24a7176e839adc1732e925018f50570183a7536de2a4df1ee39d52adfb0b853c74b85f943d0ca5372f6ca10f8eb333adfadd83ba55177c95
+  checksum: e71aded2eb1ba7993c1df07b96ff997c54971971de7072115413651a90b01fe12c557c10b6a677df49a57cb9492c0974be4ff20acf1d4494cac88f01783bfeed
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-routes@npm:5.3.3-pre.1319"
+"@openmrs/esm-routes@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-routes@npm:5.3.3-pre.1347"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
-  checksum: 87e0c9212f9f10b3b5a2f620ebfa8acf2d3c1ad14ae2aae67ac56cf3e33a27b2b684dc80a21fd39231ce28bfd49cff21c746d74e10ea7ca6256062fde3021f88
+  checksum: 4341c5dca94ece2698a232c200f0ef02d340bb4d5b039c33559b818baebd83eaf2fc89500f0feeafa726255a2de339ff62eed51e10d061056eb54477e82c0778
   languageName: node
   linkType: hard
 
@@ -3244,20 +3244,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-state@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-state@npm:5.3.3-pre.1319"
+"@openmrs/esm-state@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-state@npm:5.3.3-pre.1347"
   dependencies:
     zustand: "npm:^4.3.6"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 284274550861627b3fbfffdc237e40cf487bb643c622a8032457040105b432ac1fb59213efb3806663e93c86c8987be3dfe715f22caa5e07987138f311a4e212
+  checksum: f821aefe11f2c1a60c4c5f26304b4706555c8a0c41a5a177d6720da9c8291a7605a8c7195a3599dbe001a3efb814d7d31e925cf7330bed3dba69c455dd10e001
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-styleguide@npm:5.3.3-pre.1319"
+"@openmrs/esm-styleguide@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-styleguide@npm:5.3.3-pre.1347"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
@@ -3276,26 +3276,26 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: cb1d86e4aa145b5daee78441311c213b3bf70a8e3ef0de53b3827e0b122b10c71f9beb10bafbcf4b192416c37dc0da0c5b4aabb13b2e8082679f8d06d9ae3da2
+  checksum: f2e101f84ba7fe8e8c254f23e168deaca95b378470a4dc82340cedeff4f03d4bb92221a338d3d8727b850869a0f8cb201dd71abefe8984e27d2d4000771b206f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/esm-utils@npm:5.3.3-pre.1319"
+"@openmrs/esm-utils@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/esm-utils@npm:5.3.3-pre.1347"
   dependencies:
     semver: "npm:7.3.2"
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: 2c6e559464d09e0e5847fc463d1cfb391bfdf6b2a5d74294252faf3b63297bea4fb1c2151d4e992f9aa30c61e111642d0194728108780e3c0dbfcc029d0d715c
+  checksum: 1ecebcb4fc9db1048971029d009209a88249d6fc99b9e71fcc7362bf44ab7e32991c7a54aef9faa882c49c4fbe1d7ec63a86ce1fff9298691a7e039d56800f59
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.3.3-pre.1319":
-  version: 5.3.3-pre.1319
-  resolution: "@openmrs/webpack-config@npm:5.3.3-pre.1319"
+"@openmrs/webpack-config@npm:5.3.3-pre.1347":
+  version: 5.3.3-pre.1347
+  resolution: "@openmrs/webpack-config@npm:5.3.3-pre.1347"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -3312,7 +3312,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: c2beebd9fccc672c49c511bf983bc44d5a910d53552072b8c28177f31d8d6c359ef433db3e7574b074eada95151365ad41c26568e7289f22c01103a922e63782
+  checksum: 776e41ab8b44b0ddc2f6cedd41a36c917150efb5086296d953ae879316c01bdc7fd245e142d0c08a5bb6ee55c5982e2cd653cd8efe8210ff83994f8b6811fab3
   languageName: node
   linkType: hard
 
@@ -12747,6 +12747,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-watch@npm:^0.7.4":
+  version: 0.7.4
+  resolution: "node-watch@npm:0.7.4"
+  checksum: ea752dd5cd0aa1344ced1002409c8a81829cc5406fd949f34e8886786f2015651d2da9c3d3d4f164d23b9e84c7062ff97051746fe77db18955ffb23dc3dc0b76
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^6.0.0":
   version: 6.0.0
   resolution: "nopt@npm:6.0.0"
@@ -13088,12 +13095,12 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 5.3.3-pre.1319
-  resolution: "openmrs@npm:5.3.3-pre.1319"
+  version: 5.3.3-pre.1347
+  resolution: "openmrs@npm:5.3.3-pre.1347"
   dependencies:
     "@carbon/icons-react": "npm:11.26.0"
-    "@openmrs/esm-app-shell": "npm:5.3.3-pre.1319"
-    "@openmrs/webpack-config": "npm:5.3.3-pre.1319"
+    "@openmrs/esm-app-shell": "npm:5.3.3-pre.1347"
+    "@openmrs/webpack-config": "npm:5.3.3-pre.1347"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.2"
@@ -13107,6 +13114,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.5.0"
     inquirer: "npm:^7.3.3"
     mini-css-extract-plugin: "npm:^2.4.5"
+    node-watch: "npm:^0.7.4"
     npm-registry-fetch: "npm:^14.0.3"
     pacote: "npm:^15.0.0"
     postcss: "npm:^8.4.6"
@@ -13123,7 +13131,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 3dd7863d786989d680ce8c63a64d80110edf19fb1da1ffefb0b577a84266d0e226dc35caf079b17b440ee3bba6d35506aff7161af8fafb39a1b505d74c3537a7
+  checksum: 0de913e6863454aa490ddf688e3f4d673ddc0102e851525991998edf6c12e1fc114ccfab084ad8189a310b379f5737f05be89511a0a3398016fda348da562da7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

The only code relying on `fromPage` was removed in https://github.com/openmrs/openmrs-esm-patient-chart/pull/1341. So this removes the code that set `fromPage`, moving back to `ConfigurableLink`, and getting partway to solving https://openmrs.atlassian.net/browse/O3-1354


## Related Issue
Related to https://openmrs.atlassian.net/browse/O3-1354
