### PR TITLE
(fix) O3-2756: Fix inline dropdown rendering in appointments and service queues headers

### DIFF
--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
@@ -1,13 +1,13 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
+import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
+import { DatePicker, DatePickerInput, Dropdown, Layer } from '@carbon/react';
 import { Location } from '@carbon/react/icons';
 import { useSession } from '@openmrs/esm-framework';
-import AppointmentsIllustration from './appointments-illustration.component';
-import styles from './appointments-header.scss';
-import { DatePicker, DatePickerInput, Dropdown, Layer } from '@carbon/react';
-import dayjs from 'dayjs';
 import { changeStartDate, useAppointmentDate } from '../helpers';
 import { useAppointmentServices } from '../hooks/useAppointmentService';
+import AppointmentsIllustration from './appointments-illustration.component';
+import styles from './appointments-header.scss';
 
 interface AppointmentHeaderProps {
   title: string;
@@ -43,7 +43,7 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, onChange 
             datePickerType="single">
             <DatePickerInput
               style={{ cursor: 'pointer', backgroundColor: 'transparent', border: 'none', maxWidth: '10rem' }}
-              id="date-picker-calendar-id"
+              id="appointment-date-picker"
               placeholder="DD-MMM-YYYY"
               labelText=""
               type="text"
@@ -52,21 +52,20 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, onChange 
           </DatePicker>
         </div>
         <div className={styles.dropdownContainer}>
-          <label className={styles.view}>{t('view', 'View')}:</label>
           {typeof onChange === 'function' && (
-            <Layer>
-              <Dropdown
-                aria-label="Select service type"
-                id="selectServicesDropDown"
-                items={[{ name: 'All', uuid: '' }, ...serviceTypes]}
-                itemToString={(item) => (item ? item.name : '')}
-                label={t('selectServiceType', 'Select service type')}
-                type="inline"
-                size="sm"
-                direction="bottom"
-                onChange={({ selectedItem }) => onChange(selectedItem?.uuid)}
-              />
-            </Layer>
+            <Dropdown
+              className={styles.dropdown}
+              aria-label="Select service type"
+              id="serviceDropdown"
+              items={[{ name: 'All', uuid: '' }, ...serviceTypes]}
+              itemToString={(item) => (item ? item.name : '')}
+              label={t('selectServiceType', 'Select service type')}
+              type="inline"
+              size="sm"
+              direction="bottom"
+              titleText={t('view', 'View')}
+              onChange={({ selectedItem }) => onChange(selectedItem?.uuid)}
+            />
           )}
         </div>
       </div>

--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
@@ -68,7 +68,7 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, onChange 
               />
             </Layer>
           )}
-        </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.component.tsx
@@ -51,8 +51,9 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, onChange 
             />
           </DatePicker>
         </div>
-        {typeof onChange === 'function' && (
-          <div className={styles.dropdownContainer}>
+        <div className={styles.dropdownContainer}>
+          <label className={styles.view}>{t('view', 'View')}:</label>
+          {typeof onChange === 'function' && (
             <Layer>
               <Dropdown
                 aria-label="Select service type"
@@ -60,15 +61,14 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, onChange 
                 items={[{ name: 'All', uuid: '' }, ...serviceTypes]}
                 itemToString={(item) => (item ? item.name : '')}
                 label={t('selectServiceType', 'Select service type')}
-                titleText={t('view', 'View')}
                 type="inline"
                 size="sm"
                 direction="bottom"
                 onChange={({ selectedItem }) => onChange(selectedItem?.uuid)}
               />
             </Layer>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.scss
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.scss
@@ -46,7 +46,9 @@
 
 .dropdownContainer {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
+  margin-top: 0.25rem;
 }
 
 .value {

--- a/packages/esm-appointments-app/src/appointments-header/appointments-header.scss
+++ b/packages/esm-appointments-app/src/appointments-header/appointments-header.scss
@@ -72,6 +72,17 @@
   }
 }
 
+.dropdown {
+  :global(.cds--list-box__field) {
+    width: 14rem;
+    overflow: hidden;
+  }
+
+  :global(.cds--dropdown--inline .cds--list-box__menu) {
+    left: -4rem;
+  }
+}
+
 // Overriding styles for RTL support
 html[dir='rtl'] {
   .date-and-location {

--- a/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Calendar, Location } from '@carbon/react/icons';
-import { Dropdown, DropdownSkeleton } from '@carbon/react';
+import { Dropdown } from '@carbon/react';
 import { formatDate, useSession } from '@openmrs/esm-framework';
 import PatientQueueIllustration from './patient-queue-illustration.component';
 import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
@@ -45,21 +45,18 @@ const PatientQueueHeader: React.FC<{ title?: string }> = ({ title }) => {
             <Calendar size={16} />
             <span className={styles.value}>{formatDate(new Date(), { mode: 'standard' })}</span>
           </div>
-          <div className={styles.dropdown}>
-            {isLoading ? (
-              <DropdownSkeleton />
-            ) : (
-              <Dropdown
-                ariaLabel="Dropdown"
-                id="typeOfCare"
-                label={currentQueueLocationName ?? t('all', 'All')}
-                items={[{ id: 'all', name: t('all', 'All') }, ...queueLocations]}
-                itemToString={(item) => (item ? item.name : '')}
-                titleText={t('view', 'View')}
-                type="inline"
-                onChange={handleQueueLocationChange}
-              />
-            )}
+          <div className={styles.dropdownContainer}>
+            <Dropdown
+              aria-label="Select queue location"
+              className={styles.dropdown}
+              id="queueLocationDropdown"
+              label={currentQueueLocationName ?? t('all', 'All')}
+              items={[{ id: 'all', name: t('all', 'All') }, ...queueLocations]}
+              itemToString={(item) => (item ? item.name : '')}
+              titleText={t('view', 'View')}
+              type="inline"
+              onChange={handleQueueLocationChange}
+            />
           </div>
         </div>
       </div>

--- a/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
@@ -46,15 +46,16 @@ const PatientQueueHeader: React.FC<{ title?: string }> = ({ title }) => {
             <span className={styles.value}>{formatDate(new Date(), { mode: 'standard' })}</span>
           </div>
           <div className={styles.dropdown}>
-            <label className={styles.view}>{t('view', 'View')}:</label>
             {isLoading ? (
               <DropdownSkeleton />
             ) : (
               <Dropdown
+                ariaLabel="Dropdown"
                 id="typeOfCare"
                 label={currentQueueLocationName ?? t('all', 'All')}
                 items={[{ id: 'all', name: t('all', 'All') }, ...queueLocations]}
                 itemToString={(item) => (item ? item.name : '')}
+                titleText={t('view', 'View')}
                 type="inline"
                 onChange={handleQueueLocationChange}
               />

--- a/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.scss
+++ b/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.scss
@@ -54,19 +54,21 @@
   @include type.type-style('label-01');
 }
 
-.dropdown {
+.dropdownContainer {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  margin-top: 0.25rem;
+  margin-top: 0.5rem;
+}
 
-  :global(.cds--dropdown__wrapper--inline) {
-    align-items: center;
-    display: flex;
+.dropdown {
+  :global(.cds--list-box__field) {
+    width: 14rem;
+    overflow: hidden;
   }
 
-  :global(.cds--list-box__menu) {
-    left: -10.15rem;
+  :global(.cds--dropdown--inline .cds--list-box__menu) {
+    left: -4rem;
   }
 }
 


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes various aspects of how hinline dropdowns get rendered in the Appointments and Service Queues [page headers](https://zeroheight.com/23a080e38/p/8358ed-page-header). Specifically, both of these dropdowns use the [inline](https://react.carbondesignsystem.com/?path=/story/components-dropdown--inline) variant of the Carbon dropdown component. Presently, the following issues exist with those dropdowns:

- The default behaviour for the inline dropdown component is that clicking the label triggers the display of options in the dropdown panel.

	https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/a865c56f-cb09-4a47-b4aa-57ce07cbf667

  The inline dropdown in the Service Queues page header does not respect this behaviour because it doesn't specify a label using the `titleText` prop. Instead it defines a separate label using the `<label>` element. 

-  Both dropdowns content renders beyond the bounds of the parent element. 

    https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/9591fd2a-ebc6-41c4-85bc-d224fb0baedb

This PR fixes the first issue by removing the label element and using the `titleText` prop instead to set a label for the inline dropdown. It also fixes the second issue by introducing a workaround that effectively 'flips' the inline dropdown's content to the left. In lieu of a proper solution for aligning dropdowns, we could eventually end up generalizing this workaround into a custom component in the style guide.

## Related Issue

https://openmrs.atlassian.net/browse/O3-2756
