### PR TITLE
(fix) O3-2723: Fix patient saves gender initial as lowercase

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -252,7 +252,7 @@ export class FormManager {
       });
 
     /*
-      If there was initially an identifier assigned to the patient, 
+      If there was initially an identifier assigned to the patient,
       which is now not present in the patientIdentifiers(values.identifiers),
       this means that the identifier is meant to be deleted, hence we need
       to delete the respective identifiers.
@@ -302,7 +302,7 @@ export class FormManager {
       person: {
         uuid: values.patientUuid,
         names: FormManager.getNames(values, patientUuidMap),
-        gender: values.gender.charAt(0),
+        gender: values.gender.charAt(0).toUpperCase(),
         birthdate,
         birthdateEstimated: values.birthdateEstimated,
         attributes: FormManager.getPatientAttributes(isNewPatient, values, patientUuidMap),

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -281,7 +281,7 @@ describe('Registering a new patient', () => {
           attributes: [],
           birthdate: '1993-8-2',
           birthdateEstimated: false,
-          gender: expect.stringMatching(/M/i),
+          gender: expect.stringMatching(/^M$/),
           names: [{ givenName: 'Paul', middleName: '', familyName: 'Gaihre', preferred: true, uuid: undefined }],
           dead: false,
           uuid: expect.anything(),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
 - The PR fixes the issue that when saving a person/patient, the gender initial was being saved as lowercase, which affected some displays i.e Active Visits Table. 

## Screenshots
<!-- Required if you are making UI changes. -->
#### Before update
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/53287480/046ce811-4700-424f-96b8-a9c39b64cc9e)

#### After the update i.e David Williams
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/53287480/da32c25a-d1f8-4ab2-a3b7-cb0a5ac626f9)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2723](https://openmrs.atlassian.net/browse/O3-2723)

## Other
<!-- Anything not covered above -->
