### PR TITLE
(refactor) O3-2815: Replace usages of `/ws/rest/v1` with `restBaseUrl`

### DIFF
--- a/__mocks__/active-visits.mock.ts
+++ b/__mocks__/active-visits.mock.ts
@@ -1,3 +1,4 @@
+import { restBaseUrl } from '@openmrs/esm-framework';
 export const mockServiceData = [
   { uuid: '176052c7-5fd4-4b33-89cc-7bae6848c65a', display: 'Clinical consultation' },
   { uuid: 'd80ff12a-06a7-11ed-b939-0242ac120002', display: 'Triage' },
@@ -32,7 +33,7 @@ export const mockVisitQueueEntries = [
         links: [
           {
             rel: 'self',
-            uri: 'http://openmrs:8080/openmrs/ws/rest/v1/concept/aaec62b1-4b03-4166-ada7-230cb4b4aaaa',
+            uri: `http://openmrs:8080/openmrs/${restBaseUrl}/concept/aaec62b1-4b03-4166-ada7-230cb4b4aaaa`,
           },
         ],
       },

--- a/e2e/core/global-setup.ts
+++ b/e2e/core/global-setup.ts
@@ -1,4 +1,3 @@
-import { restBaseUrl } from '@openmrs/esm-framework';
 import { request } from '@playwright/test';
 import * as dotenv from 'dotenv';
 
@@ -16,7 +15,7 @@ async function globalSetup() {
   const token = Buffer.from(`${process.env.E2E_USER_ADMIN_USERNAME}:${process.env.E2E_USER_ADMIN_PASSWORD}`).toString(
     'base64',
   );
-  await requestContext.post(`${process.env.E2E_BASE_URL}/${restBaseUrl}/session`, {
+  await requestContext.post(`${process.env.E2E_BASE_URL}/ws/rest/v1/session`, {
     data: {
       sessionLocation: process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
       locale: 'en',

--- a/e2e/core/global-setup.ts
+++ b/e2e/core/global-setup.ts
@@ -1,3 +1,4 @@
+import { restBaseUrl } from '@openmrs/esm-framework';
 import { request } from '@playwright/test';
 import * as dotenv from 'dotenv';
 
@@ -15,7 +16,7 @@ async function globalSetup() {
   const token = Buffer.from(`${process.env.E2E_USER_ADMIN_USERNAME}:${process.env.E2E_USER_ADMIN_PASSWORD}`).toString(
     'base64',
   );
-  await requestContext.post(`${process.env.E2E_BASE_URL}/ws/rest/v1/session`, {
+  await requestContext.post(`${process.env.E2E_BASE_URL}/${restBaseUrl}/session`, {
     data: {
       sessionLocation: process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
       locale: 'en',

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -1,4 +1,3 @@
-import { restBaseUrl } from '@openmrs/esm-framework';
 import { type APIRequestContext, type PlaywrightWorkerArgs, type WorkerFixture } from '@playwright/test';
 
 /**
@@ -16,7 +15,7 @@ import { type APIRequestContext, type PlaywrightWorkerArgs, type WorkerFixture }
  */
 export const api: WorkerFixture<APIRequestContext, PlaywrightWorkerArgs> = async ({ playwright }, use) => {
   const ctx = await playwright.request.newContext({
-    baseURL: `${process.env.E2E_BASE_URL}/${restBaseUrl}`,
+    baseURL: `${process.env.E2E_BASE_URL}/ws/rest/v1/`,
     httpCredentials: {
       username: process.env.E2E_USER_ADMIN_USERNAME,
       password: process.env.E2E_USER_ADMIN_PASSWORD,

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -1,4 +1,5 @@
-import { APIRequestContext, PlaywrightWorkerArgs, WorkerFixture } from '@playwright/test';
+import { restBaseUrl } from '@openmrs/esm-framework';
+import { type APIRequestContext, type PlaywrightWorkerArgs, type WorkerFixture } from '@playwright/test';
 
 /**
  * A fixture which initializes an [`APIRequestContext`](https://playwright.dev/docs/api/class-apirequestcontext)
@@ -15,7 +16,7 @@ import { APIRequestContext, PlaywrightWorkerArgs, WorkerFixture } from '@playwri
  */
 export const api: WorkerFixture<APIRequestContext, PlaywrightWorkerArgs> = async ({ playwright }, use) => {
   const ctx = await playwright.request.newContext({
-    baseURL: `${process.env.E2E_BASE_URL}/ws/rest/v1/`,
+    baseURL: `${process.env.E2E_BASE_URL}/${restBaseUrl}`,
     httpCredentials: {
       username: process.env.E2E_USER_ADMIN_USERNAME,
       password: process.env.E2E_USER_ADMIN_PASSWORD,

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -11,6 +11,7 @@ import {
   formatDatetime,
   parseDate,
   useConfig,
+  restBaseUrl,
 } from '@openmrs/esm-framework';
 dayjs.extend(isToday);
 
@@ -48,7 +49,7 @@ export function useActiveVisits() {
       return null;
     }
 
-    let url = `/ws/rest/v1/visit?v=${customRepresentation}&`;
+    let url = `${restBaseUrl}/visit?v=${customRepresentation}&`;
     let urlSearchParams = new URLSearchParams();
 
     urlSearchParams.append('includeInactive', 'false');

--- a/packages/esm-active-visits-app/src/visits-summary/visit.resource.ts
+++ b/packages/esm-active-visits-app/src/visits-summary/visit.resource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch, type OpenmrsResource, type Visit } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, type OpenmrsResource, type Visit } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 
 export interface Encounter {
@@ -149,7 +149,7 @@ export function useVisit(visitUuid: string) {
     'encounterProviders:(uuid,display,encounterRole:(uuid,display),' +
     'provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime';
 
-  const apiUrl = `/ws/rest/v1/visit/${visitUuid}?v=${customRepresentation}`;
+  const apiUrl = `${restBaseUrl}/visit/${visitUuid}?v=${customRepresentation}`;
 
   const { data, error, isLoading, isValidating } = useSWR<{ data: Visit }, Error>(
     visitUuid ? apiUrl : null,

--- a/packages/esm-appointments-app/src/admin/appointment-services/appointment-services-hook.ts
+++ b/packages/esm-appointments-app/src/admin/appointment-services/appointment-services-hook.ts
@@ -19,7 +19,7 @@ const appointmentServiceInitialValue: AppointmentService = {
 };
 
 const addNewAppointmentService = (payload) => {
-  return openmrsFetch('/ws/rest/v1/appointmentService', {
+  return openmrsFetch('${restBaseUrl}/appointmentService', {
     method: 'POST',
     body: payload,
     headers: { 'Content-Type': 'application/json' },

--- a/packages/esm-appointments-app/src/admin/appointment-services/appointment-services-hook.ts
+++ b/packages/esm-appointments-app/src/admin/appointment-services/appointment-services-hook.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentService } from '../../types';
 
 const appointmentServiceInitialValue: AppointmentService = {
@@ -19,7 +19,7 @@ const appointmentServiceInitialValue: AppointmentService = {
 };
 
 const addNewAppointmentService = (payload) => {
-  return openmrsFetch('${restBaseUrl}/appointmentService', {
+  return openmrsFetch(`${restBaseUrl}/appointmentService`, {
     method: 'POST',
     body: payload,
     headers: { 'Content-Type': 'application/json' },

--- a/packages/esm-appointments-app/src/appointments/forms/cancel-form/cancel-appointment.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/forms/cancel-form/cancel-appointment.component.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Layer, TextArea } from '@carbon/react';
-import { useSession, showSnackbar, ExtensionSlot, usePatient } from '@openmrs/esm-framework';
+import { useSession, showSnackbar, ExtensionSlot, usePatient, restBaseUrl } from '@openmrs/esm-framework';
 import { cancelAppointment } from '../forms.resource';
 import { useSWRConfig } from 'swr';
 import { useAppointmentDate } from '../../../helpers';
@@ -38,8 +38,8 @@ const CancelAppointment: React.FC<CancelAppointmentProps> = ({ appointment }) =>
         subtitle: t('cancelledSuccessfully', 'It has been cancelled successfully'),
         title: t('appointmentCancelled', 'Appointment cancelled'),
       });
-      mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${currentAppointmentDate}&status=Scheduled`);
-      mutate(`/ws/rest/v1/appointment/appointmentStatus?forDate=${currentAppointmentDate}&status=Cancelled`);
+      mutate(`${restBaseUrl}/appointment/appointmentStatus?forDate=${currentAppointmentDate}&status=Scheduled`);
+      mutate(`${restBaseUrl}/appointment/appointmentStatus?forDate=${currentAppointmentDate}&status=Cancelled`);
       closeOverlay();
     } else {
       showSnackbar({

--- a/packages/esm-appointments-app/src/appointments/forms/forms.resource.ts
+++ b/packages/esm-appointments-app/src/appointments/forms/forms.resource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentPayload } from '../../types';
 import dayjs from 'dayjs';
 import { omrsDateFormat } from '../../constants';
@@ -9,7 +9,7 @@ export const cancelAppointment = async (toStatus: string, appointmentUuid: strin
   const abortController = new AbortController();
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const statusChangeTime = dayjs(new Date()).format(omrsDateFormat);
-  const url = `/ws/rest/v1/appointments/${appointmentUuid}/status-change`;
+  const url = `${restBaseUrl}/appointments/${appointmentUuid}/status-change`;
   return await openmrsFetch(url, {
     body: { toStatus, onDate: statusChangeTime, timeZone: timeZone },
     method: 'POST',
@@ -20,7 +20,7 @@ export const cancelAppointment = async (toStatus: string, appointmentUuid: strin
 
 // NOTE: I don't think this is used anywhere?
 export const checkAppointmentConflict = async (appointmentPayload: AppointmentPayload) => {
-  return await openmrsFetch('/ws/rest/v1/appointments/conflicts', {
+  return await openmrsFetch(`${restBaseUrl}/appointments/conflicts`, {
     method: 'POST',
     body: {
       patientUuid: appointmentPayload.patientUuid,

--- a/packages/esm-appointments-app/src/config-schema.ts
+++ b/packages/esm-appointments-app/src/config-schema.ts
@@ -1,4 +1,4 @@
-import { Type, validators } from '@openmrs/esm-framework';
+import { Type, restBaseUrl, validators } from '@openmrs/esm-framework';
 import { spaHomePage } from './constants';
 
 export const configSchema = {
@@ -63,7 +63,7 @@ export const configSchema = {
   },
   defaultFacilityUrl: {
     _type: Type.String,
-    _default: '/ws/rest/v1/kenyaemr/default-facility',
+    _default: `${restBaseUrl}/kenyaemr/default-facility`,
     _description: 'Custom URL to load default facility if it is not in the session',
   },
   customPatientChartUrl: {

--- a/packages/esm-appointments-app/src/form/appointments-form.resource.ts
+++ b/packages/esm-appointments-app/src/form/appointments-form.resource.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import useSWR, { useSWRConfig } from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import {
   type AppointmentPayload,
   type AppointmentService,
@@ -86,7 +86,7 @@ export function useAppointments(patientUuid: string, startDate: string, abortCon
 
 export function useAppointmentService() {
   const { data, error, isLoading } = useSWR<{ data: Array<AppointmentService> }, Error>(
-    `/ws/rest/v1/appointmentService/all/full`,
+    `${restBaseUrl}/appointmentService/all/full`,
     openmrsFetch,
   );
 
@@ -98,7 +98,7 @@ export function useAppointmentService() {
 }
 
 export function saveAppointment(appointment: AppointmentPayload, abortController: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/appointment`, {
+  return openmrsFetch(`${restBaseUrl}/appointment`, {
     method: 'POST',
     signal: abortController.signal,
     headers: {
@@ -112,7 +112,7 @@ export function saveRecurringAppointments(
   recurringAppointments: RecurringAppointmentsPayload,
   abortController: AbortController,
 ) {
-  return openmrsFetch(`/ws/rest/v1/recurring-appointments`, {
+  return openmrsFetch(`${restBaseUrl}/recurring-appointments`, {
     method: 'POST',
     signal: abortController.signal,
     headers: {
@@ -124,14 +124,14 @@ export function saveRecurringAppointments(
 
 // TODO refactor to use SWR?
 export function getAppointmentsByUuid(appointmentUuid: string, abortController: AbortController) {
-  return openmrsFetch(`/ws/rest/v1/appointments/${appointmentUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/appointments/${appointmentUuid}`, {
     signal: abortController.signal,
   });
 }
 
 // TODO refactor to use SWR?
 export function getAppointmentService(abortController: AbortController, uuid) {
-  return openmrsFetch(`/ws/rest/v1/appointmentService?uuid=` + uuid, {
+  return openmrsFetch(`${restBaseUrl}/appointmentService?uuid=` + uuid, {
     signal: abortController.signal,
   });
 }
@@ -140,7 +140,7 @@ export const cancelAppointment = async (toStatus: string, appointmentUuid: strin
   const omrsDateFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZZ';
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const statusChangeTime = dayjs(new Date()).format(omrsDateFormat);
-  const url = `/ws/rest/v1/appointments/${appointmentUuid}/status-change`;
+  const url = `${restBaseUrl}/appointments/${appointmentUuid}/status-change`;
   return await openmrsFetch(url, {
     body: { toStatus, onDate: statusChangeTime, timeZone: timeZone },
     method: 'POST',

--- a/packages/esm-appointments-app/src/home/check-in-modal/check-in-modal.component.tsx
+++ b/packages/esm-appointments-app/src/home/check-in-modal/check-in-modal.component.tsx
@@ -2,11 +2,11 @@ import React, { useState } from 'react';
 import dayjs from 'dayjs';
 import { Button, Layer, ModalBody, ModalFooter, ModalHeader, TimePicker } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { showNotification, showActionableNotification } from '@openmrs/esm-framework';
+import { showNotification, showActionableNotification, restBaseUrl } from '@openmrs/esm-framework';
 import { updateAppointmentStatus } from '../home-appointments.resource';
+import { useMutateAppointments } from '../../form/appointments-form.resource';
 import { handleUndoAction } from '../common';
 import styles from './check-in-modal.scss';
-import { useMutateAppointments } from '../../form/appointments-form.resource';
 
 interface ChangeStatusDialogProps {
   closeCheckInModal: () => void;

--- a/packages/esm-appointments-app/src/home/common.ts
+++ b/packages/esm-appointments-app/src/home/common.ts
@@ -1,4 +1,4 @@
-import { showModal, showNotification, showActionableNotification } from '@openmrs/esm-framework';
+import { showModal, showNotification, showActionableNotification, restBaseUrl } from '@openmrs/esm-framework';
 import { updateAppointmentStatus, undoAppointmentStatus } from './home-appointments.resource';
 
 export const launchCheckInAppointmentModal = (appointmentUuid: string) => {

--- a/packages/esm-appointments-app/src/home/home-appointments.resource.ts
+++ b/packages/esm-appointments-app/src/home/home-appointments.resource.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import useSWR from 'swr';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { useAppointmentDate } from '../helpers';
 import { omrsDateFormat } from '../constants';
 import type { AppointmentService, AppointmentsFetchResponse } from '../types';
@@ -11,7 +11,7 @@ export function useTodaysAppointments() {
   const { t } = useTranslation();
   const { currentAppointmentDate } = useAppointmentDate();
 
-  const apiUrl = `/ws/rest/v1/appointment/all?forDate=${currentAppointmentDate}`;
+  const apiUrl = `${restBaseUrl}/appointment/all?forDate=${currentAppointmentDate}`;
   const { data, error, isLoading, isValidating, mutate } = useSWR<AppointmentsFetchResponse, Error>(
     currentAppointmentDate ? apiUrl : null,
     openmrsFetch,
@@ -33,7 +33,7 @@ export function useTodaysAppointments() {
 }
 
 export function useServices() {
-  const apiUrl = `/ws/rest/v1/appointmentService/all/default`;
+  const apiUrl = `${restBaseUrl}/appointmentService/all/default`;
   const { data, error, isLoading, isValidating } = useSWR<{ data: Array<AppointmentService> }, Error>(
     apiUrl,
     openmrsFetch,
@@ -51,7 +51,7 @@ export const updateAppointmentStatus = async (toStatus: string, appointmentUuid:
   const abortController = new AbortController();
   const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const statusChangeTime = dayjs(new Date()).format(omrsDateFormat);
-  const url = `/ws/rest/v1/appointments/${appointmentUuid}/status-change`;
+  const url = `${restBaseUrl}/appointments/${appointmentUuid}/status-change`;
   return await openmrsFetch(url, {
     body: { toStatus, onDate: statusChangeTime, timeZone: timeZone },
     method: 'POST',
@@ -62,7 +62,7 @@ export const updateAppointmentStatus = async (toStatus: string, appointmentUuid:
 
 export const undoAppointmentStatus = async (appointmentUuid: string) => {
   const abortController = new AbortController();
-  const url = `/ws/rest/v1/appointment/undoStatusChange/${appointmentUuid}`;
+  const url = `${restBaseUrl}/appointment/undoStatusChange/${appointmentUuid}`;
   return await openmrsFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/packages/esm-appointments-app/src/hooks/useAppointmentList.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentList.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentsFetchResponse } from '../types';
 import { useAppointmentDate } from '../helpers';
 import dayjs from 'dayjs';
@@ -8,7 +8,7 @@ export const useAppointmentList = (appointmentStatus: string, date?: string) => 
   const { currentAppointmentDate } = useAppointmentDate();
   const startDate = date ? date : currentAppointmentDate;
   const endDate = dayjs(startDate).endOf('day').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'); // TODO: fix? is this correct?
-  const searchUrl = `/ws/rest/v1/appointments/search`;
+  const searchUrl = `${restBaseUrl}/appointments/search`;
   const abortController = new AbortController();
 
   const fetcher = ([url, startDate, endDate, status]) =>
@@ -37,7 +37,7 @@ export const useAppointmentList = (appointmentStatus: string, date?: string) => 
 export const useEarlyAppointmentList = (startDate?: string) => {
   const { currentAppointmentDate } = useAppointmentDate();
   const forDate = startDate ? startDate : currentAppointmentDate;
-  const url = `/ws/rest/v1/appointment/earlyAppointment?forDate=${forDate}`;
+  const url = `${restBaseUrl}/appointment/earlyAppointment?forDate=${forDate}`;
 
   const { data, error, isLoading } = useSWR<AppointmentsFetchResponse, Error>(url, openmrsFetch, {
     errorRetryCount: 2,

--- a/packages/esm-appointments-app/src/hooks/useAppointmentService.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentService.ts
@@ -1,10 +1,10 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 import { type AppointmentService } from '../types';
 
 export function useAppointmentServices() {
   const { data, error, isLoading } = useSWR<{ data: Array<AppointmentService> }>(
-    `/ws/rest/v1/appointmentService/all/default`,
+    `${restBaseUrl}/appointmentService/all/default`,
     openmrsFetch,
   );
   return { serviceTypes: data?.data ?? [], isLoading, error };

--- a/packages/esm-appointments-app/src/hooks/useAppointments.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointments.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 import useSWR from 'swr';
 import { omrsDateFormat } from '../constants';
@@ -16,8 +16,8 @@ interface AppointmentsReturnType {
 export function useAppointments(status?: string, forDate?: string) {
   const { currentAppointmentDate } = useAppointmentDate();
   const startDate = forDate ? forDate : currentAppointmentDate;
-  const apiUrl = `/ws/rest/v1/appointment/appointmentStatus?forDate=${startDate}&status=${status}`;
-  const allAppointmentsUrl = `/ws/rest/v1/appointment/all?forDate=${startDate}`;
+  const apiUrl = `${restBaseUrl}/appointment/appointmentStatus?forDate=${startDate}&status=${status}`;
+  const allAppointmentsUrl = `${restBaseUrl}/appointment/all?forDate=${startDate}`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: Array<Appointment> }, Error>(
     isEmpty(status) ? allAppointmentsUrl : apiUrl,
@@ -36,7 +36,7 @@ export function useAppointments(status?: string, forDate?: string) {
 }
 
 export const useDailyAppointments = (startDateTime: string, durationPeriod: DurationPeriod) => {
-  const url = `/ws/rest/v1/appointment/all?forDate=${startDateTime}`;
+  const url = `${restBaseUrl}/appointment/all?forDate=${startDateTime}`;
   const { data, error, isLoading } = useSWR<{ data: Array<Appointment> }>(startDateTime ? url : null, openmrsFetch);
 
   return {
@@ -48,7 +48,7 @@ export const useDailyAppointments = (startDateTime: string, durationPeriod: Dura
 
 export const useAppointmentsByDurationPeriod = (date: string, durationPeriod: DurationPeriod) => {
   const abortController = new AbortController();
-  const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
+  const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
   const { startDate, endDate } = getStartAndEndDate(durationPeriod, date);
 
   const fetcher = () =>
@@ -64,7 +64,7 @@ export const useAppointmentsByDurationPeriod = (date: string, durationPeriod: Du
       },
     });
 
-  const url = 'openmrs/ws/rest/v1/appointments/search';
+  const url = `openmrs/${restBaseUrl}/appointments/search`;
   const { data, error, isLoading } = useSWR<{ data: Array<Appointment> }>(url, fetcher);
   return { isLoading, appointments: data?.data ?? [], error };
 };

--- a/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 import useSWR from 'swr';
 import { omrsDateFormat } from '../constants';
@@ -17,7 +17,7 @@ interface AppointmentSummaryResponse {
 
 export const useAppointmentsCalendar = (forDate: string, period: string) => {
   const { startDate, endDate } = evaluateAppointmentCalendarDates(forDate, period);
-  const url = `/ws/rest/v1/appointment/appointmentSummary?startDate=${startDate}&endDate=${endDate}`;
+  const url = `${restBaseUrl}/appointment/appointmentSummary?startDate=${startDate}&endDate=${endDate}`;
 
   const { data, error, isLoading } = useSWR<{ data: Array<AppointmentSummaryResponse> }>(
     startDate && endDate ? url : null,

--- a/packages/esm-appointments-app/src/hooks/useClinicalMetrics.ts
+++ b/packages/esm-appointments-app/src/hooks/useClinicalMetrics.ts
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import dayjs from 'dayjs';
 import uniqBy from 'lodash-es/uniqBy';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type Appointment, type AppointmentSummary } from '../types';
 import { omrsDateFormat } from '../constants';
 import {
@@ -15,7 +15,7 @@ import isEmpty from 'lodash-es/isEmpty';
 export const useClinicalMetrics = () => {
   const { currentAppointmentDate } = useAppointmentDate();
   const endDate = dayjs(new Date(currentAppointmentDate).setHours(23, 59, 59, 59)).format(omrsDateFormat);
-  const url = `/ws/rest/v1/appointment/appointmentSummary?startDate=${currentAppointmentDate}&endDate=${endDate}`;
+  const url = `${restBaseUrl}/appointment/appointmentSummary?startDate=${currentAppointmentDate}&endDate=${endDate}`;
   const { data, error, isLoading, mutate } = useSWR<{
     data: Array<AppointmentSummary>;
   }>(url, openmrsFetch);
@@ -38,7 +38,7 @@ export const useClinicalMetrics = () => {
 
 export function useAllAppointmentsByDate() {
   const { currentAppointmentDate } = useAppointmentDate();
-  const apiUrl = `/ws/rest/v1/appointment/all?forDate=${currentAppointmentDate}`;
+  const apiUrl = `${restBaseUrl}/appointment/all?forDate=${currentAppointmentDate}`;
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: Array<Appointment> }, Error>(
     apiUrl,
     openmrsFetch,
@@ -60,7 +60,7 @@ export function useAllAppointmentsByDate() {
 
 export const useScheduledAppointment = (serviceUuid: string) => {
   const { currentAppointmentDate } = useAppointmentDate();
-  const url = `/ws/rest/v1/appointment/all?forDate=${currentAppointmentDate}`;
+  const url = `${restBaseUrl}/appointment/all?forDate=${currentAppointmentDate}`;
 
   const { data, error, isLoading, mutate } = useSWR<{
     data: Array<any>;

--- a/packages/esm-appointments-app/src/hooks/usePatientAppointmentHistory.ts
+++ b/packages/esm-appointments-app/src/hooks/usePatientAppointmentHistory.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentsFetchResponse } from '../types';
 import useSWR from 'swr';
 import dayjs from 'dayjs';
@@ -6,7 +6,7 @@ import { useAppointmentDate } from '../helpers';
 
 export function usePatientAppointmentHistory(patientUuid: string) {
   const abortController = new AbortController();
-  const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
+  const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
   const { currentAppointmentDate } = useAppointmentDate();
   const fetcher = () =>
     openmrsFetch(appointmentsSearchUrl, {

--- a/packages/esm-appointments-app/src/hooks/useProviders.ts
+++ b/packages/esm-appointments-app/src/hooks/useProviders.ts
@@ -1,9 +1,9 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 import { type Provider } from '../types';
 
 export function useProviders() {
-  const apiUrl = `/ws/rest/v1/provider`;
+  const apiUrl = `${restBaseUrl}/provider`;
   const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Provider> } }, Error>(
     apiUrl,
     openmrsFetch,

--- a/packages/esm-appointments-app/src/hooks/useServiceQueus.ts
+++ b/packages/esm-appointments-app/src/hooks/useServiceQueus.ts
@@ -1,8 +1,8 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 
 export const useServiceQueues = () => {
-  const apiUrl = `/ws/rest/v1/visit-queue-entry?v=full`;
+  const apiUrl = `${restBaseUrl}/visit-queue-entry?v=full`;
   const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<any> } }, Error>(
     apiUrl,
     openmrsFetch,

--- a/packages/esm-appointments-app/src/hooks/useUnscheduledAppointments.ts
+++ b/packages/esm-appointments-app/src/hooks/useUnscheduledAppointments.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 import { useAppointmentDate } from '../helpers';
 import { type Identifier } from '../types';
@@ -21,7 +21,7 @@ export interface Response {
 
 export function useUnscheduledAppointments() {
   const { currentAppointmentDate } = useAppointmentDate();
-  const url = `/ws/rest/v1/appointment/unScheduledAppointment?forDate=${currentAppointmentDate}`;
+  const url = `${restBaseUrl}/appointment/unScheduledAppointment?forDate=${currentAppointmentDate}`;
   const { data, error, isLoading } = useSWR<{ data: Array<Response> }>(url, openmrsFetch, { errorRetryCount: 2 });
   const appointments = data?.data?.map((appointment) => toAppointmentObject(appointment));
 

--- a/packages/esm-appointments-app/src/hooks/useVisits.ts
+++ b/packages/esm-appointments-app/src/hooks/useVisits.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { useSession, type Visit, openmrsFetch } from '@openmrs/esm-framework';
+import { useSession, type Visit, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 import { useAppointmentDate } from '../helpers';
 
@@ -11,7 +11,7 @@ export const useVisits = () => {
   const { currentAppointmentDate } = useAppointmentDate();
   const session = useSession();
 
-  const visitsUrl = `/ws/rest/v1/visit?includeInactive=true&v=custom:(uuid,patient:(uuid,identifiers:(identifier,uuid),person:(age,display,gender,uuid)),visitType:(uuid,name,display),location:(uuid,name,display),startDatetime,stopDatetime)&fromStartDate=${dayjs(
+  const visitsUrl = `${restBaseUrl}/visit?includeInactive=true&v=custom:(uuid,patient:(uuid,identifiers:(identifier,uuid),person:(age,display,gender,uuid)),visitType:(uuid,name,display),location:(uuid,name,display),startDatetime,stopDatetime)&fromStartDate=${dayjs(
     currentAppointmentDate,
   ).format('YYYY-MM-DD')}&location=${session?.sessionLocation?.uuid}`;
 

--- a/packages/esm-appointments-app/src/past-visit/past-visit.resource.ts
+++ b/packages/esm-appointments-app/src/past-visit/past-visit.resource.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch, Visit } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, type Visit } from '@openmrs/esm-framework';
 
 export function usePastVisits(patientUuid: string) {
   const customRepresentation =
@@ -10,7 +10,7 @@ export function usePastVisits(patientUuid: string) {
     'visitType:(uuid,name,display),attributes:(uuid,display,value),location:(uuid,name,display),startDatetime,' +
     'stopDatetime)';
 
-  const apiUrl = `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}`;
+  const apiUrl = `${restBaseUrl}/visit?patient=${patientUuid}&v=${customRepresentation}`;
   const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
     patientUuid ? apiUrl : null,
     openmrsFetch,

--- a/packages/esm-appointments-app/src/patient-queue/visit-form/queue.resource.ts
+++ b/packages/esm-appointments-app/src/patient-queue/visit-form/queue.resource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch, toDateObjectStrict, toOmrsIsoString } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, toDateObjectStrict, toOmrsIsoString } from '@openmrs/esm-framework';
 
 export async function saveQueueEntry(
   visitUuid: string,
@@ -15,7 +15,7 @@ export async function saveQueueEntry(
     generateVisitQueueNumber(locationUuid, visitUuid, queueUuid, abortController, visitQueueNumberAttributeUuid),
   ]);
 
-  return openmrsFetch(`/ws/rest/v1/visit-queue-entry`, {
+  return openmrsFetch(`${restBaseUrl}/visit-queue-entry`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -51,7 +51,7 @@ export async function generateVisitQueueNumber(
   visitQueueNumberAttributeUuid: string,
 ) {
   await openmrsFetch(
-    `/ws/rest/v1/queue-entry-number?location=${location}&queue=${queueUuid}&visit=${visitUuid}&visitAttributeType=${visitQueueNumberAttributeUuid}`,
+    `${restBaseUrl}/queue-entry-number?location=${location}&queue=${queueUuid}&visit=${visitUuid}&visitAttributeType=${visitQueueNumberAttributeUuid}`,
     {
       method: 'GET',
       headers: {

--- a/packages/esm-appointments-app/src/workload/workload.resource.ts
+++ b/packages/esm-appointments-app/src/workload/workload.resource.ts
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import dayjs from 'dayjs';
 import first from 'lodash-es/first';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentSummary } from '../types';
 import { omrsDateFormat } from '../constants';
 interface AppointmentCount {
@@ -36,7 +36,7 @@ export const useCalendarDistribution = (
 export const useAppointmentSummary = (fromDate: Date, serviceUuid: string): Array<{ date: string; count: number }> => {
   const startDate = dayjs(fromDate).startOf('week').format(omrsDateFormat);
   const endDate = dayjs(startDate).add(2, 'week').format(omrsDateFormat);
-  const url = `/ws/rest/v1/appointment/appointmentSummary?startDate=${startDate}&endDate=${endDate}`;
+  const url = `${restBaseUrl}/appointment/appointmentSummary?startDate=${startDate}&endDate=${endDate}`;
   const { data } = useSWR<{ data: Array<AppointmentSummary> }>(url, openmrsFetch);
   const results = first(data?.data?.filter(({ appointmentService }) => appointmentService.uuid === serviceUuid));
   const appointmentCountMap = results?.appointmentCountMap;

--- a/packages/esm-patient-list-management-app/src/api/api-remote.ts
+++ b/packages/esm-patient-list-management-app/src/api/api-remote.ts
@@ -1,4 +1,4 @@
-import { type LoggedInUser, openmrsFetch, refetchCurrentUser, restBaseUrl } from '@openmrs/esm-framework';
+import { type LoggedInUser, openmrsFetch, refetchCurrentUser, restBaseUrl, fhirBaseUrl } from '@openmrs/esm-framework';
 import {
   type AddPatientData,
   type CohortResponse,
@@ -124,7 +124,7 @@ export async function getPatientListMembers(cohortUuid: string, ac = new AbortCo
   const currentDate = new Date();
   const searchQuery = results.map((p) => p.patient.uuid).join(',');
 
-  const result = await openmrsFetch(`/ws/fhir2/R4/Patient/_search?_id=${searchQuery}`, {
+  const result = await openmrsFetch(`${fhirBaseUrl}/Patient/_search?_id=${searchQuery}`, {
     method: 'POST',
     signal: ac.signal,
   });

--- a/packages/esm-patient-list-management-app/src/api/api-remote.ts
+++ b/packages/esm-patient-list-management-app/src/api/api-remote.ts
@@ -1,4 +1,4 @@
-import { type LoggedInUser, openmrsFetch, refetchCurrentUser } from '@openmrs/esm-framework';
+import { type LoggedInUser, openmrsFetch, refetchCurrentUser, restBaseUrl } from '@openmrs/esm-framework';
 import {
   type AddPatientData,
   type CohortResponse,
@@ -13,7 +13,7 @@ import {
   type PatientListUpdate,
 } from './types';
 
-export const cohortUrl = '/ws/rest/v1/cohortm';
+export const cohortUrl = `${restBaseUrl}/cohortm`;
 
 async function postData(url: string, data = {}, ac = new AbortController()) {
   const response = await openmrsFetch(url, {
@@ -87,7 +87,7 @@ export async function getAllPatientLists(
 }
 
 export function starPatientList(userUuid: string, userProperties: LoggedInUser['userProperties']) {
-  return openmrsFetch(`/ws/rest/v1/user/${userUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/user/${userUuid}`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',

--- a/packages/esm-patient-list-management-app/src/lists-dashboard/lists-dashboard.test.tsx
+++ b/packages/esm-patient-list-management-app/src/lists-dashboard/lists-dashboard.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { useLocation } from 'react-router-dom';
-import { openmrsFetch, useSession } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, useSession } from '@openmrs/esm-framework';
 import { mockSession } from '__mocks__';
 import ListsDashboard from './lists-dashboard.component';
 
@@ -45,12 +45,12 @@ describe('ListsDashboard', () => {
               links: [
                 {
                   rel: 'self',
-                  uri: 'http://dev3.openmrs.org/openmrs/ws/rest/v1/cohortm/cohorttype/e71857cb-33af-4f2c-86ab-7223bcfa37ad',
+                  uri: `http://dev3.openmrs.org/openmrs/${restBaseUrl}/cohortm/cohorttype/e71857cb-33af-4f2c-86ab-7223bcfa37ad`,
                   resourceAlias: 'cohorttype',
                 },
                 {
                   rel: 'full',
-                  uri: 'http://dev3.openmrs.org/openmrs/ws/rest/v1/cohortm/cohorttype/e71857cb-33af-4f2c-86ab-7223bcfa37ad?v=full',
+                  uri: `http://dev3.openmrs.org/openmrs/${restBaseUrl}/cohortm/cohorttype/e71857cb-33af-4f2c-86ab-7223bcfa37ad?v=full`,
                   resourceAlias: 'cohorttype',
                 },
               ],
@@ -72,12 +72,12 @@ describe('ListsDashboard', () => {
               links: [
                 {
                   rel: 'self',
-                  uri: 'http://dev3.openmrs.org/openmrs/ws/rest/v1/cohortm/cohorttype/e71857cb-33af-4f2c-86ab-7223bcfa37ad',
+                  uri: `http://dev3.openmrs.org/openmrs/${restBaseUrl}/cohortm/cohorttype/e71857cb-33af-4f2c-86ab-7223bcfa37ad`,
                   resourceAlias: 'cohorttype',
                 },
                 {
                   rel: 'full',
-                  uri: 'http://dev3.openmrs.org/openmrs/ws/rest/v1/cohortm/cohorttype/e71857cb-33af-4f2c-86ab-7223bcfa37ad?v=full',
+                  uri: `http://dev3.openmrs.org/openmrs/${restBaseUrl}/cohortm/cohorttype/e71857cb-33af-4f2c-86ab-7223bcfa37ad?v=full`,
                   resourceAlias: 'cohorttype',
                 },
               ],

--- a/packages/esm-patient-list-management-app/src/offline.ts
+++ b/packages/esm-patient-list-management-app/src/offline.ts
@@ -1,5 +1,6 @@
 import {
   fetchCurrentPatient,
+  fhirBaseUrl,
   makeUrl,
   messageOmrsServiceWorker,
   setupDynamicOfflineDataHandler,
@@ -12,7 +13,7 @@ export function setupOffline() {
     type: 'patient',
     displayName: 'Patient list',
     async isSynced(patientUuid) {
-      const expectedUrls = [`/ws/fhir2/R4/Patient/${patientUuid}`];
+      const expectedUrls = [`${fhirBaseUrl}/Patient/${patientUuid}`];
       const absoluteExpectedUrls = expectedUrls.map((url) => window.origin + makeUrl(url));
       const cache = await caches.open('omrs-spa-cache-v1');
       const keys = (await cache.keys()).map((key) => key.url);
@@ -21,7 +22,7 @@ export function setupOffline() {
     async sync(patientUuid) {
       await messageOmrsServiceWorker({
         type: 'registerDynamicRoute',
-        pattern: `/ws/fhir2/R4/Patient/${patientUuid}`,
+        pattern: `${fhirBaseUrl}/Patient/${patientUuid}`,
       });
 
       await fetchCurrentPatient(patientUuid, { headers: cacheForOfflineHeaders });

--- a/packages/esm-patient-registration-app/src/offline.resources.ts
+++ b/packages/esm-patient-registration-app/src/offline.resources.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import find from 'lodash-es/find';
 import camelCase from 'lodash-es/camelCase';
 import escapeRegExp from 'lodash-es/escapeRegExp';
-import { getConfig, messageOmrsServiceWorker, openmrsFetch, type Session } from '@openmrs/esm-framework';
+import { getConfig, messageOmrsServiceWorker, openmrsFetch, restBaseUrl, type Session } from '@openmrs/esm-framework';
 import type {
   PatientIdentifierType,
   FetchedPatientIdentifierType,
@@ -20,17 +20,17 @@ export interface Resources {
 export const ResourcesContext = React.createContext<Resources>(null);
 
 export async function fetchCurrentSession(): Promise<Session> {
-  const { data } = await cacheAndFetch<Session>('/ws/rest/v1/session');
+  const { data } = await cacheAndFetch<Session>(`${restBaseUrl}/session`);
   return data;
 }
 
 export async function fetchAddressTemplate() {
-  const { data } = await cacheAndFetch<AddressTemplate>('/ws/rest/v1/addresstemplate');
+  const { data } = await cacheAndFetch<AddressTemplate>(`${restBaseUrl}/addresstemplate`);
   return data;
 }
 
 export async function fetchAllRelationshipTypes() {
-  const { data } = await cacheAndFetch('/ws/rest/v1/relationshiptype?v=default');
+  const { data } = await cacheAndFetch(`${restBaseUrl}/relationshiptype?v=default`);
   return data;
 }
 
@@ -59,11 +59,11 @@ async function fetchFieldDefinitionType(fieldDefinition) {
   let apiUrl = '';
 
   if (fieldDefinition.type === 'person attribute') {
-    apiUrl = `/ws/rest/v1/personattributetype/${fieldDefinition.uuid}`;
+    apiUrl = `${restBaseUrl}/personattributetype/${fieldDefinition.uuid}`;
   }
 
   if (fieldDefinition.answerConceptSetUuid) {
-    await cacheAndFetch(`/ws/rest/v1/concept/${fieldDefinition.answerConceptSetUuid}`);
+    await cacheAndFetch(`${restBaseUrl}/concept/${fieldDefinition.answerConceptSetUuid}`);
   }
   const { data } = await cacheAndFetch(apiUrl);
   return data;
@@ -93,8 +93,10 @@ export async function fetchPatientIdentifierTypesWithSources(): Promise<Array<Pa
 
 async function fetchPatientIdentifierTypes(): Promise<Array<FetchedPatientIdentifierType>> {
   const [patientIdentifierTypesResponse, primaryIdentifierTypeResponse] = await Promise.all([
-    cacheAndFetch('/ws/rest/v1/patientidentifiertype?v=custom:(display,uuid,name,format,required,uniquenessBehavior)'),
-    cacheAndFetch('/ws/rest/v1/metadatamapping/termmapping?v=full&code=emr.primaryIdentifierType'),
+    cacheAndFetch(
+      `${restBaseUrl}/patientidentifiertype?v=custom:(display,uuid,name,format,required,uniquenessBehavior)`,
+    ),
+    cacheAndFetch(`${restBaseUrl}/metadatamapping/termmapping?v=full&code=emr.primaryIdentifierType`),
   ]);
 
   if (patientIdentifierTypesResponse.ok) {
@@ -124,11 +126,11 @@ async function fetchPatientIdentifierTypes(): Promise<Array<FetchedPatientIdenti
 }
 
 async function fetchIdentifierSources(identifierType: string) {
-  return await cacheAndFetch(`/ws/rest/v1/idgen/identifiersource?v=default&identifierType=${identifierType}`);
+  return await cacheAndFetch(`${restBaseUrl}/idgen/identifiersource?v=default&identifierType=${identifierType}`);
 }
 
 async function fetchAutoGenerationOptions(abortController?: AbortController) {
-  return await cacheAndFetch(`/ws/rest/v1/idgen/autogenerationoption?v=full`);
+  return await cacheAndFetch(`${restBaseUrl}/idgen/autogenerationoption?v=full`);
 }
 
 async function cacheAndFetch<T = any>(url?: string) {

--- a/packages/esm-patient-registration-app/src/offline.ts
+++ b/packages/esm-patient-registration-app/src/offline.ts
@@ -2,6 +2,7 @@ import {
   makeUrl,
   messageOmrsServiceWorker,
   navigate,
+  restBaseUrl,
   setupDynamicOfflineDataHandler,
   setupOfflineSync,
   type SyncProcessOptions,
@@ -55,9 +56,9 @@ export function setupOffline() {
 function getPatientUrlsToBeCached(patientUuid: string) {
   return [
     `/ws/fhir2/R4/Patient/${patientUuid}`,
-    `/ws/rest/v1/relationship?v=${personRelationshipRepresentation}&person=${patientUuid}`,
-    `/ws/rest/v1/person/${patientUuid}/attribute`,
-    `/ws/rest/v1/patient/${patientUuid}/identifier?v=custom:(uuid,identifier,identifierType:(uuid,required,name),preferred)`,
+    `${restBaseUrl}/relationship?v=${personRelationshipRepresentation}&person=${patientUuid}`,
+    `${restBaseUrl}/person/${patientUuid}/attribute`,
+    `${restBaseUrl}/patient/${patientUuid}/identifier?v=custom:(uuid,identifier,identifierType:(uuid,required,name),preferred)`,
   ].map((url) => window.origin + makeUrl(url));
 }
 

--- a/packages/esm-patient-registration-app/src/offline.ts
+++ b/packages/esm-patient-registration-app/src/offline.ts
@@ -1,4 +1,5 @@
 import {
+  fhirBaseUrl,
   makeUrl,
   messageOmrsServiceWorker,
   navigate,
@@ -55,7 +56,7 @@ export function setupOffline() {
 
 function getPatientUrlsToBeCached(patientUuid: string) {
   return [
-    `/ws/fhir2/R4/Patient/${patientUuid}`,
+    `${fhirBaseUrl}/Patient/${patientUuid}`,
     `${restBaseUrl}/relationship?v=${personRelationshipRepresentation}&person=${patientUuid}`,
     `${restBaseUrl}/person/${patientUuid}/attribute`,
     `${restBaseUrl}/patient/${patientUuid}/identifier?v=custom:(uuid,identifier,identifierType:(uuid,required,name),preferred)`,

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.resource.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.resource.ts
@@ -1,11 +1,11 @@
-import { type FetchResponse, openmrsFetch, showSnackbar } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, showSnackbar, restBaseUrl } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
 import { type ConceptAnswers, type ConceptResponse } from '../patient-registration.types';
 
 export function useConcept(conceptUuid: string): { data: ConceptResponse; isLoading: boolean } {
   const shouldFetch = typeof conceptUuid === 'string' && conceptUuid !== '';
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<ConceptResponse>, Error>(
-    shouldFetch ? `/ws/rest/v1/concept/${conceptUuid}` : null,
+    shouldFetch ? `${restBaseUrl}/concept/${conceptUuid}` : null,
     openmrsFetch,
   );
   if (error) {
@@ -21,7 +21,7 @@ export function useConcept(conceptUuid: string): { data: ConceptResponse; isLoad
 export function useConceptAnswers(conceptUuid: string): { data: Array<ConceptAnswers>; isLoading: boolean } {
   const shouldFetch = typeof conceptUuid === 'string' && conceptUuid !== '';
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<ConceptResponse>, Error>(
-    shouldFetch ? `/ws/rest/v1/concept/${conceptUuid}` : null,
+    shouldFetch ? `${restBaseUrl}/concept/${conceptUuid}` : null,
     openmrsFetch,
   );
   if (error) {

--- a/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/person-attributes.resource.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/person-attributes.resource.ts
@@ -1,4 +1,4 @@
-import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
 import { type PersonAttributeTypeResponse } from '../../patient-registration.types';
 
@@ -8,7 +8,7 @@ export function usePersonAttributeType(personAttributeTypeUuid: string): {
   error: any;
 } {
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<PersonAttributeTypeResponse>>(
-    `/ws/rest/v1/personattributetype/${personAttributeTypeUuid}`,
+    `${restBaseUrl}/personattributetype/${personAttributeTypeUuid}`,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -1,4 +1,10 @@
-import { type FetchResponse, openmrsFetch, queueSynchronizationItem, type Session } from '@openmrs/esm-framework';
+import {
+  type FetchResponse,
+  openmrsFetch,
+  queueSynchronizationItem,
+  type Session,
+  restBaseUrl,
+} from '@openmrs/esm-framework';
 import { patientRegistration } from '../constants';
 import {
   type FormValues,
@@ -128,7 +134,7 @@ export class FormManager {
         await savePatientPhoto(
           savePatientResponse.data.uuid,
           capturePhotoProps.imageData,
-          '/ws/rest/v1/obs',
+          `${restBaseUrl}/obs`,
           capturePhotoProps.dateTime || new Date().toISOString(),
           config.concepts.patientPhotoUuid,
         );
@@ -354,7 +360,7 @@ export class FormManager {
           .filter(([, value]) => !value)
           .forEach(async ([key]) => {
             const attributeUuid = patientUuidMap[`attribute.${key}`];
-            await openmrsFetch(`/ws/rest/v1/person/${values.patientUuid}/attribute/${attributeUuid}`, {
+            await openmrsFetch(`${restBaseUrl}/person/${values.patientUuid}/attribute/${attributeUuid}`, {
               method: 'DELETE',
             }).catch((err) => {
               console.error(err);

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
@@ -5,6 +5,7 @@ import {
   openmrsFetch,
   useConfig,
   usePatient,
+  restBaseUrl,
 } from '@openmrs/esm-framework';
 import camelCase from 'lodash-es/camelCase';
 import { type Dispatch, useEffect, useMemo, useState } from 'react';
@@ -210,7 +211,7 @@ export function useInitialPatientIdentifiers(patientUuid: string): {
 
   const { data, error, isLoading } = useSWR<FetchResponse<{ results: Array<PatientIdentifierResponse> }>, Error>(
     shouldFetch
-      ? `/ws/rest/v1/patient/${patientUuid}/identifier?v=custom:(uuid,identifier,identifierType:(uuid,required,name),preferred)`
+      ? `${restBaseUrl}/patient/${patientUuid}/identifier?v=custom:(uuid,identifier,identifierType:(uuid,required,name),preferred)`
       : null,
     openmrsFetch,
   );
@@ -247,7 +248,7 @@ function useInitialEncounters(patientUuid: string, patientToEdit: fhir.Patient) 
   const { registrationObs } = useConfig() as RegistrationConfig;
   const { data, error, isLoading } = useSWR<FetchResponse<{ results: Array<Encounter> }>>(
     patientToEdit && registrationObs.encounterTypeUuid
-      ? `/ws/rest/v1/encounter?patient=${patientUuid}&v=custom:(encounterDatetime,obs:(concept:ref,value:ref))&encounterType=${registrationObs.encounterTypeUuid}`
+      ? `${restBaseUrl}/encounter?patient=${patientUuid}&v=custom:(encounterDatetime,obs:(concept:ref,value:ref))&encounterType=${registrationObs.encounterTypeUuid}`
       : null,
     openmrsFetch,
   );
@@ -265,7 +266,7 @@ function useInitialPersonAttributes(personUuid: string) {
   const shouldFetch = !!personUuid;
   const { data, error, isLoading } = useSWR<FetchResponse<{ results: Array<PersonAttributeResponse> }>, Error>(
     shouldFetch
-      ? `/ws/rest/v1/person/${personUuid}/attribute?v=custom:(uuid,display,attributeType:(uuid,display,format),value)`
+      ? `${restBaseUrl}/person/${personUuid}/attribute?v=custom:(uuid,display,attributeType:(uuid,display,format),value)`
       : null,
     openmrsFetch,
   );

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.resource.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.resource.test.tsx
@@ -1,4 +1,4 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { savePatient } from './patient-registration.resource';
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
@@ -15,12 +15,12 @@ describe('savePatient', () => {
   it('appends patient uuid in url if provided', () => {
     mockOpenmrsFetch.mockImplementationOnce((url) => url);
     savePatient(null, '1234');
-    expect(mockOpenmrsFetch.mock.calls[0][0]).toEqual('/ws/rest/v1/patient/1234');
+    expect(mockOpenmrsFetch.mock.calls[0][0]).toEqual(`${restBaseUrl}/patient/1234`);
   });
 
   it('does not append patient uuid in url', () => {
     mockOpenmrsFetch.mockImplementationOnce(() => {});
     savePatient(null);
-    expect(mockOpenmrsFetch.mock.calls[0][0]).toEqual('/ws/rest/v1/patient/');
+    expect(mockOpenmrsFetch.mock.calls[0][0]).toEqual(`${restBaseUrl}/patient/`);
   });
 });

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.resource.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.resource.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import { type Patient, type Relationship, type PatientIdentifier, type Encounter } from './patient-registration.types';
 
 export const uuidIdentifier = '05a29f94-c0ed-11e2-94be-8c13b969e334';
@@ -22,7 +22,7 @@ function dataURItoFile(dataURI: string) {
 export function savePatient(patient: Patient | null, updatePatientUuid?: string) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/patient/${updatePatientUuid || ''}`, {
+  return openmrsFetch(`${restBaseUrl}/patient/${updatePatientUuid || ''}`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -35,7 +35,7 @@ export function savePatient(patient: Patient | null, updatePatientUuid?: string)
 export function saveEncounter(encounter: Encounter) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/encounter`, {
+  return openmrsFetch(`${restBaseUrl}/encounter`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -48,7 +48,7 @@ export function saveEncounter(encounter: Encounter) {
 export function generateIdentifier(source: string) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/idgen/identifiersource/${source}/identifier`, {
+  return openmrsFetch(`${restBaseUrl}/idgen/identifiersource/${source}/identifier`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -61,7 +61,7 @@ export function generateIdentifier(source: string) {
 export function deletePersonName(nameUuid: string, personUuid: string) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/person/${personUuid}/name/${nameUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/person/${personUuid}/name/${nameUuid}`, {
     method: 'DELETE',
     signal: abortController.signal,
   });
@@ -70,7 +70,7 @@ export function deletePersonName(nameUuid: string, personUuid: string) {
 export function saveRelationship(relationship: Relationship) {
   const abortController = new AbortController();
 
-  return openmrsFetch('/ws/rest/v1/relationship', {
+  return openmrsFetch(`${restBaseUrl}/relationship`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -83,7 +83,7 @@ export function saveRelationship(relationship: Relationship) {
 export function updateRelationship(relationshipUuid, relationship: { relationshipType: string }) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/relationship/${relationshipUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/relationship/${relationshipUuid}`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -96,7 +96,7 @@ export function updateRelationship(relationshipUuid, relationship: { relationshi
 export function deleteRelationship(relationshipUuid) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/relationship/${relationshipUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/relationship/${relationshipUuid}`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -161,7 +161,7 @@ export function usePatientPhoto(patientUuid: string): UsePatientPhotoResult {
   const {
     concepts: { patientPhotoUuid },
   } = useConfig();
-  const url = `/ws/rest/v1/obs?patient=${patientUuid}&concept=${patientPhotoUuid}&v=full`;
+  const url = `${restBaseUrl}/obs?patient=${patientUuid}&concept=${patientPhotoUuid}&v=full`;
 
   const { data, error, isLoading } = useSWR<{ data: ObsFetchResponse }, Error>(patientUuid ? url : null, openmrsFetch);
 
@@ -181,10 +181,10 @@ export function usePatientPhoto(patientUuid: string): UsePatientPhotoResult {
 
 export async function fetchPerson(query: string, abortController: AbortController) {
   const [patientsRes, personsRes] = await Promise.all([
-    openmrsFetch(`/ws/rest/v1/patient?q=${query}`, {
+    openmrsFetch(`${restBaseUrl}/patient?q=${query}`, {
       signal: abortController.signal,
     }),
-    openmrsFetch(`/ws/rest/v1/person?q=${query}`, {
+    openmrsFetch(`${restBaseUrl}/person?q=${query}`, {
       signal: abortController.signal,
     }),
   ]);
@@ -202,7 +202,7 @@ export async function fetchPerson(query: string, abortController: AbortControlle
 
 export async function addPatientIdentifier(patientUuid: string, patientIdentifier: PatientIdentifier) {
   const abortController = new AbortController();
-  return openmrsFetch(`/ws/rest/v1/patient/${patientUuid}/identifier/`, {
+  return openmrsFetch(`${restBaseUrl}/patient/${patientUuid}/identifier/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -214,7 +214,7 @@ export async function addPatientIdentifier(patientUuid: string, patientIdentifie
 
 export async function updatePatientIdentifier(patientUuid: string, identifierUuid: string, identifier: string) {
   const abortController = new AbortController();
-  return openmrsFetch(`/ws/rest/v1/patient/${patientUuid}/identifier/${identifierUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/patient/${patientUuid}/identifier/${identifierUuid}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -226,7 +226,7 @@ export async function updatePatientIdentifier(patientUuid: string, identifierUui
 
 export async function deletePatientIdentifier(patientUuid: string, patientIdentifierUuid: string) {
   const abortController = new AbortController();
-  return openmrsFetch(`/ws/rest/v1/patient/${patientUuid}/identifier/${patientIdentifierUuid}?purge`, {
+  return openmrsFetch(`${restBaseUrl}/patient/${patientUuid}/identifier/${patientIdentifierUuid}?purge`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships.resource.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships.resource.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type RelationshipValue } from '../../patient-registration.types';
 import { personRelationshipRepresentation } from '../../../constants';
 
@@ -10,7 +10,7 @@ export function useInitialPatientRelationships(patientUuid: string): {
 } {
   const shouldFetch = !!patientUuid;
   const { data, error, isLoading } = useSWR<FetchResponse<RelationshipsResponse>, Error>(
-    shouldFetch ? `/ws/rest/v1/relationship?v=${personRelationshipRepresentation}&person=${patientUuid}` : null,
+    shouldFetch ? `${restBaseUrl}/relationship?v=${personRelationshipRepresentation}&person=${patientUuid}` : null,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import CompactPatientBanner from './compact-patient-banner.component';
-import { defineConfigSchema, getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { defineConfigSchema, getDefaultsFromConfigSchema, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import { type SearchedPatient } from '../types';
 import { PatientSearchContext } from '../patient-search-context';
 import { configSchema } from '../config-schema';
@@ -23,7 +23,7 @@ const patients: Array<SearchedPatient> = [
           links: [
             {
               rel: 'self',
-              uri: 'http://dev3.openmrs.org/openmrs/ws/rest/v1/patientidentifiertype/05a29f94-c0ed-11e2-94be-8c13b969e334',
+              uri: `http://dev3.openmrs.org/openmrs/${restBaseUrl}/patientidentifiertype/05a29f94-c0ed-11e2-94be-8c13b969e334`,
               resourceAlias: 'patientidentifiertype',
             },
           ],

--- a/packages/esm-patient-search-app/src/compact-patient-search/patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/patient-search.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import { PatientSearchContext } from '../patient-search-context';
 import { configSchema } from '../config-schema';
 import { type SearchedPatient } from '../types';
@@ -64,7 +64,7 @@ describe('PatientSearch', () => {
               links: [
                 {
                   rel: 'self',
-                  uri: 'http://dev3.openmrs.org/openmrs/ws/rest/v1/patientidentifiertype/05a29f94-c0ed-11e2-94be-8c13b969e334',
+                  uri: `http://dev3.openmrs.org/openmrs/${restBaseUrl}/patientidentifiertype/05a29f94-c0ed-11e2-94be-8c13b969e334`,
                   resourceAlias: 'patientidentifiertype',
                 },
               ],

--- a/packages/esm-patient-search-app/src/compact-patient-search/recently-searched-patients.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/recently-searched-patients.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import { type SearchedPatient } from '../types';
 import { PatientSearchContext } from '../patient-search-context';
 import { configSchema } from '../config-schema';
@@ -64,7 +64,7 @@ describe('RecentlySearchedPatients', () => {
               links: [
                 {
                   rel: 'self',
-                  uri: 'http://dev3.openmrs.org/openmrs/ws/rest/v1/patientidentifiertype/05a29f94-c0ed-11e2-94be-8c13b969e334',
+                  uri: `http://dev3.openmrs.org/openmrs/${restBaseUrl}/patientidentifiertype/05a29f94-c0ed-11e2-94be-8c13b969e334`,
                   resourceAlias: 'patientidentifiertype',
                 },
               ],

--- a/packages/esm-patient-search-app/src/index.ts
+++ b/packages/esm-patient-search-app/src/index.ts
@@ -1,6 +1,7 @@
 import {
   defineConfigSchema,
   fetchCurrentPatient,
+  fhirBaseUrl,
   getSyncLifecycle,
   makeUrl,
   messageOmrsServiceWorker,
@@ -39,7 +40,7 @@ export function startupApp() {
     type: 'patient',
     displayName: 'Patient search',
     async isSynced(patientUuid) {
-      const expectedUrls = [`/ws/fhir2/R4/Patient/${patientUuid}`];
+      const expectedUrls = [`${fhirBaseUrl}/Patient/${patientUuid}`];
       const absoluteExpectedUrls = expectedUrls.map((url) => window.origin + makeUrl(url));
       const cache = await caches.open('omrs-spa-cache-v1');
       const keys = (await cache.keys()).map((key) => key.url);
@@ -48,7 +49,7 @@ export function startupApp() {
     async sync(patientUuid) {
       await messageOmrsServiceWorker({
         type: 'registerDynamicRoute',
-        pattern: `/ws/fhir2/R4/Patient/${patientUuid}`,
+        pattern: `${fhirBaseUrl}/Patient/${patientUuid}`,
       });
 
       await fetchCurrentPatient(patientUuid);

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/contact-details/relationships.resource.ts
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/contact-details/relationships.resource.ts
@@ -1,11 +1,11 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 
 const customRepresentation =
   'custom:(display,uuid,personA:(age,display,birthdate,uuid),personB:(age,display,birthdate,uuid),relationshipType:(uuid,display,description,aIsToB,bIsToA))';
 
 export function useRelationships(patientUuid: string) {
-  const apiUrl = `/ws/rest/v1/relationship?v=${customRepresentation}&person=${patientUuid}`;
+  const apiUrl = `${restBaseUrl}/relationship?v=${customRepresentation}&person=${patientUuid}`;
 
   const { data, error, isLoading, isValidating } = useSWR<{ data: RelationshipsResponse }, Error>(
     patientUuid ? apiUrl : null,

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/hooks/usePatientAttributes.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/hooks/usePatientAttributes.tsx
@@ -1,4 +1,4 @@
-import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
 import { type Patient } from '../types';
 
@@ -12,7 +12,7 @@ const customRepresentation =
  */
 export const usePatientAttributes = (patientUuid: string) => {
   const { data, error, isLoading } = useSWRImmutable<{ data: Patient }>(
-    `/ws/rest/v1/patient/${patientUuid}?v=${customRepresentation}`,
+    `${restBaseUrl}/patient/${patientUuid}?v=${customRepresentation}`,
     openmrsFetch,
   );
 

--- a/packages/esm-patient-search-app/src/patient-search.resource.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
-import { openmrsFetch, showNotification, useSession, type FetchResponse } from '@openmrs/esm-framework';
+import { openmrsFetch, showNotification, useSession, type FetchResponse, restBaseUrl } from '@openmrs/esm-framework';
 import type { PatientSearchResponse, SearchedPatient, User } from './types';
 
 const v =
@@ -26,7 +26,7 @@ export function useInfinitePatientSearch(
       if (prevPageData && !prevPageData?.data?.links.some((link) => link.rel === 'next')) {
         return null;
       }
-      let url = `/ws/rest/v1/patient?q=${searchTerm}&v=${customRepresentation}&includeDead=${includeDead}&limit=${resultsToFetch}&totalCount=true`;
+      let url = `${restBaseUrl}/patient?q=${searchTerm}&v=${customRepresentation}&includeDead=${includeDead}&limit=${resultsToFetch}&totalCount=true`;
       if (page) {
         url += `&startIndex=${page * resultsToFetch}`;
       }
@@ -62,7 +62,7 @@ export function useRecentlyViewedPatients(showRecentlySearchedPatients: boolean 
   const { user } = useSession();
   const userUuid = user?.uuid;
   const { data, error, mutate } = useSWR<FetchResponse<User>, Error>(
-    showRecentlySearchedPatients && userUuid ? `/ws/rest/v1/user/${userUuid}` : null,
+    showRecentlySearchedPatients && userUuid ? `${restBaseUrl}/user/${userUuid}` : null,
     openmrsFetch,
   );
 
@@ -83,7 +83,7 @@ export function useRecentlyViewedPatients(showRecentlySearchedPatients: boolean 
       const remainingPatients = recentlyViewedPatients.filter((uuid) => uuid !== patientUuid);
       const newUserProperties = { ...userProperties, patientsVisited: [patientUuid, ...remainingPatients].join(',') };
 
-      return openmrsFetch(`/ws/rest/v1/user/${user?.uuid}`, {
+      return openmrsFetch(`${restBaseUrl}/user/${user?.uuid}`, {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
@@ -119,7 +119,7 @@ export function useRESTPatients(
 
   const getPatientUrl = (index) => {
     if (index < patientUuids.length) {
-      return `/ws/rest/v1/patient/${patientUuids[index]}?v=${customRepresentation}`;
+      return `${restBaseUrl}/patient/${patientUuids[index]}?v=${customRepresentation}`;
     } else {
       return null;
     }

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.resource.ts
@@ -13,6 +13,7 @@ import {
   toOmrsIsoString,
   useConfig,
   type Visit,
+  restBaseUrl,
 } from '@openmrs/esm-framework';
 import { type Identifer, type MappedServiceQueueEntry, type QueueServiceInfo } from '../types';
 import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
@@ -148,7 +149,7 @@ export function useStatus() {
     concepts: { statusConceptSetUuid },
   } = config;
 
-  const apiUrl = `/ws/rest/v1/concept/${statusConceptSetUuid}`;
+  const apiUrl = `${restBaseUrl}/concept/${statusConceptSetUuid}`;
   const { data, error, isLoading } = useSWRImmutable<FetchResponse>(apiUrl, openmrsFetch);
 
   return {
@@ -163,7 +164,7 @@ export function usePriority() {
     concepts: { priorityConceptSetUuid },
   } = config;
 
-  const apiUrl = `/ws/rest/v1/concept/${priorityConceptSetUuid}`;
+  const apiUrl = `${restBaseUrl}/concept/${priorityConceptSetUuid}`;
   const { data, error, isLoading } = useSWRImmutable<FetchResponse>(apiUrl, openmrsFetch);
 
   return {
@@ -179,7 +180,7 @@ export function useVisitQueueEntries(currServiceName: string, locationUuid: stri
   const config = useConfig();
   const { visitQueueNumberAttributeUuid } = config;
 
-  const apiUrl = `/ws/rest/v1/visit-queue-entry?location=${queueLocationUuid}&v=full`;
+  const apiUrl = `${restBaseUrl}/visit-queue-entry?location=${queueLocationUuid}&v=full`;
   const { t } = useTranslation();
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<VisitQueueEntry> } }, Error>(
     apiUrl,
@@ -277,7 +278,7 @@ export async function updateQueueEntry(
 
   await Promise.all([endPatientStatus(previousQueueUuid, queueEntryUuid, endedAt)]);
 
-  return openmrsFetch(`/ws/rest/v1/visit-queue-entry`, {
+  return openmrsFetch(`${restBaseUrl}/visit-queue-entry`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -308,7 +309,7 @@ export async function updateQueueEntry(
 
 export async function endPatientStatus(previousQueueUuid: string, queueEntryUuid: string, endedAt: Date) {
   const abortController = new AbortController();
-  await openmrsFetch(`/ws/rest/v1/queue/${previousQueueUuid}/entry/${queueEntryUuid}`, {
+  await openmrsFetch(`${restBaseUrl}/queue/${previousQueueUuid}/entry/${queueEntryUuid}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -321,7 +322,7 @@ export async function endPatientStatus(previousQueueUuid: string, queueEntryUuid
 }
 
 export function useServiceQueueEntries(service: string, locationUuid: string) {
-  const apiUrl = `/ws/rest/v1/visit-queue-entry?status=waiting&service=${service}&location=${locationUuid}&v=full`;
+  const apiUrl = `${restBaseUrl}/visit-queue-entry?status=waiting&service=${service}&location=${locationUuid}&v=full`;
   const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<VisitQueueEntry> } }, Error>(
     service && locationUuid ? apiUrl : null,
     openmrsFetch,
@@ -362,7 +363,7 @@ export async function addQueueEntry(
 
   await Promise.all([generateVisitQueueNumber(locationUuid, visitUuid, queueUuid, visitQueueNumberAttributeUuid)]);
 
-  return openmrsFetch(`/ws/rest/v1/visit-queue-entry`, {
+  return openmrsFetch(`${restBaseUrl}/visit-queue-entry`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -399,7 +400,7 @@ export async function generateVisitQueueNumber(
   const abortController = new AbortController();
 
   await openmrsFetch(
-    `/ws/rest/v1/queue-entry-number?location=${location}&queue=${queueUuid}&visit=${visitUuid}&visitAttributeType=${visitQueueNumberAttributeUuid}`,
+    `${restBaseUrl}/queue-entry-number?location=${location}&queue=${queueUuid}&visit=${visitUuid}&visitAttributeType=${visitQueueNumberAttributeUuid}`,
     {
       method: 'GET',
       headers: {
@@ -413,7 +414,7 @@ export async function generateVisitQueueNumber(
 export function serveQueueEntry(servicePointName: string, ticketNumber: string, status: string) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/queueutil/assignticket`, {
+  return openmrsFetch(`${restBaseUrl}/queueutil/assignticket`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.resource.ts
+++ b/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.resource.ts
@@ -1,11 +1,11 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 import { type ProvidersQueueRoom, type QueueRoom } from '../types';
 
 export function useQueueRooms(location: string, queueUuid: string) {
   const apiUrl = queueUuid
-    ? `/ws/rest/v1/queueroom?location=${location}&queue=${queueUuid}`
-    : `/ws/rest/v1/queueroom?location=${location}`;
+    ? `${restBaseUrl}/queueroom?location=${location}&queue=${queueUuid}`
+    : `${restBaseUrl}/queueroom?location=${location}`;
 
   const { data, error, isLoading } = useSWR<{ data: { results: Array<QueueRoom> } }, Error>(
     location ? apiUrl : null,
@@ -22,7 +22,7 @@ export function useQueueRooms(location: string, queueUuid: string) {
 export function addProviderToQueueRoom(queueRoomUuid: string, providerUuid) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/roomprovidermap`, {
+  return openmrsFetch(`${restBaseUrl}/roomprovidermap`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -42,7 +42,7 @@ export function addProviderToQueueRoom(queueRoomUuid: string, providerUuid) {
 export function updateProviderToQueueRoom(queueProviderMapUuid: string, queueRoomUuid: string, providerUuid) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/roomprovidermap/${queueProviderMapUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/roomprovidermap/${queueProviderMapUuid}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -60,7 +60,7 @@ export function updateProviderToQueueRoom(queueProviderMapUuid: string, queueRoo
 }
 
 export function useProvidersQueueRoom(providerUuid: string) {
-  const apiUrl = `/ws/rest/v1/roomprovidermap?provider=${providerUuid}`;
+  const apiUrl = `${restBaseUrl}/roomprovidermap?provider=${providerUuid}`;
 
   const { data, error, isLoading, mutate } = useSWR<{ data: { results: Array<ProvidersQueueRoom> } }, Error>(
     providerUuid ? apiUrl : null,

--- a/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.resource.ts
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.resource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch, parseDate } from '@openmrs/esm-framework';
+import { openmrsFetch, parseDate, restBaseUrl } from '@openmrs/esm-framework';
 import { endPatientStatus, type MappedVisitQueueEntry } from '../active-visits/active-visits-table.resource';
 
 export async function batchClearQueueEntries(queueEntries: Array<MappedVisitQueueEntry>) {
@@ -18,7 +18,7 @@ export async function batchClearQueueEntries(queueEntries: Array<MappedVisitQueu
       ]);
 
       concurrentReq.push(
-        openmrsFetch(`/ws/rest/v1/visit/${queueEntries[index].visitUuid}`, {
+        openmrsFetch(`${restBaseUrl}/visit/${queueEntries[index].visitUuid}`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/packages/esm-service-queues-app/src/config-schema.ts
+++ b/packages/esm-service-queues-app/src/config-schema.ts
@@ -1,4 +1,4 @@
-import { Type, validators } from '@openmrs/esm-framework';
+import { Type, restBaseUrl, validators } from '@openmrs/esm-framework';
 import vitalsConfigSchema, { type VitalsConfigObject } from './current-visit/visit-details/vitals-config-schema';
 import biometricsConfigSchema, {
   type BiometricsConfigObject,
@@ -130,7 +130,7 @@ export const configSchema = {
   },
   defaultFacilityUrl: {
     _type: Type.String,
-    _default: '/ws/rest/v1/kenyaemr/default-facility',
+    _default: `${restBaseUrl}/kenyaemr/default-facility`,
     _description: 'Custom URL to load default facility if it is not in the session',
   },
   customPatientChartText: {

--- a/packages/esm-service-queues-app/src/current-visit/current-visit.resource.ts
+++ b/packages/esm-service-queues-app/src/current-visit/current-visit.resource.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch, type Visit } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, type Visit } from '@openmrs/esm-framework';
 import { type ConceptMetadata } from './hooks/useVitalsConceptMetadata';
 import { type ObsMetaInfo } from '../types/index';
 
@@ -17,7 +17,7 @@ export function useVisit(visitUuid: string) {
     'encounterProviders:(uuid,display,encounterRole:(uuid,display),' +
     'provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime';
 
-  const apiUrl = `/ws/rest/v1/visit/${visitUuid}?v=${customRepresentation}`;
+  const apiUrl = `${restBaseUrl}/visit/${visitUuid}?v=${customRepresentation}`;
 
   const { data, error, isLoading, isValidating } = useSWR<{ data: Visit }, Error>(
     visitUuid ? apiUrl : null,

--- a/packages/esm-service-queues-app/src/current-visit/hooks/useVitalsConceptMetadata.tsx
+++ b/packages/esm-service-queues-app/src/current-visit/hooks/useVitalsConceptMetadata.tsx
@@ -1,5 +1,5 @@
 import useSWRImmutable from 'swr/immutable';
-import { openmrsFetch, useConfig, formatTime, parseDate } from '@openmrs/esm-framework';
+import { openmrsFetch, useConfig, formatTime, parseDate, restBaseUrl } from '@openmrs/esm-framework';
 import { type Observation, type PatientVitals, Encounter } from '../../types/index';
 import { type ConfigObject } from '../../config-schema';
 
@@ -7,7 +7,7 @@ export function useVitalsConceptMetadata() {
   const customRepresentation =
     'custom:(setMembers:(uuid,display,hiNormal,hiAbsolute,hiCritical,lowNormal,lowAbsolute,lowCritical,units))';
 
-  const apiUrl = `/ws/rest/v1/concept/?q=VITALS SIGNS&v=${customRepresentation}`;
+  const apiUrl = `${restBaseUrl}/concept/?q=VITALS SIGNS&v=${customRepresentation}`;
 
   const { data, error, isLoading } = useSWRImmutable<{ data: VitalsConceptMetadataResponse }, Error>(
     apiUrl,

--- a/packages/esm-service-queues-app/src/helpers/useQueues.ts
+++ b/packages/esm-service-queues-app/src/helpers/useQueues.ts
@@ -1,9 +1,9 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
 import { type QueueServiceInfo } from '../types';
 
 export function useQueues(locationUuid?: string) {
-  const apiUrl = '/ws/rest/v1/queue' + (locationUuid ? `?location=${locationUuid}` : '');
+  const apiUrl = `${restBaseUrl}/queue` + (locationUuid ? `?location=${locationUuid}` : '');
 
   const { data } = useSWRImmutable<{ data: { results: Array<QueueServiceInfo> } }, Error>(apiUrl, openmrsFetch);
 

--- a/packages/esm-service-queues-app/src/past-visit/past-visit.resource.ts
+++ b/packages/esm-service-queues-app/src/past-visit/past-visit.resource.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch, type Visit } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, type Visit } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 
 export function usePastVisits(patientUuid: string) {
@@ -12,7 +12,7 @@ export function usePastVisits(patientUuid: string) {
     'encounterProviders:(uuid,display,encounterRole:(uuid,display),' +
     'provider:(uuid,person:(uuid,display)))),visitType:(uuid,name,display),startDatetime,stopDatetime,patient';
 
-  const apiUrl = `/ws/rest/v1/visit?patient=${patientUuid}&v=${customRepresentation}`;
+  const apiUrl = `${restBaseUrl}/visit?patient=${patientUuid}&v=${customRepresentation}`;
 
   const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
     patientUuid ? apiUrl : null,

--- a/packages/esm-service-queues-app/src/patient-info/appointments.resource.ts
+++ b/packages/esm-service-queues-app/src/patient-info/appointments.resource.ts
@@ -1,9 +1,9 @@
 import dayjs from 'dayjs';
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentsFetchResponse } from '../types';
 
-export const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
+export const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
 
 export function useAppointments(patientUuid: string, startDate: string) {
   const abortController = new AbortController();

--- a/packages/esm-service-queues-app/src/patient-info/hooks/usePatientAttributes.tsx
+++ b/packages/esm-service-queues-app/src/patient-info/hooks/usePatientAttributes.tsx
@@ -1,4 +1,4 @@
-import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
 import { type ConfigObject } from '../../config-schema';
 import { type Patient, Attribute } from '../../types';
@@ -13,7 +13,7 @@ const customRepresentation =
  */
 export const usePatientAttributes = (patientUuid: string) => {
   const { data, error, isLoading } = useSWRImmutable<{ data: Patient }>(
-    `/ws/rest/v1/patient/${patientUuid}?v=${customRepresentation}`,
+    `${restBaseUrl}/patient/${patientUuid}?v=${customRepresentation}`,
     openmrsFetch,
   );
 

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.resource.ts
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.resource.ts
@@ -1,4 +1,4 @@
-import { useSession, type Visit, openmrsFetch } from '@openmrs/esm-framework';
+import { useSession, type Visit, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 import useSWR from 'swr';
 import { type WaitTime } from '../types';
@@ -15,7 +15,7 @@ export function useActiveVisits() {
     startDate +
     '&location=' +
     sessionLocation;
-  const url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}`;
+  const url = `${restBaseUrl}/visit?includeInactive=false&v=${customRepresentation}`;
   const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Visit> } }, Error>(
     sessionLocation ? url : null,
     openmrsFetch,
@@ -41,7 +41,7 @@ export function useActiveVisits() {
 }
 
 export function useAverageWaitTime(serviceUuid: string, statusUuid: string) {
-  const apiUrl = `/ws/rest/v1/queue-metrics?queue=${serviceUuid}&status=${statusUuid}`;
+  const apiUrl = `${restBaseUrl}/queue-metrics?queue=${serviceUuid}&status=${statusUuid}`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: WaitTime }, Error>(
     serviceUuid && statusUuid ? apiUrl : null,

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/queue-metrics.resource.ts
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/queue-metrics.resource.ts
@@ -1,12 +1,12 @@
 import useSWR from 'swr';
 import useSWRImmutable from 'swr/immutable';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type Appointment, type QueueServiceInfo } from '../types';
 import { startOfDay } from '../constants';
 
 export function useServiceMetricsCount(service: string, location: string) {
   const status = 'Waiting';
-  const apiUrl = `/ws/rest/v1/queue-entry-metrics?service=${service}&status=${status}&location=${location}`;
+  const apiUrl = `${restBaseUrl}/queue-entry-metrics?service=${service}&status=${status}&location=${location}`;
 
   const { data } = useSWRImmutable<
     {
@@ -23,7 +23,7 @@ export function useServiceMetricsCount(service: string, location: string) {
 }
 
 export const useAppointmentMetrics = () => {
-  const apiUrl = `/ws/rest/v1/appointment/all?forDate=${startOfDay}`;
+  const apiUrl = `${restBaseUrl}/appointment/all?forDate=${startOfDay}`;
 
   const { data, error, isLoading } = useSWR<{
     data: Array<Appointment>;

--- a/packages/esm-service-queues-app/src/patient-search/hooks/useActivePatientEnrollment.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/hooks/useActivePatientEnrollment.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type PatientProgram } from '../../types';
 import uniqBy from 'lodash-es/uniqBy';
 
 export const useActivePatientEnrollment = (patientUuid: string) => {
   const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateCompleted,location:(uuid,display))`;
-  const apiUrl = `/ws/rest/v1/programenrollment?patient=${patientUuid}&v=${customRepresentation}`;
+  const apiUrl = `${restBaseUrl}/programenrollment?patient=${patientUuid}&v=${customRepresentation}`;
 
   const { data, error, isLoading } = useSWR<{ data: { results: Array<PatientProgram> } }>(
     patientUuid ? apiUrl : null,

--- a/packages/esm-service-queues-app/src/patient-search/hooks/useScheduledVisits.ts
+++ b/packages/esm-service-queues-app/src/patient-search/hooks/useScheduledVisits.ts
@@ -1,12 +1,12 @@
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 import { type AppointmentsFetchResponse } from '../../types';
 
 export function useScheduledVisits(patientUuid: string) {
   const abortController = new AbortController();
   let startDate = dayjs(new Date().toISOString()).subtract(6, 'month').toISOString();
-  const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
+  const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
 
   const fetcher = () =>
     openmrsFetch(appointmentsSearchUrl, {

--- a/packages/esm-service-queues-app/src/patient-search/search.resource.ts
+++ b/packages/esm-service-queues-app/src/patient-search/search.resource.ts
@@ -1,7 +1,7 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export function findPatients(query: string, objectVersion: string, controller: AbortController, includeDead: boolean) {
-  const url = `/ws/rest/v1/patient?q=${query}&v=${objectVersion}&includeDead=${includeDead}`;
+  const url = `${restBaseUrl}/patient?q=${query}&v=${objectVersion}&includeDead=${includeDead}`;
 
   return openmrsFetch(url, {
     method: 'GET',

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/queue.resource.ts
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/queue.resource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch, toDateObjectStrict, toOmrsIsoString } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, toDateObjectStrict, toOmrsIsoString } from '@openmrs/esm-framework';
 import { generateVisitQueueNumber } from '../../active-visits/active-visits-table.resource';
 import { type Appointment } from '../../types';
 
@@ -20,7 +20,7 @@ export async function addQueueEntry(
     generateVisitQueueNumber(locationUuid, visitUuid, queueServiceUuid, visitQueueNumberAttributeUuid),
   ]);
 
-  return openmrsFetch(`/ws/rest/v1/visit-queue-entry`, {
+  return openmrsFetch(`${restBaseUrl}/visit-queue-entry`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -50,7 +50,7 @@ export async function addQueueEntry(
 export async function saveAppointment(appointment: Appointment) {
   const abortController = new AbortController();
 
-  await openmrsFetch(`/ws/rest/v1/appointment`, {
+  await openmrsFetch(`${restBaseUrl}/appointment`, {
     method: 'POST',
     signal: abortController.signal,
     headers: {

--- a/packages/esm-service-queues-app/src/queue-entry-table-components/transition-entry.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-entry-table-components/transition-entry.component.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { mutate } from 'swr';
 import { Button } from '@carbon/react';
 import { Notification } from '@carbon/react/icons';
-import { showModal, showNotification } from '@openmrs/esm-framework';
+import { restBaseUrl, showModal, showNotification } from '@openmrs/esm-framework';
 import { type MappedVisitQueueEntry, serveQueueEntry } from '../active-visits/active-visits-table.resource';
 import styles from './transition-entry.scss';
 interface TransitionMenuProps {
@@ -18,7 +18,7 @@ const TransitionMenu: React.FC<TransitionMenuProps> = ({ queueEntry, closeModal 
     serveQueueEntry(queueEntry?.service, queueEntry?.visitQueueNumber, 'calling').then(
       ({ status }) => {
         if (status === 200) {
-          mutate(`/ws/rest/v1/queueutil/assignticket`);
+          mutate(`${restBaseUrl}/queueutil/assignticket`);
         }
       },
       (error) => {

--- a/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist.resource.ts
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist.resource.ts
@@ -1,12 +1,12 @@
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type Appointment, type AppointmentsFetchResponse } from '../types/index';
 import { type Provider } from '../types';
 import { startOfDay } from '../constants';
 import dayjs from 'dayjs';
 
 export function useAppointments() {
-  const apiUrl = `/ws/rest/v1/appointment/all?forDate=${startOfDay}`;
+  const apiUrl = `${restBaseUrl}/appointment/all?forDate=${startOfDay}`;
   const { data, error, isLoading, isValidating } = useSWR<{ data: Array<Appointment> }, Error>(apiUrl, openmrsFetch);
 
   return {
@@ -18,7 +18,7 @@ export function useAppointments() {
 }
 
 export function useCheckedInAppointments() {
-  const apiUrl = `/ws/rest/v1/appointment/appointmentStatus?forDate=${startOfDay}&status=CheckedIn`;
+  const apiUrl = `${restBaseUrl}/appointment/appointmentStatus?forDate=${startOfDay}&status=CheckedIn`;
 
   const { data, error, isLoading, isValidating } = useSWR<{ data: Array<Appointment> }, Error>(apiUrl, openmrsFetch);
 
@@ -32,7 +32,7 @@ export function useCheckedInAppointments() {
 
 export function useProviders() {
   const customRepresentation = 'custom:(uuid,display,person:(age,display,gender,uuid))';
-  const apiUrl = `/ws/rest/v1/provider?q=&v=${customRepresentation}`;
+  const apiUrl = `${restBaseUrl}/provider?q=&v=${customRepresentation}`;
   const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<Provider> } }, Error>(
     apiUrl,
     openmrsFetch,
@@ -49,7 +49,7 @@ export function useProviders() {
 export function usePatientAppointments(patientUuid: string, startDate) {
   const abortController = new AbortController();
 
-  const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
+  const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
   const fetcher = () =>
     openmrsFetch(appointmentsSearchUrl, {
       method: 'POST',

--- a/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.component.tsx
@@ -12,7 +12,7 @@ import {
   Button,
   InlineNotification,
 } from '@carbon/react';
-import { showSnackbar, useLayoutType } from '@openmrs/esm-framework';
+import { restBaseUrl, showSnackbar, useLayoutType } from '@openmrs/esm-framework';
 import { type SearchTypes } from '../types';
 import { mutate } from 'swr';
 import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
@@ -61,7 +61,7 @@ const QueueRoomForm: React.FC<QueueRoomFormProps> = ({ toggleSearchType, closePa
               subtitle: t('queueRoomAddedSuccessfully', 'Queue room added successfully'),
             });
             closePanel();
-            mutate(`/ws/rest/v1/queueroom`);
+            mutate(`${restBaseUrl}/queueroom`);
           }
         },
         (error) => {

--- a/packages/esm-service-queues-app/src/queue-rooms/queue-room.resource.ts
+++ b/packages/esm-service-queues-app/src/queue-rooms/queue-room.resource.ts
@@ -1,9 +1,9 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export function saveQueueRoom(name: string, description: string, queueUuid: string) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/queueroom`, {
+  return openmrsFetch(`${restBaseUrl}/queueroom`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/esm-service-queues-app/src/queue-screen/useActiveTickets.tsx
+++ b/packages/esm-service-queues-app/src/queue-screen/useActiveTickets.tsx
@@ -1,9 +1,9 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 
 export const useActiveTickets = () => {
   const { data, isLoading, error, mutate } = useSWR<{ data: Record<string, { status: string; ticketNumber: string }> }>(
-    '/ws/rest/v1/queueutil/active-tickets',
+    `${restBaseUrl}/queueutil/active-tickets`,
     openmrsFetch,
     { refreshInterval: 3000 },
   );

--- a/packages/esm-service-queues-app/src/queue-services/queue-service-form.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-services/queue-service-form.component.tsx
@@ -13,7 +13,7 @@ import {
   InlineNotification,
 } from '@carbon/react';
 import { mutate } from 'swr';
-import { showSnackbar, useLayoutType } from '@openmrs/esm-framework';
+import { restBaseUrl, showSnackbar, useLayoutType } from '@openmrs/esm-framework';
 import { saveQueue, useServiceConcepts } from './queue-service.resource';
 import { type SearchTypes } from '../types';
 import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
@@ -66,8 +66,8 @@ const QueueServiceForm: React.FC<QueueServiceFormProps> = ({ toggleSearchType, c
               subtitle: t('queueAddedSuccessfully', 'Queue addeded successfully'),
             });
             closePanel();
-            mutate(`/ws/rest/v1/queue?${userLocation}`);
-            mutate(`/ws/rest/v1/queue?location=${userLocation}`);
+            mutate(`${restBaseUrl}/queue?${userLocation}`);
+            mutate(`${restBaseUrl}/queue?location=${userLocation}`);
           }
         },
         (error) => {

--- a/packages/esm-service-queues-app/src/queue-services/queue-service.resource.ts
+++ b/packages/esm-service-queues-app/src/queue-services/queue-service.resource.ts
@@ -1,5 +1,5 @@
 import useSWRImmutable from 'swr/immutable';
-import { type FetchResponse, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, useConfig, restBaseUrl } from '@openmrs/esm-framework';
 
 export function useServiceConcepts() {
   const config = useConfig();
@@ -7,7 +7,7 @@ export function useServiceConcepts() {
     concepts: { serviceConceptSetUuid },
   } = config;
 
-  const apiUrl = `/ws/rest/v1/concept/${serviceConceptSetUuid}`;
+  const apiUrl = `${restBaseUrl}/concept/${serviceConceptSetUuid}`;
   const { data, isLoading } = useSWRImmutable<FetchResponse>(apiUrl, openmrsFetch);
 
   return {
@@ -19,7 +19,7 @@ export function useServiceConcepts() {
 export function saveQueue(queueName: string, queueConcept: string, queueDescription: string, queueLocation: string) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/queue`, {
+  return openmrsFetch(`${restBaseUrl}/queue`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.resource.ts
+++ b/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.resource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch, updateVisit } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, updateVisit } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 import { endPatientStatus } from '../active-visits/active-visits-table.resource';
 import { type AppointmentsFetchResponse, type EndVisitPayload } from '../types';
@@ -52,7 +52,7 @@ export async function voidQueueEntry(
 export function useCheckedInAppointments(patientUuid: string, startDate: string) {
   const abortController = new AbortController();
 
-  const appointmentsSearchUrl = `/ws/rest/v1/appointments/search`;
+  const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
   const fetcher = () =>
     openmrsFetch(appointmentsSearchUrl, {
       method: 'POST',
@@ -84,7 +84,7 @@ export function useCheckedInAppointments(patientUuid: string, startDate: string)
 }
 
 export async function changeAppointmentStatus(toStatus: string, appointmentUuid: string) {
-  const url = `/ws/rest/v1/appointments/${appointmentUuid}/status-change`;
+  const url = `${restBaseUrl}/appointments/${appointmentUuid}/status-change`;
   return openmrsFetch(url, {
     body: { toStatus, onDate: statusChangeTime, timeZone: timeZone },
     method: 'POST',

--- a/packages/esm-service-queues-app/src/transition-queue-entry/transition-queue-entry.resource.ts
+++ b/packages/esm-service-queues-app/src/transition-queue-entry/transition-queue-entry.resource.ts
@@ -1,9 +1,9 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export function requeueQueueEntry(priorityComment: string, queueUuid: string, queueEntryUuid: string) {
   const abortController = new AbortController();
 
-  return openmrsFetch(`/ws/rest/v1/queue/${queueUuid}/entry/${queueEntryUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/queue/${queueUuid}/entry/${queueEntryUuid}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/esm-service-queues-app/src/visits-missing-inqueue/visits-missing-inqueue.resource.ts
+++ b/packages/esm-service-queues-app/src/visits-missing-inqueue/visits-missing-inqueue.resource.ts
@@ -2,7 +2,7 @@ import useSWR from 'swr';
 import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday';
 import last from 'lodash-es/last';
-import { openmrsFetch, type Visit, useSession } from '@openmrs/esm-framework';
+import { openmrsFetch, type Visit, useSession, restBaseUrl } from '@openmrs/esm-framework';
 import { type VisitQueueEntry } from '../active-visits/active-visits-table.resource';
 
 dayjs.extend(isToday);
@@ -32,14 +32,14 @@ export function useMissingQueueEntries() {
     startDate +
     '&location=' +
     sessionLocation;
-  const url = `/ws/rest/v1/visit?includeInactive=false&v=${customRepresentation}`;
+  const url = `${restBaseUrl}/visit?includeInactive=false&v=${customRepresentation}`;
   const {
     data: visitsData,
     error: visitsError,
     isValidating: visitsIsValidating,
   } = useSWR<{ data: { results: Array<Visit> } }, Error>(sessionLocation ? url : null, openmrsFetch);
 
-  const apiUrl = `/ws/rest/v1/visit-queue-entry`;
+  const apiUrl = `${restBaseUrl}/visit-queue-entry`;
   const {
     data: queueData,
     error: queueError,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Replaced all the instances of /ws/rest/v1 with restBaseUrl from framework

## Related Issue
[O3-2815](https://openmrs.atlassian.net/jira/software/c/projects/O3/issues/O3-2815)
