### PR TITLE
(fix) 03-2706: Fix active visit widget empty state copy

### DIFF
--- a/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
+++ b/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
@@ -65,7 +65,7 @@ const VisitDetailComponent: React.FC<VisitDetailComponentProps> = ({ visitUuid, 
   } else {
     return (
       <div className={styles.visitEmptyState}>
-        <h4 className={styles.productiveHeading02}>{t('noVisitsFound', 'No visits found')}</h4>
+        <h4 className={styles.productiveHeading02}>{t('noEncountersFound', 'No encounters found')}</h4>
         <p className={classNames(styles.bodyLong01, styles.text02)}>
           {t('thereIsNoInformationToDisplayHere', 'There is no information to display here')}
         </p>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR tweaks the copy shown in the Active Visits widget's empty state after expanding a table row.

## Screenshots

![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/53287480/b5f63697-cb6e-4304-87a3-0ad6e4c885a7)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2706](https://openmrs.atlassian.net/browse/O3-2706)

## Other
<!-- Anything not covered above -->
