### PR TITLE
(fix) Restore banner tags in search results

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { SkeletonIcon, SkeletonText, Tag } from '@carbon/react';
+import { Tag } from '@carbon/react';
 import { ConfigurableLink, ExtensionSlot, age, interpolateString, useConfig } from '@openmrs/esm-framework';
 import { PatientSearchContext } from '../patient-search-context';
 import type { FHIRIdentifier, FHIRPatientType, Identifier, SearchedPatient } from '../types';
@@ -53,7 +53,7 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
         gender: patient.person.gender,
         birthDate: patient.person.birthdate,
         deceasedDateTime: patient.person.deathDate,
-        deceasedBoolean: patient.person.death,
+        deceasedBoolean: patient.person.dead,
         identifier: patient.identifiers as any as Array<FHIRIdentifier>,
         address: preferredAddress
           ? [
@@ -95,11 +95,11 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
               <div className={styles.flexRow}>
                 <h2 className={styles.patientName}>{`${patient.name?.[0]?.given?.join(' ')} ${patient.name?.[0]
                   ?.family}`}</h2>
-                {/* <ExtensionSlot
-                    name="patient-banner-tags-slot"
-                    state={{ patient, patientUuid: patient.id }}
-                    className={styles.flexRow}
-                  /> */}
+                <ExtensionSlot
+                  name="patient-banner-tags-slot"
+                  state={{ patient, patientUuid: patient.id }}
+                  className={styles.flexRow}
+                />
               </div>
               <div className={styles.demographics}>
                 {getGender(patient.gender)} <span className={styles.middot}>&middot;</span> {age(patient.birthDate)}
@@ -107,7 +107,7 @@ const PatientSearchResults = React.forwardRef<HTMLDivElement, PatientSearchResul
                 {config.defaultIdentifierTypes.length ? (
                   <>
                     {patientIdentifiers.length > 1 ? (
-                      <PatientIdentifier identifiers={patientIdentifiers} />
+                      <Identifiers identifiers={patientIdentifiers} />
                     ) : (
                       <CustomIdentifier patient={patients[index]} identifierName={config.defaultIdentifier} />
                     )}
@@ -162,31 +162,7 @@ const ClickablePatientContainer = ({ patient, children }: ClickablePatientContai
   }
 };
 
-export const SearchResultSkeleton = () => {
-  return (
-    <div className={styles.patientSearchResult} data-testid="search-skeleton">
-      <div className={styles.patientAvatar} role="img">
-        <SkeletonIcon
-          style={{
-            height: '3rem',
-            width: '3rem',
-          }}
-        />
-      </div>
-      <div>
-        <h2>
-          <SkeletonText />
-        </h2>
-        <span className={styles.demographics}>
-          <SkeletonIcon /> <span className={styles.middot}>&middot;</span> <SkeletonIcon />{' '}
-          <span className={styles.middot}>&middot;</span> <SkeletonIcon />
-        </span>
-      </div>
-    </div>
-  );
-};
-
-const PatientIdentifier: React.FC<{ identifiers: Array<Identifier> }> = ({ identifiers }) => {
+const Identifiers: React.FC<{ identifiers: Array<Identifier> }> = ({ identifiers }) => {
   return (
     <>
       {identifiers.map((identifier) => (

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
@@ -117,3 +117,8 @@
   flex-flow: row wrap;
   align-items: center;
 }
+
+.skeletonIcon {
+  height: 3rem;
+  width: 3rem;
+}

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
@@ -5,7 +5,6 @@ import {
   defineConfigSchema,
   getDefaultsFromConfigSchema,
   navigate,
-  provide,
   useConfig,
   useSession,
 } from '@openmrs/esm-framework';

--- a/packages/esm-patient-search-app/src/compact-patient-search/loader.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/loader.component.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { SkeletonIcon, SkeletonText } from '@carbon/react';
+import styles from './compact-patient-banner.scss';
+
+export const Loader = () => {
+  return (
+    <div className={styles.patientSearchResult} data-testid="search-skeleton">
+      <div className={styles.patientAvatar} role="img">
+        <SkeletonIcon className={styles.skeletonIcon} />
+      </div>
+      <div>
+        <SkeletonText />
+        <span className={styles.demographics}>
+          <SkeletonIcon /> <span className={styles.middot}>&middot;</span> <SkeletonIcon />{' '}
+          <span className={styles.middot}>&middot;</span> <SkeletonIcon />
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default Loader;

--- a/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
@@ -2,7 +2,8 @@ import React, { useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Layer, Loading, Tile } from '@carbon/react';
 import EmptyDataIllustration from '../ui-components/empty-data-illustration.component';
-import PatientSearchResults, { SearchResultSkeleton } from './compact-patient-banner.component';
+import CompactPatientBanner from './compact-patient-banner.component';
+import Loader from './loader.component';
 import type { PatientSearchResponse } from '../types';
 import styles from './patient-search.scss';
 
@@ -43,7 +44,7 @@ const PatientSearch = React.forwardRef<HTMLDivElement, PatientSearchProps>(
       return (
         <div className={styles.searchResultsContainer}>
           {[...Array(5)].map((_, index) => (
-            <SearchResultSkeleton key={index} />
+            <Loader key={index} />
           ))}
         </div>
       );
@@ -79,7 +80,7 @@ const PatientSearch = React.forwardRef<HTMLDivElement, PatientSearchProps>(
                 count: totalResults,
               })}
             </p>
-            <PatientSearchResults patients={searchResults} ref={ref} />
+            <CompactPatientBanner patients={searchResults} ref={ref} />
             {hasMore && (
               <div className={styles.loadingIcon} ref={loadingIconRef}>
                 <Loading withOverlay={false} small />

--- a/packages/esm-patient-search-app/src/compact-patient-search/recent-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/recent-patient-search.component.tsx
@@ -1,9 +1,10 @@
 import React, { useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Layer, Loading, Tile } from '@carbon/react';
-import type { PatientSearchResponse, SearchedPatient } from '../types';
+import type { PatientSearchResponse } from '../types';
 import EmptyDataIllustration from '../ui-components/empty-data-illustration.component';
-import PatientSearchResults, { SearchResultSkeleton } from './compact-patient-banner.component';
+import Loader from './loader.component';
+import PatientSearchResults from './compact-patient-banner.component';
 import styles from './patient-search.scss';
 
 interface RecentPatientSearchProps extends PatientSearchResponse {}
@@ -41,7 +42,7 @@ const RecentPatientSearch = React.forwardRef<HTMLDivElement, RecentPatientSearch
       return (
         <div className={styles.searchResultsContainer}>
           {[...Array(5)].map((_, index) => (
-            <SearchResultSkeleton key={index} />
+            <Loader key={index} />
           ))}
         </div>
       );

--- a/packages/esm-patient-search-app/src/types/index.ts
+++ b/packages/esm-patient-search-app/src/types/index.ts
@@ -1,4 +1,5 @@
 import { type FetchResponse, type OpenmrsResource } from '@openmrs/esm-framework';
+
 export interface SearchedPatient {
   uuid: string;
   identifiers: Array<Identifier>;
@@ -7,8 +8,8 @@ export interface SearchedPatient {
     age: number;
     birthdate: string;
     gender: string;
-    death: boolean;
-    deathDate: string;
+    dead: boolean;
+    deathDate: string | null;
     personName: {
       display: string;
       givenName: string;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR restores the `patient-banner-tags-slot` extension slot in the compact patient banner. This slot renders tags such as deceased and active visit tags (for patients who are dead and who have active visits respectively) in the search results. 

This slot was originally disabled in https://github.com/openmrs/openmrs-esm-patient-management/pull/817 after the slot began exhibiting some odd behaviour that we later learned (following @brandones' excellent work) was owing to [spurious re-renders](https://github.com/openmrs/openmrs-esm-core/pull/874) in the navbar.

Now that the underlying issue has been resolved, it's probably OK to restore this functionality. I've also moved things around including:

- Renaming the `PatientSearchResults` component to `CompactPatientBanner`. I don't know why a Component in a file named `compact-patient-banner.component.tsx` would be named `PatientSearchResults`, especially when there's another completely different component with the same exact name.
- I've also factored the `SearchResultSkeleton` component out into its own file (it was not getting used in the component where it was defined) and renamed it to `Loader`.

## Screenshots

### Checking that there aren't any spurious re-renders in the navbar

https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/934251aa-22ae-406f-8b24-f41fe4f27c6d

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
