### PR TITLE
(fix) KHP3-5058: Remove sort weight field in start visit form

### DIFF
--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.component.tsx
@@ -4,9 +4,10 @@ import { InlineNotification, Layer, Select, SelectItem, RadioButtonGroup, RadioB
 import { useQueueLocations } from '../hooks/useQueueLocations';
 import { usePriority, useStatus } from '../../active-visits/active-visits-table.resource';
 import styles from './visit-form-queue-fields.scss';
-import { type ConfigObject, useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { useQueues } from '../../helpers/useQueues';
+import { type ConfigObject } from '../../config-schema';
 
 const StartVisitQueueFields: React.FC = () => {
   const { t } = useTranslation();
@@ -14,22 +15,14 @@ const StartVisitQueueFields: React.FC = () => {
   const { priorities } = usePriority();
   const { statuses } = useStatus();
   const { queueLocations } = useQueueLocations();
-  const config = useConfig() as ConfigObject;
-  const defaultStatus = config.concepts.defaultStatusConceptUuid;
-  const defaultPriority = config.concepts.defaultPriorityConceptUuid;
-  const emergencyPriorityConceptUuid = config.concepts.emergencyPriorityConceptUuid;
+  const {
+    concepts: { defaultPriorityConceptUuid, defaultStatusConceptUuid },
+  } = useConfig<ConfigObject>();
   const [selectedQueueLocation, setSelectedQueueLocation] = useState(queueLocations[0]?.id);
   const { queues } = useQueues(selectedQueueLocation);
-  const [priority, setPriority] = useState(defaultPriority);
-  const [status, setStatus] = useState(defaultStatus);
-  const [sortWeight, setSortWeight] = useState(0);
+  const [priority, setPriority] = useState(defaultPriorityConceptUuid);
+  const [status, setStatus] = useState(defaultStatusConceptUuid);
   const [service, setSelectedService] = useState('');
-
-  useEffect(() => {
-    if (priority === emergencyPriorityConceptUuid) {
-      setSortWeight(1);
-    }
-  }, [priority]);
 
   useEffect(() => {
     if (queues?.length > 0) {
@@ -131,7 +124,7 @@ const StartVisitQueueFields: React.FC = () => {
             className={styles.radioButtonWrapper}
             name="priority"
             id="priority"
-            defaultSelected={defaultPriority}
+            defaultSelected={defaultPriorityConceptUuid}
             onChange={(uuid) => {
               setPriority(uuid);
             }}>
@@ -139,16 +132,6 @@ const StartVisitQueueFields: React.FC = () => {
               priorities.map(({ uuid, display }) => <RadioButton key={uuid} labelText={display} value={uuid} />)}
           </RadioButtonGroup>
         )}
-      </section>
-
-      <section className={classNames(styles.section, styles.sectionHidden)}>
-        <TextInput
-          type="number"
-          id="sortWeight"
-          name="sortWeight"
-          labelText={t('sortWeight', 'Sort weight')}
-          value={sortWeight}
-        />
       </section>
     </div>
   );

--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.test.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.test.tsx
@@ -45,7 +45,6 @@ describe('StartVisitQueueFields', () => {
     expect(getByLabelText('Select a service')).toBeInTheDocument();
     expect(getByLabelText('Select a status')).toBeInTheDocument();
     expect(getByText('High')).toBeInTheDocument();
-    expect(getByLabelText('Sort weight')).toBeInTheDocument();
   });
 
   it('updates the selected queue location', async () => {

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -224,7 +224,6 @@
   "showLess": "Show less",
   "showPatientsWaitingFor": "Show patients waiting for",
   "sortBy": "Sort by",
-  "sortWeight": "Sort weight",
   "sp02": "Sp02",
   "startAgeRangeInvalid": "Start age range is not valid",
   "startAVisit": "Start a visit",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR removes `sortWeight` from the visit-queue fields component. This field wasn't being used for any other thing.
cc @CynthiaKamau 
## Screenshots
Removed the section with red border
![Screenshot 2024-02-12 at 11 14 47](https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/47c207c3-5195-4e74-b222-638aa32b0d00)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
