### PR TITLE
(fix) O3 2804: Reuse ResponsiveWrapper component from esm-framework

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -8,7 +8,6 @@ import {
   DatePicker,
   Form,
   InlineLoading,
-  Layer,
   MultiSelect,
   NumberInput,
   Select,
@@ -24,7 +23,14 @@ import {
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { useLocations, useSession, showSnackbar, useLayoutType, useConfig } from '@openmrs/esm-framework';
+import {
+  useLocations,
+  useSession,
+  showSnackbar,
+  useLayoutType,
+  useConfig,
+  ResponsiveWrapper,
+} from '@openmrs/esm-framework';
 import { convertTime12to24 } from '@openmrs/esm-patient-common-lib';
 import {
   saveAppointment,
@@ -302,7 +308,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
         <section className={styles.formGroup}>
           <span className={styles.heading}>{t('location', 'Location')}</span>
           <div>
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <Controller
                 name="location"
                 control={control}
@@ -330,7 +336,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
         </section>
         <section className={styles.formGroup}>
           <span className={styles.heading}>{t('service', 'Service')}</span>
-          <ResponsiveWrapper isTablet={isTablet}>
+          <ResponsiveWrapper>
             <Controller
               name="selectedService"
               control={control}
@@ -364,7 +370,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
 
         <section className={styles.formGroup}>
           <span className={styles.heading}>{t('appointmentType_title', 'Appointment Type')}</span>
-          <ResponsiveWrapper isTablet={isTablet}>
+          <ResponsiveWrapper>
             <Controller
               name="appointmentType"
               control={control}
@@ -417,12 +423,12 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
                     toggled={isAllDayAppointment}
                   />
                 )}
-                <ResponsiveWrapper isTablet={isTablet}>
+                <ResponsiveWrapper>
                   <Controller
                     name="appointmentDateTime"
                     control={control}
                     render={({ field: { onChange, value, ref } }) => (
-                      <ResponsiveWrapper isTablet={isTablet}>
+                      <ResponsiveWrapper>
                         <DatePicker
                           datePickerType="range"
                           dateFormat={datePickerFormat}
@@ -459,7 +465,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
                   <TimeAndDuration isTablet={isTablet} control={control} services={services} watch={watch} t={t} />
                 )}
 
-                <ResponsiveWrapper isTablet={isTablet}>
+                <ResponsiveWrapper>
                   <Controller
                     name="recurringPatternPeriod"
                     control={control}
@@ -482,7 +488,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
                   />
                 </ResponsiveWrapper>
 
-                <ResponsiveWrapper isTablet={isTablet}>
+                <ResponsiveWrapper>
                   <Controller
                     name="recurringPatternType"
                     control={control}
@@ -543,7 +549,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
                     toggled={isAllDayAppointment}
                   />
                 )}
-                <ResponsiveWrapper isTablet={isTablet}>
+                <ResponsiveWrapper>
                   <Controller
                     name="appointmentDateTime"
                     control={control}
@@ -575,7 +581,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
 
         {getValues('selectedService') && (
           <section className={styles.formGroup}>
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <Workload
                 selectedService={watch('selectedService')}
                 appointmentDate={watch('appointmentDateTime').startDate}
@@ -587,7 +593,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
         {context !== 'creating' ? (
           <section className={styles.formGroup}>
             <span className={styles.heading}>{t('appointmentStatus', 'Appointment Status')}</span>
-            <ResponsiveWrapper isTablet={isTablet}>
+            <ResponsiveWrapper>
               <Controller
                 name="appointmentStatus"
                 control={control}
@@ -621,7 +627,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
             name="appointmentNote"
             control={control}
             render={({ field: { onChange, onBlur, value, ref } }) => (
-              <ResponsiveWrapper isTablet={isTablet}>
+              <ResponsiveWrapper>
                 <TextArea
                   id="appointmentNote"
                   value={value}
@@ -648,16 +654,12 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
   );
 };
 
-function ResponsiveWrapper({ children, isTablet }) {
-  return isTablet ? <Layer>{children}</Layer> : <div>{children}</div>;
-}
-
 function TimeAndDuration({ isTablet, t, watch, control, services }) {
   const defaultDuration = services?.find((service) => service.name === watch('selectedService'))?.durationMins || null;
 
   return (
-    <React.Fragment>
-      <ResponsiveWrapper isTablet={isTablet}>
+    <>
+      <ResponsiveWrapper>
         <Controller
           name="startTime"
           control={control}
@@ -687,7 +689,7 @@ function TimeAndDuration({ isTablet, t, watch, control, services }) {
           )}
         />
       </ResponsiveWrapper>
-      <ResponsiveWrapper isTablet={isTablet}>
+      <ResponsiveWrapper>
         <Controller
           name="duration"
           control={control}
@@ -709,7 +711,7 @@ function TimeAndDuration({ isTablet, t, watch, control, services }) {
           )}
         />
       </ResponsiveWrapper>
-    </React.Fragment>
+    </>
   );
 }
 

--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.component.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
-import { InlineNotification, Layer, Select, SelectItem, RadioButtonGroup, RadioButton, TextInput } from '@carbon/react';
+import { InlineNotification, Select, SelectItem, RadioButtonGroup, RadioButton, TextInput } from '@carbon/react';
 import { useQueueLocations } from '../hooks/useQueueLocations';
 import { usePriority, useStatus } from '../../active-visits/active-visits-table.resource';
 import styles from './visit-form-queue-fields.scss';
-import { type ConfigObject, useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { type ConfigObject, useConfig, useLayoutType, ResponsiveWrapper } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { useQueues } from '../../helpers/useQueues';
 
@@ -47,7 +47,7 @@ const StartVisitQueueFields: React.FC = () => {
     <div>
       <section className={styles.section}>
         <div className={styles.sectionTitle}>{t('queueLocation', 'Queue location')}</div>
-        <ResponsiveWrapper isTablet={isTablet}>
+        <ResponsiveWrapper>
           <Select
             labelText={t('selectQueueLocation', 'Select a queue location')}
             id="queueLocation"
@@ -153,9 +153,5 @@ const StartVisitQueueFields: React.FC = () => {
     </div>
   );
 };
-
-function ResponsiveWrapper({ children, isTablet }) {
-  return isTablet ? <Layer>{children}</Layer> : <div>{children}</div>;
-}
 
 export default StartVisitQueueFields;

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
@@ -9,7 +9,6 @@ import {
   DatePickerInput,
   Form,
   InlineNotification,
-  Layer,
   Row,
   Select,
   SelectItem,
@@ -34,6 +33,7 @@ import {
   toDateObjectStrict,
   showSnackbar,
   useConfig,
+  ResponsiveWrapper,
   type ConfigObject,
 } from '@openmrs/esm-framework';
 import BaseVisitType from './base-visit-type.component';
@@ -229,7 +229,7 @@ const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchTyp
                   style={{ width: '100%' }}
                 />
               </DatePicker>
-              <ResponsiveWrapper isTablet={isTablet}>
+              <ResponsiveWrapper>
                 <TimePicker
                   id="visitStartTime"
                   labelText={t('time', 'Time')}
@@ -356,9 +356,5 @@ const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchTyp
     </Form>
   );
 };
-
-function ResponsiveWrapper({ children, isTablet }) {
-  return isTablet ? <Layer>{children}</Layer> : <div>{children}</div>;
-}
 
 export default StartVisitForm;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,9 +2857,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-api@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-api@npm:5.3.3-pre.1450"
+"@openmrs/esm-api@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-api@npm:5.4.1-pre.1567"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -2868,17 +2868,17 @@ __metadata:
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 0558ee9d238d8632ad73c2ed2b356ba07315e7185a37d4502f94038a15d44778af70146563016fedd1f213c4127f3f03a3aae346e651a4658e677bf8ed4ada9d
+  checksum: 734b3b614e17e158e134a26ce603c886f8649f242901e2463bfe4d734d9ed6b1637e66ef52d489cd311cfd93acc860c6225df3ee2459536ebb4c3497f04e1535
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-app-shell@npm:5.3.3-pre.1450"
+"@openmrs/esm-app-shell@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-app-shell@npm:5.4.1-pre.1567"
   dependencies:
     "@carbon/react": "npm:~1.37.0"
-    "@openmrs/esm-framework": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-styleguide": "npm:5.3.3-pre.1450"
+    "@openmrs/esm-framework": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-styleguide": "npm:5.4.1-pre.1567"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -2903,7 +2903,7 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 4b0f2a5929c5be9521d063a1f01d0ad3e402ab9520dcde09cb3909d35456623090d982abcc022c9dfcee3a853d230de4e7116f712c91b608e2e765496ebc0d8e
+  checksum: 441cddd6f4643a771a2e2133c8ad2ec5debcfbfcdd0be0e8e139c2ec50aeea78803902395718d4b30e6f9d733f4ea2dba2063baf8bcb537a774ba8eaeb4d8785
   languageName: node
   linkType: hard
 
@@ -2925,40 +2925,40 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-config@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-config@npm:5.3.3-pre.1450"
+"@openmrs/esm-config@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-config@npm:5.4.1-pre.1567"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 85bb4848f6296a1402cf7a9779de3e158525d44e9928333d02c4225d0ecfd475501a824e5de648268518c361cbe678a9d3c74d4fc134b29d400c6b732dff9525
+  checksum: c4028fde9c9e65df8bc0113538008e8cc8b32599eca05b53754df358c8022523d6f1c28a51b8953d2000d69c54a0195951cfc013e295690057acdeab25f62c25
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1450"
+"@openmrs/esm-dynamic-loading@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.4.1-pre.1567"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 41f37c54df17829d685286126e5222ddbe4fccebf0b6994c4465c1c24deef44c1e55297190410336ff3d4396303bc4a2f56cc4d63f3938c1e41cec65fa3de208
+  checksum: f94836a6f4cad570355ce37b376cfa3aba0411688c21f627ab49e715f8dba93086a78715a5597e30f4fbe50028c3f54feb4cd5b1c8f9de7e8a2c7d3a9dc80606
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-error-handling@npm:5.3.3-pre.1450"
+"@openmrs/esm-error-handling@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-error-handling@npm:5.4.1-pre.1567"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: b3271a4962c13f81ba6de760959299be7813ebbbb1097d170ffcb85e575af0155da37454bf32e62baa7e70436ba8fc07bfc0082ad925ffba35cf5dd99bf0945a
+  checksum: a3bcebca5b0deb367f700d23ddf6531951d316dc717b078c3b8daca62b11aceeee2bbabc33bef373d4316107e878bc75682c44be827664ce7fce6d5c20b7446f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-extensions@npm:5.3.3-pre.1450"
+"@openmrs/esm-extensions@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-extensions@npm:5.4.1-pre.1567"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -2967,41 +2967,41 @@ __metadata:
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: b13013d799f3dde74800a436431d8353b1807a413482415653f216eedce67b6901f7121311e7b2891ebe05f35ab95c4df16900d5a644907aae4cba3ca4d8a236
+  checksum: d08f137935c00190b9019d6d5e556269a464fb07582fae535b2eb49f13de6a43fb490365ec6d2c9752cf19cc5075d138de45188f9a1d6282c14ae490401366ee
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-feature-flags@npm:5.3.3-pre.1450"
+"@openmrs/esm-feature-flags@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-feature-flags@npm:5.4.1-pre.1567"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 348ea8e29b48ba280f5db562f1d1b3f6e4194bf693da0eb2a770c0b5a59f36f0aca473a831e9375fc359c2c421b24b68f74ec6b27dd2652e084d8d7a9ea87aa7
+  checksum: 6fa596325827b03c37a9c262a238cf362fda0b79b42dbf8d1f58f1285013e6e508956df8e11e4c57cf6f244e828b43c4a523981c8832e3d8eb5394f1c841ca97
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:5.3.3-pre.1450, @openmrs/esm-framework@npm:next":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-framework@npm:5.3.3-pre.1450"
+"@openmrs/esm-framework@npm:5.4.1-pre.1567, @openmrs/esm-framework@npm:next":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-framework@npm:5.4.1-pre.1567"
   dependencies:
-    "@openmrs/esm-api": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-config": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-dynamic-loading": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-error-handling": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-extensions": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-feature-flags": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-globals": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-navigation": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-offline": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-react-utils": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-routes": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-state": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-styleguide": "npm:5.3.3-pre.1450"
-    "@openmrs/esm-utils": "npm:5.3.3-pre.1450"
+    "@openmrs/esm-api": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-config": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-dynamic-loading": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-error-handling": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-extensions": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-feature-flags": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-globals": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-navigation": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-offline": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-react-utils": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-routes": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-state": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-styleguide": "npm:5.4.1-pre.1567"
+    "@openmrs/esm-utils": "npm:5.4.1-pre.1567"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
@@ -3012,33 +3012,33 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: 9774aaffaac21052b49b6778183ca1d85a5c76f93dc0983bfe4aea4ebe181b3389b1f2fdcbec36afbf149c84ff6ba74554891683fb232c0fedb55623786ca190
+  checksum: 0b25ffa02114cfc01794fecb169a28f1829020d297c7cb0d20b6d58d4c0ee687f6c0064a677f74edda0e180a5e63b7ea8d5ca7605f7630baad9c2e3e97afe12d
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-globals@npm:5.3.3-pre.1450"
+"@openmrs/esm-globals@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-globals@npm:5.4.1-pre.1567"
   peerDependencies:
     single-spa: 5.x
-  checksum: fea501d7876243fc8a3d9e7fec809393530e100a4f5a8a30a2b8aaa9743580718347b2e91cc2067186acfebc9e4875efad2bc4609908815e0ff8d432b89bcc47
+  checksum: 57cdf8d784afa58ffec5f5b7e17c3efad7e6662f8ce137974e634dcbe92217e8dd72e23c75b430182ef6674685957cf13172174c9ac0917cd8696961d7513bc2
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-navigation@npm:5.3.3-pre.1450"
+"@openmrs/esm-navigation@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-navigation@npm:5.4.1-pre.1567"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: 6a34d108070b5da2d0050f35911d89262f765282310df0b714861d4a05c696b9daa5d0df9233e3d65015e577b7b4a01f68bfaa804d02aac94c42256bdb73ad2a
+  checksum: 40211b802a484cf09f15f09238fa1e82d2d8f84b4eda87b53bc4cd106acf7c47dd496b47abe475249f3652c932264b060490573b5dbf139dd85a22cdf928298d
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-offline@npm:5.3.3-pre.1450"
+"@openmrs/esm-offline@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-offline@npm:5.4.1-pre.1567"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -3050,7 +3050,7 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: f7733f212fa5e1e45588e28ea0c16e23d87fb068c1c71f60d634786d98ede1cf01affdec917c7ee6386b65a91e1e0a6101c964a7b42bd2026be1f82b53be5429
+  checksum: 2f90b5c56ce2090f82581e2a1f620df45a97a028fae8e404ddacbf462b00b57657f6f2e2840a13f2c56ce0b95d638b28727c8040ae7239c6cc838f5f990e528b
   languageName: node
   linkType: hard
 
@@ -3192,9 +3192,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-react-utils@npm:5.3.3-pre.1450"
+"@openmrs/esm-react-utils@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-react-utils@npm:5.4.1-pre.1567"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:^6.0.0"
@@ -3212,17 +3212,17 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 71c3a3f40ca0f4936781e65111ed281b3bd31d35f48fa6d4747293960ec08148665cd9b1be27a48dcddf48f901424b83182f13e7fd0334a806920a75ae346157
+  checksum: 119c0a0dc2d2615c6b34dc26c7d0fe9c6cb9a6c12e8974330e5f5861026a7a67bcfcbb29d61ff4f656ad3ddba399625516562f9f5de9fdd61b309dbaa542eabc
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-routes@npm:5.3.3-pre.1450"
+"@openmrs/esm-routes@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-routes@npm:5.4.1-pre.1567"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
-  checksum: 1cfcd8ea2afd16bf0e150f66950a2aeca3c89c639227740474e8cb37e6a98b25b16783340939213a5088d1b3809f185a9b97ace399c568d5e8d6e8f462c74cd3
+  checksum: 24761ee3988bef8fa9a6b8732d54b9d77b859ec960dc91bee9f9a695997f39ddb4007a5d25d96a4f17a6547ce52078a431ddadadbbc88746052fb03794e0a08e
   languageName: node
   linkType: hard
 
@@ -3242,20 +3242,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-state@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-state@npm:5.3.3-pre.1450"
+"@openmrs/esm-state@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-state@npm:5.4.1-pre.1567"
   dependencies:
     zustand: "npm:^4.3.6"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 7a17cec155a7f3833af247951edc8a4c3c4a7c317f457aacae6b70e067d3c5008d1efe55bcb4663f2e3da96a2d908eef7cbef44cb73cfc2d028073fd0ba27bbe
+  checksum: ad7df45aad222e62acf02657f5e0d45a5639448ac58e575581a3c6532db642e871e887c75b5ea6f5355d7af47fe66ecc5254e82468e4fef01f16cef1cf88f6e5
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-styleguide@npm:5.3.3-pre.1450"
+"@openmrs/esm-styleguide@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-styleguide@npm:5.4.1-pre.1567"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
@@ -3274,26 +3274,26 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 02ac16866d9c927ff3b5671cf52af6b4f84cfd9709ea4461aa02090447eacb9729ab8523550c86600d134feb7b1e67776d1c51717584880a4af231a54f7a52b5
+  checksum: c88229a4eb162ee02969298701ad530dc392f403d1a066a1d02746b1fd6cc970af2602e8ebcc8fce428c86b48c5ae3b5d3093b40c64c09c47fb5665bbb6ed556
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/esm-utils@npm:5.3.3-pre.1450"
+"@openmrs/esm-utils@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/esm-utils@npm:5.4.1-pre.1567"
   dependencies:
     semver: "npm:7.3.2"
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: 410091c919cf1a8701f11efc0fc0822c6257e5efb1396a440e63e2235f714d8eb348619b344c1216b57163e40bd35268bcbfdc97e17f0e1332b7085f83e3e495
+  checksum: b230498d1c5167fc27ae08733390101d71ae26e7e81373ce36b8d277e4cc57f309ad17d7bcfb76a1293650cd4630f403f38289989ed876dff5082db89bdc3eec
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.3.3-pre.1450":
-  version: 5.3.3-pre.1450
-  resolution: "@openmrs/webpack-config@npm:5.3.3-pre.1450"
+"@openmrs/webpack-config@npm:5.4.1-pre.1567":
+  version: 5.4.1-pre.1567
+  resolution: "@openmrs/webpack-config@npm:5.4.1-pre.1567"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -3310,7 +3310,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: f4e4dabbf4dff302e17b9b0602979ecd9cdc88dfc70b91ccdf7e5ad359152af08b7b4243bc25b762e5c35186df9d8746e0f6d6c5a5ea2067be199471b88412a1
+  checksum: a8294cd3627664912dfbd7b91f45dff94c43d5ee2feb030fe30d5514af980270c55073fcdeacc7b6e88b0b443b40dd0e60a4c26ce69e1c4797bf246f19b9ca5a
   languageName: node
   linkType: hard
 
@@ -13286,12 +13286,12 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 5.3.3-pre.1450
-  resolution: "openmrs@npm:5.3.3-pre.1450"
+  version: 5.4.1-pre.1567
+  resolution: "openmrs@npm:5.4.1-pre.1567"
   dependencies:
     "@carbon/icons-react": "npm:11.26.0"
-    "@openmrs/esm-app-shell": "npm:5.3.3-pre.1450"
-    "@openmrs/webpack-config": "npm:5.3.3-pre.1450"
+    "@openmrs/esm-app-shell": "npm:5.4.1-pre.1567"
+    "@openmrs/webpack-config": "npm:5.4.1-pre.1567"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.2"
@@ -13322,7 +13322,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 20e63d81c0bdb1db4199e424018746bddcb51bd88b307d34ff13f134ea890241b02ae6f8b1b560cb317b873e7302dec38d4a7729392b8301ee6548eeb4a67137
+  checksum: 3e1e7a59ffae1c411f026a7308523e4d3e545486b12d1f1afe2fa1caf97ab949732f30e414a389b1315c7a2376d3c9e409f3c62c15d0d350a0e470997614a80b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
Replace all the instances of 'ResponsiveWrapper' with the component present in esm-framework, also removed all the custom ResponsiveWrapper, also removed unused Layer component imports.

## Related Issue
[03-2804](https://openmrs.atlassian.net/jira/software/c/projects/O3/issues/O3-2804)