### PR TITLE
(fix) O3-2756: On clicking the `View` button, the adjacent dropdown menu is triggered, and the dropdown items are displayed. But it should not get displayed. It should be displayed on clicking `Select Service Type` 

### DIFF
--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
@@ -51,8 +51,9 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, onChange 
             />
           </DatePicker>
         </div>
-        {typeof onChange === 'function' && (
-          <div className={styles.dropdownContainer}>
+        <div className={styles.dropdownContainer}>
+          <label className={styles.view}>{t('view', 'View')}:</label>
+          {typeof onChange === 'function' && (
             <Layer>
               <Dropdown
                 ariaLabel="Dropdown"
@@ -60,15 +61,14 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, onChange 
                 items={[{ name: 'All', uuid: '' }, ...serviceTypes]}
                 itemToString={(item) => (item ? item.name : '')}
                 label={t('selectServiceType', 'Select service type')}
-                titleText={t('view', 'View')}
                 type="inline"
                 size="sm"
                 direction="bottom"
                 onChange={({ selectedItem }) => onChange(selectedItem?.uuid)}
               />
             </Layer>
+          )}
           </div>
-        )}
       </div>
     </div>
   );

--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.scss
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.scss
@@ -46,7 +46,9 @@
 
 .dropdownContainer {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
+  margin-top: 0.25rem;
 }
 
 .value {


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [X] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [X] My work includes tests or is validated by existing tests.

## Summary
When the user clicks the 'View' button, the dropdown menu located beside it is being triggered unexpectedly. As a result, the dropdown items are shown when they shouldn't be, leading to an unintended user experience.

## Video link:
Before: https://www.loom.com/share/ff73bdb2b6944077bfca4bca29da4663?sid=abac56e1-a135-441c-9d88-f17cb8de2f21

After: https://www.loom.com/share/f7dc119fc1b745b8be697b60c2f8ce65?sid=34b657c2-39f4-4af0-9feb-573227684ab0

## Related Issue
https://openmrs.atlassian.net/browse/O3-2756

