### PR TITLE
(fix) O3-2710: Warning notifications on registration page should close automatically

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -134,6 +134,7 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
           title: t('incompleteForm', 'The following field has errors:'),
           kind: 'warning',
           isLowContrast: true,
+          timeoutInMs: 5000,
         });
       });
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Warning notification during patient registration currently have no `timeout`. As mentioned is the issue, warning should close automatically.

I have added a `timeout` of 5 sec.

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
[https://openmrs.atlassian.net/browse/O3-2710](https://openmrs.atlassian.net/browse/O3-2710)
