### PR TITLE
(fix):Filter Queue Entries to return count of those waiting for a ser…

### DIFF
--- a/packages/esm-service-queues-app/src/patient-queue-metrics/queue-metrics.resource.ts
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/queue-metrics.resource.ts
@@ -6,7 +6,7 @@ import { startOfDay } from '../constants';
 
 export function useServiceMetricsCount(service: string, location: string) {
   const status = 'Waiting';
-  const apiUrl = `${restBaseUrl}/queue-entry-metrics?service=${service}&status=${status}&location=${location}`;
+  const apiUrl = `${restBaseUrl}/queue-entry-metrics?service=${service}&status=${status}&location=${location}&isEnded=false`;
 
   const { data } = useSWRImmutable<
     {


### PR DESCRIPTION
…vice

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Essentially the queue metrics count should only return those waiting for a particular service and not those who have finished with a particular service. The counts should also match what is displayed on the table.
## Screenshots
![Screenshot from 2024-03-13 17-18-07](https://github.com/openmrs/openmrs-esm-patient-management/assets/4432218/ac8035f5-f527-416a-906b-f1f845258486)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
