### PR TITLE
(fix) O3-2949 visits should not be modified when queue is cleared

### DIFF
--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.resource.ts
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.resource.ts
@@ -43,10 +43,8 @@ export interface MappedVisitQueueEntry {
   service: string;
   status: QueueStatus;
   statusUuid: string;
-  visitStartDateTime: string;
   visitType: string;
   visitUuid: string;
-  visitLocation: string;
   visitTypeUuid: string;
   waitTime: string;
   queueUuid: string;
@@ -158,9 +156,7 @@ export const mapVisitQueueEntryProperties = (
   status: queueEntry.status.display as QueueStatus,
   statusUuid: queueEntry.status.uuid,
   waitTime: queueEntry.startedAt ? `${dayjs().diff(dayjs(queueEntry.startedAt), 'minutes')}` : '--',
-  visitStartDateTime: queueEntry.startedAt,
   visitType: queueEntry.visit?.visitType?.display,
-  visitLocation: queueEntry.visit?.location?.uuid,
   queueLocation: (queueEntry?.queue as any)?.location?.uuid,
   visitTypeUuid: queueEntry.visit?.visitType?.uuid,
   visitUuid: queueEntry.visit?.uuid,

--- a/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.component.tsx
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.component.tsx
@@ -36,6 +36,7 @@ const ClearQueueEntriesDialog: React.FC<ClearQueueEntriesDialogProps> = ({ visit
           isLowContrast: false,
           subtitle: error?.message,
         });
+        closeModal();
       },
     );
   }, [closeModal, mutate, t, visitQueueEntries]);
@@ -51,7 +52,7 @@ const ClearQueueEntriesDialog: React.FC<ClearQueueEntriesDialogProps> = ({ visit
         <p className={styles.subHeading} id="subHeading">
           {t(
             'clearAllQueueEntriesWarningMessage',
-            'Clearing all queue entries will remove  all the patients from the queues and will not allow you to fill any other encounter forms for the patients',
+            'Clearing all queue entries will remove  all the patients from the queues',
           )}
         </p>
       </ModalBody>

--- a/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.resource.ts
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.resource.ts
@@ -1,46 +1,6 @@
-import { openmrsFetch, parseDate, restBaseUrl } from '@openmrs/esm-framework';
 import { endPatientStatus, type MappedVisitQueueEntry } from '../active-visits/active-visits-table.resource';
 
 export async function batchClearQueueEntries(queueEntries: Array<MappedVisitQueueEntry>) {
-  const abortController = new AbortController();
-  // number of concurrent requests in one batch
-  const batchSize = 10;
-  // request counter
-  let curReq = 0;
-  // as long as there are items in the list continue to form batches
-  while (curReq < queueEntries.length) {
-    const end = queueEntries.length < curReq + batchSize ? queueEntries.length : curReq + batchSize;
-    const concurrentReq = new Array(batchSize);
-    const endedAt = new Date();
-    for (let index = curReq; index < end; index++) {
-      await Promise.all([
-        endPatientStatus(queueEntries[index]?.queueUuid, queueEntries[index]?.queueEntryUuid, endedAt),
-      ]);
-
-      concurrentReq.push(
-        openmrsFetch(`${restBaseUrl}/visit/${queueEntries[index].visitUuid}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          signal: abortController.signal,
-          body: {
-            location: queueEntries[index]?.visitLocation,
-            startDatetime: parseDate(queueEntries[index]?.visitStartDateTime),
-            visitType: queueEntries[index]?.visitTypeUuid,
-            stopDatetime: new Date(),
-          },
-        }),
-      );
-      curReq++;
-    }
-    // wait until all promises are done or one promise is rejected
-    return await Promise.all(concurrentReq)
-      .then((res) => {
-        return res;
-      })
-      .catch((error) => {
-        return error;
-      });
-  }
+  const endedAt = new Date();
+  return await Promise.all(queueEntries.map((qe) => endPatientStatus(qe?.queueUuid, qe?.queueEntryUuid, endedAt)));
 }

--- a/packages/esm-service-queues-app/src/types/index.ts
+++ b/packages/esm-service-queues-app/src/types/index.ts
@@ -325,7 +325,6 @@ export interface MappedQueueEntry {
   service: string;
   status: string;
   statusUuid: string;
-  visitStartDateTime: string;
   visitType: string;
   visitUuid: string;
   waitTime: string;

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -42,7 +42,7 @@
   "chooseService": "Select a service",
   "chooseStatus": "Select a status",
   "clearAllQueueEntries": "Clear all queue entries?",
-  "clearAllQueueEntriesWarningMessage": "Clearing all queue entries will remove  all the patients from the queues and will not allow you to fill any other encounter forms for the patients",
+  "clearAllQueueEntriesWarningMessage": "Clearing all queue entries will remove  all the patients from the queues",
   "clearQueue": "Clear queue",
   "clinicMetrics": "Clinic metrics",
   "configurePriorities": "Please configure priorities to continue.",


### PR DESCRIPTION
## Requirements

- [ x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x ] My work includes tests or is validated by existing tests.

## Summary
The existing "Clear Queue" function will incorrectly shift the visit start date to the most recent queue startedAt date for each queue entry being cleared.  It may also modify the visit location and type.  This is a potentially significant issue.  The solution proposed in this PR is to eliminate the manipulation and closing of visits entirely from this operation.  Although there are definitely use cases or workflows where one could imagine the desire to close visits as well, this is not generally accepted or expected behavior, and even if it were desired, we would want to make sure this was a transactional operation, not a sequential operation that could leave the visit in an inconsistent state.  So the best solution for now is to eliminate this entirely, and create a future ticket to enhance this capability with the ability to close visits as well given appropriate configuration settings.

## Related Issue
https://openmrs.atlassian.net/browse/O3-2949
