### PR TITLE
(fix) queue table by status should only show active entries

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/queue-table-by-status.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table-by-status.component.tsx
@@ -47,7 +47,7 @@ const QueueTableByStatus: React.FC<QueueTableByStatusProps> = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const { queueEntries, isLoading } = useQueueEntries({ queue: selectedQueue.uuid });
+  const { queueEntries, isLoading } = useQueueEntries({ queue: selectedQueue.uuid, isEnded: false });
   const allowedStatuses = selectedQueue.allowedStatuses;
 
   const currentStatusUuid = selectedStatus?.uuid ?? allowedStatuses?.[0]?.uuid;

--- a/packages/esm-service-queues-app/src/types/index.ts
+++ b/packages/esm-service-queues-app/src/types/index.ts
@@ -468,6 +468,7 @@ export interface QueueEntrySearchCriteria {
   location?: Array<string> | string;
   service?: Array<string> | string;
   status?: Array<string> | string;
+  isEnded: boolean;
 }
 
 // TODO: The follow types match the types from backend.


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Recent changes to the rest endpoint meant that all queue entries were being retrieved for the queue table by status rather than just active entries.  This fixes that by passing in the appropriate search criteria from the component.
