### PR TITLE
(fix) O3-2477 Remove kenyaemr-specific defaults from service queues default config …

### DIFF
--- a/packages/esm-service-queues-app/src/config-schema.ts
+++ b/packages/esm-service-queues-app/src/config-schema.ts
@@ -97,7 +97,7 @@ export const configSchema = {
   visitQueueNumberAttributeUuid: {
     _type: Type.UUID,
     _description: 'The UUID of the visit attribute that contains the visit queue number.',
-    _default: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
+    _default: '',
   },
   vitals: vitalsConfigSchema,
   biometrics: biometricsConfigSchema,
@@ -134,7 +134,7 @@ export const configSchema = {
   },
   defaultFacilityUrl: {
     _type: Type.String,
-    _default: `${restBaseUrl}/kenyaemr/default-facility`,
+    _default: '',
     _description: 'Custom URL to load default facility if it is not in the session',
   },
   customPatientChartText: {


### PR DESCRIPTION
…values

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
The configuration schema for service queues contains some default values that are specific to kenya emr.  These should be removed and the application should gracefully handle their absence.

## Related Issue
https://openmrs.atlassian.net/browse/O3-2477
