### PR TITLE
(fix) O3-2711 - Trash Icon centered in patient Identifiers

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
@@ -144,8 +144,7 @@ export const IdentifierInput: React.FC<IdentifierInputProps> = ({ patientIdentif
               kind="danger--ghost"
               onClick={handleDelete}
               iconDescription={t('deleteIdentifierTooltip', 'Delete')}
-              disabled={disabled}
-              hasIconOnly>
+              disabled={disabled}>
               <TrashCan size={16} />
             </Button>
           </UserHasAccess>


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Just removed the `hasIconOnly` from button.
## Screenshots

> Before :

<img width="841" alt="Screenshot 2024-01-21 at 2 56 30 PM" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/94985341/404426d2-bbc1-48c7-a98d-ea3bc0aea03d">

> After :
<img width="1440" alt="Screenshot 2024-01-21 at 2 38 32 PM" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/94985341/31ead1d4-69ac-42d9-a856-8f803a3b6e19">


## Related Issue
[O3-2711](https://openmrs.atlassian.net/browse/O3-2711)


