### PR TITLE
(fix) Add a check for customConceptAnswers when configuring coded person attribute fields

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/person-attributes/coded-person-attribute-field.component.tsx
@@ -26,12 +26,13 @@ export function CodedPersonAttributeField({
   const { data: conceptAnswers, isLoading: isLoadingConceptAnswers } = useConceptAnswers(
     customConceptAnswers.length ? '' : answerConceptSetUuid,
   );
+
   const { t } = useTranslation();
   const fieldName = `attributes.${personAttributeType.uuid}`;
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    if (!answerConceptSetUuid) {
+    if (!answerConceptSetUuid && !customConceptAnswers.length) {
       reportError(
         t(
           'codedPersonAttributeNoAnswerSet',
@@ -41,10 +42,10 @@ export function CodedPersonAttributeField({
       );
       setError(true);
     }
-  }, [answerConceptSetUuid]);
+  }, [answerConceptSetUuid, customConceptAnswers]);
 
   useEffect(() => {
-    if (!isLoadingConceptAnswers) {
+    if (!isLoadingConceptAnswers && !customConceptAnswers.length) {
       if (!conceptAnswers) {
         reportError(
           t(
@@ -69,7 +70,7 @@ export function CodedPersonAttributeField({
         setError(true);
       }
     }
-  }, [isLoadingConceptAnswers, conceptAnswers]);
+  }, [isLoadingConceptAnswers, conceptAnswers, customConceptAnswers]);
 
   const answers = useMemo(() => {
     if (customConceptAnswers.length) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work is validated by existing tests.

## Summary

This PR addresses an issue discovered while configuring the Patient Registration form. After adding customized concept answers to a patient attribute `format org.openmrs.Concept`, the error `The person attribute field 'nextOfKinRelationship' is of type 'coded' but has been defined without an answer concept set UUID. The 'answerConceptSetUuid' key is required.` is displayed. This has been resolved by adding `customConceptAnswers` to the check that determines whether the error should be shown.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
N/A

## Other
Error displayed should include customConceptAnswers
