### PR TITLE
Revert "(feat) make default onKeyUp instant seach for tablet devices configurable (#970)"

### DIFF
--- a/packages/esm-patient-search-app/src/config-schema.ts
+++ b/packages/esm-patient-search-app/src/config-schema.ts
@@ -12,12 +12,6 @@ export const configSchema = {
       _default: false,
       _description: 'Whether to show recently searched patients',
     },
-    disableTabletSearchOnKeyUp: {
-      _type: Type.Boolean,
-      _default: false,
-      _description:
-        'Disable the default "keyup search" for instant patient search as typing concludes on tablet devices',
-    },
   },
   includeDead: {
     _type: Type.Boolean,
@@ -49,12 +43,4 @@ export const configSchema = {
     _description: 'Identifier to be shown in the event defaultIdentifierTypes does is empty',
     _default: 'OpenMRS ID',
   },
-};
-
-export type PatientSearchConfig = {
-  search: { patientSearchResult: string; showRecentlySearchedPatients: string; disableTabletSearchOnKeyUp: boolean };
-  includeDead: boolean;
-  contactAttributeType: Array<string>;
-  defaultIdentifierTypes: Array<string>;
-  defaultIdentifier: string;
 };

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -15,8 +15,8 @@ interface PatientSearchBarProps {
 const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChildren<PatientSearchBarProps>>(
   ({ buttonProps, initialSearchTerm, onChange, onClear, onSubmit, small }, ref) => {
     const { t } = useTranslation();
-
     const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
+
     const handleChange = useCallback(
       (val) => {
         if (typeof onChange === 'function') {

--- a/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-button/patient-search-button.test.tsx
@@ -3,11 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import PatientSearchButton from './patient-search-button.component';
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  useConfig: jest.fn().mockReturnValue({ search: { disableTabletSearchOnKeyUp: false } }),
-}));
-
 describe('PatientSearchButton', () => {
   it('renders with default props', () => {
     render(<PatientSearchButton />);

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
@@ -10,7 +10,6 @@ jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   isDesktop: jest.fn(),
   useOnClickOutside: jest.fn(),
-  useConfig: jest.fn().mockReturnValue({ search: { disableTabletSearchOnKeyUp: false } }),
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/packages/esm-patient-search-app/src/patient-search-overlay/patient-search-overlay.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-overlay/patient-search-overlay.component.tsx
@@ -1,10 +1,9 @@
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useConfig, useDebounce } from '@openmrs/esm-framework';
+import { useDebounce } from '@openmrs/esm-framework';
 import AdvancedPatientSearchComponent from '../patient-search-page/advanced-patient-search.component';
 import Overlay from '../ui-components/overlay';
 import PatientSearchBar from '../patient-search-bar/patient-search-bar.component';
-import { type PatientSearchConfig } from '../config-schema';
 
 interface PatientSearchOverlayProps {
   onClose: () => void;
@@ -14,9 +13,6 @@ interface PatientSearchOverlayProps {
 
 const PatientSearchOverlay: React.FC<PatientSearchOverlayProps> = ({ onClose, query = '', header }) => {
   const { t } = useTranslation();
-  const {
-    search: { disableTabletSearchOnKeyUp },
-  } = useConfig<PatientSearchConfig>();
   const [searchTerm, setSearchTerm] = useState(query);
   const showSearchResults = Boolean(searchTerm?.trim());
   const debouncedSearchTerm = useDebounce(searchTerm);
@@ -29,7 +25,7 @@ const PatientSearchOverlay: React.FC<PatientSearchOverlayProps> = ({ onClose, qu
     <Overlay header={header ?? t('searchResults', 'Search results')} close={onClose}>
       <PatientSearchBar
         initialSearchTerm={query}
-        onChange={(query) => !disableTabletSearchOnKeyUp && onSearchTermChange(query)}
+        onChange={onSearchTermChange}
         onClear={handleClearSearchTerm}
         onSubmit={onSearchTermChange}
       />

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-page.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-page.test.tsx
@@ -8,7 +8,6 @@ const mockIsDesktop = isDesktop as jest.Mock;
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   isDesktop: jest.fn(),
-  useConfig: jest.fn().mockReturnValue({ search: { disableTabletSearchOnKeyUp: false } }),
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/packages/esm-patient-search-app/src/root.test.tsx
+++ b/packages/esm-patient-search-app/src/root.test.tsx
@@ -2,12 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import PatientSearchRootComponent from './root.component';
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  isDesktop: jest.fn(),
-  useConfig: jest.fn().mockReturnValue({ search: { disableTabletSearchOnKeyUp: false } }),
-}));
-
 describe('PatientSearchRootComponent', () => {
   const originalPushState = window.history.pushState;
 


### PR DESCRIPTION
This reverts commit ca96dc751acee9a01443b8dc1f5125bfc5ba7105.

The config is badly named and has an unhelpful description. Needs to be reworked. Until it is fixed, we should just get rid of it so we don't have to make a "breaking change" to fix it.
