### PR TITLE
(fix) various UI issues with transition queue entry form and queue table

### DIFF
--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.scss
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.scss
@@ -90,6 +90,7 @@
     align-items: baseline;
     height: spacing.$spacing-07;
     margin-bottom: spacing.$spacing-02;
+    z-index: 1; // prevent dropdown from getting covered by table elements
   }
 }
 

--- a/packages/esm-service-queues-app/src/queue-table/queue-table-by-status.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table-by-status.component.tsx
@@ -50,15 +50,8 @@ const QueueTableByStatus: React.FC<QueueTableByStatusProps> = ({
   const { queueEntries, isLoading } = useQueueEntries({ queue: selectedQueue.uuid });
   const allowedStatuses = selectedQueue.allowedStatuses;
 
-  const currentStatusUuid = selectedStatus?.uuid;
-
-  const currentStatusIndex = Math.max(0, allowedStatuses?.findIndex((s) => s.uuid == currentStatusUuid));
-
-  const queueEntriesForCurrentStatus = queueEntries?.filter(
-    (entry) => !currentStatusUuid || entry.status.uuid == currentStatusUuid,
-  );
-
-  const tableConfig = configByStatus?.get(currentStatusUuid) ?? defaultQueueTableConfig;
+  const currentStatusUuid = selectedStatus?.uuid ?? allowedStatuses?.[0]?.uuid;
+  const currentStatusIndex = allowedStatuses?.findIndex((s) => s.uuid == currentStatusUuid);
 
   const noStatuses = !allowedStatuses?.length;
   if (isLoading) {
@@ -73,6 +66,9 @@ const QueueTableByStatus: React.FC<QueueTableByStatusProps> = ({
       />
     );
   }
+
+  const queueEntriesForCurrentStatus = queueEntries?.filter((entry) => entry.status.uuid == currentStatusUuid);
+  const tableConfig = configByStatus?.get(currentStatusUuid) ?? defaultQueueTableConfig;
 
   return (
     <div className={styles.container}>

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.scss
@@ -45,6 +45,7 @@
     align-items: baseline;
     height: spacing.$spacing-07;
     margin-bottom: spacing.$spacing-02;
+    z-index: 1; // prevent dropdown from getting covered by table elements
   }
 
   :global(.cds--table-toolbar) {
@@ -52,9 +53,6 @@
     height: 3rem;
     overflow: visible;
   }
-}
-
-.tableToolbaer {
 }
 
 .queueTable tr:last-of-type {

--- a/packages/esm-service-queues-app/src/queue-table/transitions/transition-queue-entry-modal.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/transitions/transition-queue-entry-modal.component.tsx
@@ -132,7 +132,7 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
                       key={uuid}
                       text={
                         uuid == queueEntry.queue.uuid
-                          ? t('currentValueFormatted', '{{value}} (Current value)', { value: display })
+                          ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
                           : display
                       }
                       value={uuid}
@@ -163,7 +163,7 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
                         name={display}
                         labelText={
                           uuid == queueEntry.status.uuid
-                            ? t('currentValueFormatted', '{{value}} (Current value)', { value: display })
+                            ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
                             : display
                         }
                         value={uuid}
@@ -196,7 +196,7 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
                         name={uuid}
                         text={
                           uuid == queueEntry.priority.uuid
-                            ? t('currentValueFormatted', '{{value}} (Current value)', { value: display })
+                            ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
                             : display
                         }
                         key={uuid}

--- a/packages/esm-service-queues-app/src/queue-table/transitions/transition-queue-entry-modal.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/transitions/transition-queue-entry-modal.component.tsx
@@ -42,8 +42,8 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
     selectedPriority: queueEntry.priority.uuid,
     selectedStatus: queueEntry.status.uuid,
   });
-
   const { queues } = useQueues();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const selectedQueue = queues.find((q) => q.uuid == formState.selectedQueue);
 
@@ -74,6 +74,7 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
 
   const submitForm = (e) => {
     e.preventDefault();
+    setIsSubmitting(true);
 
     transitionQueueEntry({
       queueEntryToTransition: queueEntry.uuid,
@@ -101,8 +102,13 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
           kind: 'error',
           subtitle: error?.message,
         });
+      })
+      .finally(() => {
+        setIsSubmitting(false);
       });
   };
+
+  const selectedPriorityIndex = priorities.findIndex((p) => p.uuid == formState.selectedPriority);
 
   return (
     <div>
@@ -121,10 +127,16 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
                   invalidText="Required"
                   value={formState.selectedQueue}
                   onChange={(event) => setSelectedQueueUuid(event.target.value)}>
-                  {queues?.map((queue) => (
-                    <SelectItem key={queue.uuid} text={queue.display} value={queue.uuid}>
-                      {queue.display}
-                    </SelectItem>
+                  {queues?.map(({ uuid, display }) => (
+                    <SelectItem
+                      key={uuid}
+                      text={
+                        uuid == queueEntry.queue.uuid
+                          ? t('currentValueFormatted', '{{value}} (Current value)', { value: display })
+                          : display
+                      }
+                      value={uuid}
+                    />
                   ))}
                 </Select>
               </section>
@@ -146,7 +158,16 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
                       setSelectedStatusUuid(uuid);
                     }}>
                     {statuses?.map(({ uuid, display }) => (
-                      <RadioButton key={uuid} name={display} labelText={display} value={uuid} />
+                      <RadioButton
+                        key={uuid}
+                        name={display}
+                        labelText={
+                          uuid == queueEntry.status.uuid
+                            ? t('currentValueFormatted', '{{value}} (Current value)', { value: display })
+                            : display
+                        }
+                        value={uuid}
+                      />
                     ))}
                   </RadioButtonGroup>
                 )}
@@ -165,13 +186,23 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
                 ) : (
                   <ContentSwitcher
                     size="sm"
-                    selectedIndex={1}
+                    selectedIndex={selectedPriorityIndex}
                     onChange={(event) => {
                       setSelectedPriorityUuid(event.name as string);
                     }}>
-                    {priorities?.map(({ uuid, display }) => {
-                      return <Switch role="radio" name={uuid} text={display} key={uuid} value={uuid} />;
-                    })}
+                    {priorities?.map(({ uuid, display }) => (
+                      <Switch
+                        role="radio"
+                        name={uuid}
+                        text={
+                          uuid == queueEntry.priority.uuid
+                            ? t('currentValueFormatted', '{{value}} (Current value)', { value: display })
+                            : display
+                        }
+                        key={uuid}
+                        value={uuid}
+                      />
+                    ))}
                   </ContentSwitcher>
                 )}
               </section>
@@ -184,7 +215,8 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ q
           </Button>
           <Button
             disabled={
-              formState.selectedQueue == queueEntry.queue.uuid && formState.selectedStatus == queueEntry.status.uuid
+              isSubmitting ||
+              (formState.selectedQueue == queueEntry.queue.uuid && formState.selectedStatus == queueEntry.status.uuid)
             }
             type="submit">
             {t('transitionPatient', 'Transition patient')}

--- a/packages/esm-service-queues-app/src/queue-table/transitions/transition-queue-entry-modal.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/transitions/transition-queue-entry-modal.test.tsx
@@ -28,11 +28,15 @@ describe('TransitionQueueEntryModal: ', () => {
     expect(screen.getByText(queueEntry.patient.display)).toBeInTheDocument();
 
     for (const status of allowedStatuses) {
-      expect(screen.getByRole('radio', { name: status.display })).toBeInTheDocument();
+      const expectedStatusDisplay =
+        queueEntry.status.uuid == status.uuid ? `${status.display} (Current value)` : status.display;
+      expect(screen.getByRole('radio', { name: expectedStatusDisplay })).toBeInTheDocument();
     }
 
     for (const pri of allowedPriorities) {
-      expect(screen.getByRole('radio', { name: pri.display })).toBeInTheDocument();
+      const expectedPriorityDisplay =
+        queueEntry.priority.uuid == pri.uuid ? `${pri.display} (Current value)` : pri.display;
+      expect(screen.getByRole('radio', { name: expectedPriorityDisplay })).toBeInTheDocument();
     }
   });
 

--- a/packages/esm-service-queues-app/src/queue-table/transitions/transition-queue-entry-modal.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/transitions/transition-queue-entry-modal.test.tsx
@@ -29,13 +29,12 @@ describe('TransitionQueueEntryModal: ', () => {
 
     for (const status of allowedStatuses) {
       const expectedStatusDisplay =
-        queueEntry.status.uuid == status.uuid ? `${status.display} (Current value)` : status.display;
+        queueEntry.status.uuid == status.uuid ? `${status.display} (Current)` : status.display;
       expect(screen.getByRole('radio', { name: expectedStatusDisplay })).toBeInTheDocument();
     }
 
     for (const pri of allowedPriorities) {
-      const expectedPriorityDisplay =
-        queueEntry.priority.uuid == pri.uuid ? `${pri.display} (Current value)` : pri.display;
+      const expectedPriorityDisplay = queueEntry.priority.uuid == pri.uuid ? `${pri.display} (Current)` : pri.display;
       expect(screen.getByRole('radio', { name: expectedPriorityDisplay })).toBeInTheDocument();
     }
   });

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -49,7 +49,7 @@
   "configureServices": "Please configure services to continue.",
   "configureStatus": "Please configure status to continue.",
   "contactDetails": "Contact Details",
-  "currentValueFormatted": "{{value}} (Current value)",
+  "currentValueFormatted": "{{value}} (Current)",
   "currentVisit": "Current visit",
   "date": "Date",
   "date&Time": "Date & time",

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -49,6 +49,7 @@
   "configureServices": "Please configure services to continue.",
   "configureStatus": "Please configure status to continue.",
   "contactDetails": "Contact Details",
+  "currentValueFormatted": "{{value}} (Current value)",
   "currentVisit": "Current visit",
   "date": "Date",
   "date&Time": "Date & time",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fixes various UI issues with the transition queue entry form + queue table.

In transition queue entry form:
- the priority selection now defaults to the current value
- the form submit button now gets disabled while the form submit request is pending
- there is text to indicate the current queue entry value for queue/status/priority

In queue table by status:
- when visiting `/openmrs/spa/home/service-queues/queue-table-by-status/<queue-table-uuid>/` (without status uuid specified), we default to the first tab
- z-index is added to table toolbar content to prevent dropdown from being covered by table elements.

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/0b21f487-3f8f-416b-b8ad-72e4e7e025f6)
"(Current value)" now placed next to current value of queue entry

![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/be3e8514-78bf-457f-b14c-180b97ddbe34)
dropdown now does not get blocked by the bell icon and "Transfer" button


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
