### PR TITLE
(fix) O3-2693 Appointment Creation Form DatePicker uses incorrect minDate format

### DIFF
--- a/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-form.component.tsx
@@ -90,7 +90,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment, patientU
   );
 
   const appointmentService = services?.find(({ uuid }) => uuid === patientAppointment.serviceUuid);
-  const today = dayjs().startOf('day').format();
+  const today = dayjs().startOf('day').format('DD/MM/YYYY');
 
   useEffect(() => {
     if (locations?.length && sessionUser) {


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
As of today (2024-01-03) the Appointment creation DatePicker only allows for dates after 2024-04-20
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/7b64de3a-6ce2-415d-8012-232a0d62f76b)

With this change, the minDate defaults correctly to today's date (2024-01-03)
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/bc04c9a4-1a05-48a1-bf05-81865194ba76)

The Carbon documentation is lacking on what format should be accepted for its minDate and maxDate params. From cursory trial-and-error, it seems like the format should follow the `dateFormat` passed in to the DatePicker.

https://react.carbondesignsystem.com/?path=/docs/components-datepicker--overview#datepicker-mindate

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
This is a quick fix for this particular issue, but there are likely other similar problems elsewhere in the code base. A more complete fix should probably involve a standardized DatePicker. See:
https://openmrs.atlassian.net/browse/O3-998
https://openmrs.atlassian.net/browse/O3-1991

## Other
<!-- Anything not covered above -->
