### PR TITLE
(refactor) Set global testTimeout in Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -40,4 +40,5 @@ module.exports = {
   testEnvironmentOptions: {
     url: 'http://localhost/',
   },
+  testTimeout: 25000,
 };

--- a/packages/esm-appointments-app/src/appointments/appointment-tabs.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-tabs.test.tsx
@@ -8,8 +8,6 @@ import AppointmentTabs from './appointment-tabs.component';
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 
-jest.setTimeout(10000);
-
 describe('AppointmentTabs', () => {
   xit(`renders tabs showing different appointment lists`, async () => {
     const user = userEvent.setup();

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -12,8 +12,6 @@ import { saveEncounter, savePatient } from './patient-registration.resource';
 import { mockedAddressTemplate } from '__mocks__';
 import { mockPatient } from 'tools';
 
-jest.setTimeout(10000);
-
 const mockedUseConfig = useConfig as jest.Mock;
 const mockedUsePatient = usePatient as jest.Mock;
 const mockedSaveEncounter = saveEncounter as jest.Mock;

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.test.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.test.tsx
@@ -62,8 +62,6 @@ jest.mock('../helpers/helpers', () => {
   };
 });
 
-jest.setTimeout(20000);
-
 describe('ActiveVisitsTable: ', () => {
   beforeEach(() => {
     mockUseSession.mockReturnValue(mockSession),

--- a/packages/esm-service-queues-app/src/active-visits/change-status-dialog.test.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/change-status-dialog.test.tsx
@@ -35,8 +35,6 @@ jest.mock('@openmrs/esm-framework', () => {
   };
 });
 
-jest.setTimeout(20000);
-
 describe('Queue entry details', () => {
   beforeEach(() =>
     mockedUseConfig.mockReturnValue({

--- a/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist-base-table.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist-base-table.test.tsx
@@ -59,8 +59,6 @@ jest.mock('@openmrs/esm-framework', () => {
   };
 });
 
-jest.setTimeout(20000);
-
 describe('QueuePatientBaseTable: ', () => {
   it('renders a tabular overview of appointments data when available', async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes test timeouts from individual tests and moves them up into the global Jest config as a single testTimeout property whose value is set to 25000ms. Hopefully this tackles the issue where tests time out non-deterministically.

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*
