### PR TITLE
(fix) Remove extraneous margin from visit form

### DIFF
--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.component.tsx
@@ -44,7 +44,7 @@ const StartVisitQueueFields: React.FC = () => {
   }, [queueLocations]);
 
   return (
-    <div className={styles.container}>
+    <div>
       <section className={styles.section}>
         <div className={styles.sectionTitle}>{t('queueLocation', 'Queue location')}</div>
         <ResponsiveWrapper isTablet={isTablet}>

--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.scss
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.scss
@@ -1,21 +1,17 @@
-@use '@carbon/styles/scss/spacing';
-@use '@carbon/styles/scss/type';
+@use '@carbon/layout';
+@use '@carbon/type';
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .sectionTitle {
   @include type.type-style('heading-compact-02');
   color: $text-02;
-  margin-bottom: spacing.$spacing-05;
+  margin-bottom: layout.$spacing-05;
 }
 
 .section {
-  margin: spacing.$spacing-03;
+  margin: layout.$spacing-03;
 }
 
 .sectionHidden {
   display: none;
-}
-
-.container {
-  margin: spacing.$spacing-05;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes some extraneous margin around fields related to service queues in the `Start Visit` form.

## Screenshots

> Before

![CleanShot 2024-01-19 at 12  24 06@2x](https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/20e77a49-1c9a-4563-8f98-c15990e825f9)

> After

![CleanShot 2024-01-19 at 12  26 22@2x](https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/61268fc9-36d0-4100-8394-319e6ccc9898)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
