### PR TITLE
(chore) Enable `continue-on-error` for deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
     steps:
       - name: Trigger RefApp Build
         uses: fjogeleit/http-request-action@master
+        continue-on-error: true
         with:
           url: https://ci.openmrs.org/rest/api/latest/queue/REFAPP-D3X
           method: "POST"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds a `continue-on-error` option to the deploy-patient-chart job and sets its value to true. This makes it so that the workflow will continue to execute even if that step or job encounters an error. This is a prerequisite for additional changes earmarked for the Bamboo deployment job further downstream.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
