### PR TITLE
(fix) O3-2686 hide action overflow menu in patient banner in various …

### DIFF
--- a/packages/esm-appointments-app/src/appointments/forms/cancel-form/cancel-appointment.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/cancel-form/cancel-appointment.component.tsx
@@ -60,6 +60,7 @@ const CancelAppointment: React.FC<CancelAppointmentProps> = ({ appointment }) =>
           state={{
             patient,
             patientUuid: appointment.patientUuid,
+            hideActionsOverflow: true,
           }}
         />
       )}

--- a/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/create-edit-form/appointments-form.component.tsx
@@ -157,7 +157,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment, patientU
   }, [currentAppointmentDate, patientAppointment, t]);
 
   return (
-    <Form className={styles.form}>
+    <Form className={styles.form} onClick={(e) => e.preventDefault()}>
       <section>
         {isLoading ? (
           <div className={styles.loaderContainer}>
@@ -170,6 +170,7 @@ const AppointmentForm: React.FC<AppointmentFormProps> = ({ appointment, patientU
               state={{
                 patient,
                 patientUuid: patientAppointment.patientUuid,
+                hideActionsOverflow: false,
               }}
             />
           </div>

--- a/packages/esm-appointments-app/src/patient-queue/visit-form/visit-form.component.tsx
+++ b/packages/esm-appointments-app/src/patient-queue/visit-form/visit-form.component.tsx
@@ -192,6 +192,7 @@ const VisitForm: React.FC<VisitFormProps> = ({ patientUuid, appointment }) => {
             state={{
               patient,
               patientUuid: appointment.patientUuid,
+              hideActionsOverflow: true,
             }}
           />
         )}


### PR DESCRIPTION
…appointment overlay forms


## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
In the New Appointment form, clicking the "Action" button refreshes the entire page instead of just popping up the action menu. We ended up deciding not to need the Action menu at all, so we are just hiding it. 

The actual underlying issue was that the `<button>` elements in a `<Form>` element defaults to trigger the form's `onSubmit` action, which defaults to refreshing the page. The PR also adds a fix by just having the Form's `onSubmit` do nothing. The <button> elements are actually slotted in through extensions, which makes this issue hard to catch (not sure how best to prevent this). 

## Screenshots
See video uploaded at: https://openmrs.atlassian.net/browse/O3-2686

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
