### PR TITLE
(feat) Properly destructure the selected location from the queue header dropdown

### DIFF
--- a/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
@@ -21,7 +21,7 @@ const PatientQueueHeader: React.FC<{ title?: string }> = ({ title }) => {
   const userLocation = userSession?.sessionLocation?.display;
   const currentQueueLocationName = useSelectedQueueLocationName();
 
-  const handleQueueLocationChange = useCallback((selectedItem) => {
+  const handleQueueLocationChange = useCallback(({ selectedItem }) => {
     updateSelectedQueueLocationUuid(selectedItem.id);
     updateSelectedQueueLocationName(selectedItem.name);
     updateSelectedServiceName('All');


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR makes it so that the selected location gets properly destructured from the `handleQueueLocationChange` event handler when selecting the queue location.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
