### PR TITLE
(feat) make default onKeyUp instant seach for tablet devices configurable

### DIFF
--- a/packages/esm-patient-search-app/src/config-schema.ts
+++ b/packages/esm-patient-search-app/src/config-schema.ts
@@ -12,6 +12,12 @@ export const configSchema = {
       _default: false,
       _description: 'Whether to show recently searched patients',
     },
+    disableTabletSearchOnKeyUp: {
+      _type: Type.Boolean,
+      _default: false,
+      _description:
+        'Disable the default "keyup search" for instant patient search as typing concludes on tablet devices',
+    },
   },
   includeDead: {
     _type: Type.Boolean,
@@ -43,4 +49,12 @@ export const configSchema = {
     _description: 'Identifier to be shown in the event defaultIdentifierTypes does is empty',
     _default: 'OpenMRS ID',
   },
+};
+
+export type PatientSearchConfig = {
+  search: { patientSearchResult: string; showRecentlySearchedPatients: string; disableTabletSearchOnKeyUp: boolean };
+  includeDead: boolean;
+  contactAttributeType: Array<string>;
+  defaultIdentifierTypes: Array<string>;
+  defaultIdentifier: string;
 };

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -15,8 +15,8 @@ interface PatientSearchBarProps {
 const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChildren<PatientSearchBarProps>>(
   ({ buttonProps, initialSearchTerm, onChange, onClear, onSubmit, small }, ref) => {
     const { t } = useTranslation();
-    const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
 
+    const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
     const handleChange = useCallback(
       (val) => {
         if (typeof onChange === 'function') {

--- a/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.test.tsx
@@ -3,6 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import PatientSearchButton from './patient-search-button.component';
 
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  useConfig: jest.fn().mockReturnValue({ search: { disableTabletSearchOnKeyUp: false } }),
+}));
+
 describe('PatientSearchButton', () => {
   it('renders with default props', () => {
     render(<PatientSearchButton />);

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
@@ -10,6 +10,7 @@ jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   isDesktop: jest.fn(),
   useOnClickOutside: jest.fn(),
+  useConfig: jest.fn().mockReturnValue({ search: { disableTabletSearchOnKeyUp: false } }),
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/packages/esm-patient-search-app/src/patient-search-overlay/patient-search-overlay.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-overlay/patient-search-overlay.component.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDebounce } from '@openmrs/esm-framework';
+import { useConfig, useDebounce } from '@openmrs/esm-framework';
 import AdvancedPatientSearchComponent from '../patient-search-page/advanced-patient-search.component';
 import Overlay from '../ui-components/overlay';
 import PatientSearchBar from '../patient-search-bar/patient-search-bar.component';
+import { type PatientSearchConfig } from '../config-schema';
 
 interface PatientSearchOverlayProps {
   onClose: () => void;
@@ -13,6 +14,9 @@ interface PatientSearchOverlayProps {
 
 const PatientSearchOverlay: React.FC<PatientSearchOverlayProps> = ({ onClose, query = '', header }) => {
   const { t } = useTranslation();
+  const {
+    search: { disableTabletSearchOnKeyUp },
+  } = useConfig<PatientSearchConfig>();
   const [searchTerm, setSearchTerm] = useState(query);
   const showSearchResults = Boolean(searchTerm?.trim());
   const debouncedSearchTerm = useDebounce(searchTerm);
@@ -25,7 +29,7 @@ const PatientSearchOverlay: React.FC<PatientSearchOverlayProps> = ({ onClose, qu
     <Overlay header={header ?? t('searchResults', 'Search results')} close={onClose}>
       <PatientSearchBar
         initialSearchTerm={query}
-        onChange={onSearchTermChange}
+        onChange={(query) => !disableTabletSearchOnKeyUp && onSearchTermChange(query)}
         onClear={handleClearSearchTerm}
         onSubmit={onSearchTermChange}
       />

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-page.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-page.test.tsx
@@ -8,6 +8,7 @@ const mockIsDesktop = isDesktop as jest.Mock;
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   isDesktop: jest.fn(),
+  useConfig: jest.fn().mockReturnValue({ search: { disableTabletSearchOnKeyUp: false } }),
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/packages/esm-patient-search-app/src/root.test.tsx
+++ b/packages/esm-patient-search-app/src/root.test.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import PatientSearchRootComponent from './root.component';
 
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  isDesktop: jest.fn(),
+  useConfig: jest.fn().mockReturnValue({ search: { disableTabletSearchOnKeyUp: false } }),
+}));
+
 describe('PatientSearchRootComponent', () => {
   const originalPushState = window.history.pushState;
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR introduces capability to disable `onKeyUp` patient search. This is informed by performance issues where network resource is limited, making every keyup hit the database. We might also want to disable the onkeyup search for desktop devices. 
@ibacher @denniskigen @vasharma05 
## Screenshots
At a facility in Homa Bay County KE
https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/bdcc02e1-a84f-4f4a-b93c-de8c002149e3



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
