### PR TITLE
(fix) Restore top border to active visits pagination container

### DIFF
--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.scss
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.scss
@@ -49,6 +49,10 @@
 
 .pagination {
   overflow: hidden;
+
+  &:global(.cds--pagination) {
+    border-top: 1px solid $ui-03;
+  }
 }
 
 .hiddenRow {

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.scss
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.scss
@@ -49,10 +49,6 @@
 
 .pagination {
   overflow: hidden;
-
-  &:global(.cds--pagination) {
-    border-top: none;
-  }
 }
 
 .hiddenRow {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR restores a top border to the active visits widget's pagination container.

## Screenshots

### Before

![CleanShot 2024-03-12 at 11  01 43@2x](https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/fba7877c-adc1-46d4-b09b-e2971542c31c)

### After

![CleanShot 2024-03-12 at 11  02 13@2x](https://github.com/openmrs/openmrs-esm-patient-management/assets/8509731/51f0724a-299f-498e-8808-43d72de59319)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
