### PR TITLE
(fix) O3-2818: Pressing search button opens advanced search but ignores query string

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -102,7 +102,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
           window.sessionStorage.setItem('searchReturnUrl', window.location.pathname);
         }
         navigate({
-          to: `\${openmrsSpaBase}/search?query=${encodeURIComponent(searchTerm)}`,
+          to: `\${openmrsSpaBase}/search?query=${encodeURIComponent(debouncedSearchTerm)}`,
         });
       }
     },

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
@@ -1,93 +1,66 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
-import { useConfig } from '@openmrs/esm-framework';
+import {
+  defineConfigSchema,
+  getDefaultsFromConfigSchema,
+  navigate,
+  provide,
+  useConfig,
+  useSession,
+} from '@openmrs/esm-framework';
 import CompactPatientSearchComponent from './compact-patient-search.component';
+import { configSchema } from '../config-schema';
 
-const mockedUseConfig = jest.mocked(useConfig);
+defineConfigSchema('@openmrs/esm-patient-search-app', configSchema);
 
-jest.mock('@openmrs/esm-framework', () => ({
-  ...jest.requireActual('@openmrs/esm-framework'),
-  useSession: jest.fn().mockReturnValue({
-    sessionLocation: {
-      uuid: 'location-uuid',
-    },
-  }),
-  useConfig: jest.fn().mockReturnValue({
-    search: {
-      patientResultUrl: '/patient/{{patientUuid}}/chart',
-      showRecentlySearchedPatients: false,
-    },
-  }),
-}));
+const mockedUseConfig = useConfig as jest.Mock;
+const mockedUseSession = useSession as jest.Mock;
+const mockedNavigate = navigate as jest.Mock;
 
 describe('CompactPatientSearchComponent', () => {
-  beforeEach(() => mockedUseConfig.mockClear());
+  beforeEach(() => {
+    mockedUseConfig.mockReturnValue(getDefaultsFromConfigSchema(configSchema));
+    mockedUseSession.mockReturnValue({
+      sessionLocation: {
+        uuid: 'location-uuid',
+      },
+    });
+  });
 
   it('renders a compact search bar', () => {
     render(<CompactPatientSearchComponent isSearchPage initialSearchTerm="" />);
-
     expect(screen.getByPlaceholderText(/Search for a patient by name or identifier number/i)).toBeInTheDocument();
-  });
-
-  it('typing into the searchbox updates the search term and triggers a search', async () => {
-    const user = userEvent.setup();
-
-    render(<CompactPatientSearchComponent isSearchPage initialSearchTerm="" />);
-
-    const searchbox = screen.getByPlaceholderText(/Search for a patient by name or identifier number/i);
-
-    await user.type(searchbox, 'John');
-
-    expect(screen.getByDisplayValue(/John/i)).toBeInTheDocument();
-  });
-
-  it('clears search term on clear button click', async () => {
-    const user = userEvent.setup();
-
-    render(<CompactPatientSearchComponent isSearchPage={true} initialSearchTerm="" />);
-
-    const searchbox = screen.getByPlaceholderText(/Search for a patient by name or identifier number/i);
-
-    const clearButton = screen.getByRole('button', { name: /Clear/i });
-
-    await user.type(searchbox, 'John');
-    await user.click(clearButton);
-
-    expect(screen.queryByDisplayValue(/John/i)).not.toBeInTheDocument();
   });
 
   it('renders search results when search term is not empty', async () => {
     const user = userEvent.setup();
-
     render(<CompactPatientSearchComponent isSearchPage={false} initialSearchTerm="" />);
-
     const searchbox = screen.getByPlaceholderText(/Search for a patient by name or identifier number/i);
-
     await user.type(searchbox, 'John');
-
     const searchResultsContainer = screen.getByTestId('floatingSearchResultsContainer');
-
     expect(searchResultsContainer).toBeInTheDocument();
   });
 
   it('renders a list of recently searched patients when a search term is not provided and the showRecentlySearchedPatients config property is set', async () => {
-    const user = userEvent.setup();
-
     mockedUseConfig.mockReturnValue({
-      search: {
-        showRecentlySearchedPatients: true,
-      },
+      ...getDefaultsFromConfigSchema(configSchema),
+      search: { showRecentlySearchedPatients: true },
     });
-
     render(<CompactPatientSearchComponent isSearchPage={false} initialSearchTerm="" />);
-
-    const searchbox = screen.getByRole('searchbox');
-
-    await user.clear(searchbox);
-
     const searchResultsContainer = screen.getByTestId('floatingSearchResultsContainer');
-
     expect(searchResultsContainer).toBeInTheDocument();
+  });
+
+  it('navigates to the advanced search page with the correct query string when the Search button is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <CompactPatientSearchComponent isSearchPage={false} initialSearchTerm="" shouldNavigateToPatientSearchPage />,
+    );
+    const searchbox = screen.getByRole('searchbox');
+    await user.type(searchbox, 'John');
+    const searchButton = screen.getByRole('button', { name: /search/i });
+    await user.click(searchButton);
+    expect(mockedNavigate).toHaveBeenCalledWith({ to: expect.stringMatching(/.*\/search\?query=John/) });
   });
 });

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
@@ -3,12 +3,7 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .searchArea {
-  width: inherit;
   display: flex;
   justify-content: center;
   align-items: center;
-}
-
-.patientSearchInput {
-  border: none;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Fixes problem introduced in https://github.com/openmrs/openmrs-esm-patient-management/pull/959

Deletes tests that test nothing; makes some tests that did basically nothing actually do something.

## Related Issue

https://openmrs.atlassian.net/browse/O3-2818
