### PR TITLE
(refactor)O3-2466: Service Queue - rename "Add patient with appointment to queue"

### DIFF
--- a/packages/esm-service-queues-app/src/active-visits/active-visits-tab.component.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-tab.component.tsx
@@ -34,7 +34,7 @@ function ActiveVisitsTabs() {
               setShowOverlay(true);
               setView(SearchTypes.SCHEDULED_VISITS);
               setViewState({ selectedPatientUuid });
-              setOverlayTitle(t('addPatientWithAppointmentToQueue', 'Add patient with appointment to queue'));
+              setOverlayTitle(t('addPatientToQueue', 'Add patient to queue'));
             },
           }}
         />

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
@@ -331,7 +331,7 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
                       setShowOverlay(true);
                       setView(SearchTypes.SCHEDULED_VISITS);
                       setViewState({ selectedPatientUuid });
-                      setOverlayTitle(t('addPatientWithAppointmentToQueue', 'Add patient with appointment to queue'));
+                      setOverlayTitle(t('addPatientToQueue', 'Add patient to queue'));
                     },
                   }}
                 />
@@ -507,7 +507,7 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
                     setShowOverlay(true);
                     setView(SearchTypes.SCHEDULED_VISITS);
                     setViewState({ selectedPatientUuid });
-                    setOverlayTitle(t('addPatientWithAppointmentToQueue', 'Add patient with appointment to queue'));
+                    setOverlayTitle(t('addPatientToQueue', 'Add patient to queue'));
                   },
                 }}
               />
@@ -533,7 +533,7 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
                   setShowOverlay(true);
                   setView(SearchTypes.SCHEDULED_VISITS);
                   setViewState({ selectedPatientUuid });
-                  setOverlayTitle(t('addPatientWithAppointmentToQueue', 'Add patient with appointment to queue'));
+                  setOverlayTitle(t('addPatientToQueue', 'Add patient to queue'));
                 },
               }}
             />

--- a/packages/esm-service-queues-app/translations/am.json
+++ b/packages/esm-service-queues-app/translations/am.json
@@ -10,7 +10,6 @@
   "addNewServiceRoom": "Add new service room",
   "addPatientToList": "Add patient to list",
   "addPatientToQueue": "Add patient to queue",
-  "addPatientWithAppointmentToQueue": "Add patient with appointment to queue",
   "addProviderQueueRoom": "Add provider queue room?",
   "addQueue": "Add queue",
   "addQueueName": "Please add a queue name",

--- a/packages/esm-service-queues-app/translations/ar.json
+++ b/packages/esm-service-queues-app/translations/ar.json
@@ -10,7 +10,6 @@
   "addNewServiceRoom": "أضف غرفة خدمة جديدة",
   "addPatientToList": "أضف المريض إلى القائمة",
   "addPatientToQueue": "أضف المريض إلى الطابور",
-  "addPatientWithAppointmentToQueue": "أضف المريض مع موعد إلى الطابور",
   "addProviderQueueRoom": "أضف غرفة طابور المزود؟",
   "addQueue": "أضف طابور",
   "addQueueName": "يرجى إضافة اسم الطابور",

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -10,7 +10,6 @@
   "addNewServiceRoom": "Add new service room",
   "addPatientToList": "Add patient to list",
   "addPatientToQueue": "Add patient to queue",
-  "addPatientWithAppointmentToQueue": "Add patient with appointment to queue",
   "addProviderQueueRoom": "Add provider queue room?",
   "addQueue": "Add queue",
   "addQueueName": "Please add a queue name",

--- a/packages/esm-service-queues-app/translations/es.json
+++ b/packages/esm-service-queues-app/translations/es.json
@@ -10,7 +10,6 @@
   "addNewServiceRoom": "Add new service room",
   "addPatientToList": "Add patient to list",
   "addPatientToQueue": "Add patient to queue",
-  "addPatientWithAppointmentToQueue": "Add patient with appointment to queue",
   "addProviderQueueRoom": "Add provider queue room?",
   "addQueue": "Add queue",
   "addQueueName": "Please add a queue name",

--- a/packages/esm-service-queues-app/translations/fr.json
+++ b/packages/esm-service-queues-app/translations/fr.json
@@ -10,7 +10,6 @@
   "addNewServiceRoom": "Add new service room",
   "addPatientToList": "Add patient to list",
   "addPatientToQueue": "Add patient to queue",
-  "addPatientWithAppointmentToQueue": "Add patient with appointment to queue",
   "addProviderQueueRoom": "Add provider queue room?",
   "addQueue": "Add queue",
   "addQueueName": "Please add a queue name",

--- a/packages/esm-service-queues-app/translations/he.json
+++ b/packages/esm-service-queues-app/translations/he.json
@@ -10,7 +10,6 @@
   "addNewServiceRoom": "הוסף חדר שירות חדש",
   "addPatientToList": "הוסף מטופל לרשימה",
   "addPatientToQueue": "הוסף מטופל לתור",
-  "addPatientWithAppointmentToQueue": "הוסף מטופל עם תור לתור",
   "addProviderQueueRoom": "הוסף חדר תור לספק?",
   "addQueue": "הוסף תור",
   "addQueueName": "אנא הוסף שם תור",

--- a/packages/esm-service-queues-app/translations/km.json
+++ b/packages/esm-service-queues-app/translations/km.json
@@ -10,7 +10,6 @@
   "addNewServiceRoom": "Add new service room",
   "addPatientToList": "បន្ថែមអ្នកជំងឺទៅក្នុងបញ្ជី",
   "addPatientToQueue": "បន្ថែមអ្នកជំងឺទៅក្នុងជួរ",
-  "addPatientWithAppointmentToQueue": "Add patient with appointment to queue",
   "addProviderQueueRoom": "Add provider queue room?",
   "addQueue": "បន្ថែមជួរ ទិន្នន័យ",
   "addQueueName": "Please add a queue name",

--- a/packages/esm-service-queues-app/translations/zh.json
+++ b/packages/esm-service-queues-app/translations/zh.json
@@ -10,7 +10,6 @@
   "addNewServiceRoom": "添加新诊室",
   "addPatientToList": "将患者添加到列表",
   "addPatientToQueue": "将患者加入队列",
-  "addPatientWithAppointmentToQueue": "将预约的患者加入队列",
   "addProviderQueueRoom": "添加提供者候诊室？",
   "addQueue": "添加队列",
   "addQueueName": "请添加一个队列名称",

--- a/packages/esm-service-queues-app/translations/zh_CN.json
+++ b/packages/esm-service-queues-app/translations/zh_CN.json
@@ -10,7 +10,6 @@
   "addNewServiceRoom": "添加新诊室",
   "addPatientToList": "将患者添加到列表",
   "addPatientToQueue": "将患者加入队列",
-  "addPatientWithAppointmentToQueue": "将预约的患者加入队列",
   "addProviderQueueRoom": "添加提供者候诊室？",
   "addQueue": "添加队列",
   "addQueueName": "请添加一个队列名称",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
When navigating to the Service Queues tab on the O3 home page, upon clicking `Add Patient to Queue` and subsequently searching for and selecting a patient, the title previously labeled as `Add patient with appointment to queue` is now changed displayed as "Add Patient to Queue".

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-management/assets/33891016/dd8fe652-1d85-45c6-8492-75ffca7040e6


## Related Issue

https://openmrs.atlassian.net/browse/O3-2466
## Other
<!-- Anything not covered above -->
