### PR TITLE
(fix) O3-2474 adding a patient to a queue should use active visit

### DIFF
--- a/packages/esm-service-queues-app/src/overlay.scss
+++ b/packages/esm-service-queues-app/src/overlay.scss
@@ -11,8 +11,8 @@
   border-left: 1px solid $text-03;
   background-color: $ui-01;
   overflow-y: auto;
-  height: 100vh;
-  z-index: 99999;
+  height: calc(100vh - 3rem);
+  z-index: 3;
 }
 
 .desktopOverlay::after {

--- a/packages/esm-service-queues-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/patient-search.component.tsx
@@ -6,7 +6,8 @@ import PatientScheduledVisits from './patient-scheduled-visits.component';
 import QueueServiceForm from '../queue-services/queue-service-form.component';
 import QueueRoomForm from '../queue-rooms/queue-room-form.component';
 import VisitForm from './visit-form/visit-form.component';
-import { ExtensionSlot, usePatient } from '@openmrs/esm-framework';
+import { ExtensionSlot, usePatient, useVisit } from '@openmrs/esm-framework';
+import ExistingVisitFormComponent from './visit-form/existing-visit-form.component';
 
 interface PatientSearchProps {
   closePanel: () => void;
@@ -21,6 +22,7 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel, view, viewSta
   const { t } = useTranslation();
   const { selectedPatientUuid } = viewState;
   const { patient } = usePatient(selectedPatientUuid);
+  const { activeVisit } = useVisit(selectedPatientUuid);
   const [searchType, setSearchType] = useState<SearchTypes>(
     view === 'queue_service_form'
       ? SearchTypes.QUEUE_SERVICE_FORM
@@ -49,7 +51,13 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel, view, viewSta
           />
         )}
         <div className="omrs-main-content">
-          {searchType === SearchTypes.SCHEDULED_VISITS ? (
+          {activeVisit ? (
+            <ExistingVisitFormComponent
+              toggleSearchType={toggleSearchType}
+              visit={activeVisit}
+              closePanel={closePanel}
+            />
+          ) : searchType === SearchTypes.SCHEDULED_VISITS ? (
             <PatientScheduledVisits
               patientUuid={selectedPatientUuid}
               toggleSearchType={toggleSearchType}

--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.scss
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.scss
@@ -11,7 +11,7 @@
 }
 
 .section {
-  margin: spacing.$spacing-02 spacing.$spacing-05 0
+  margin: spacing.$spacing-02 spacing.$spacing-05 0;
 }
 
 .sectionHidden {

--- a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.scss
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.scss
@@ -1,5 +1,7 @@
 @use '@carbon/layout';
 @use '@carbon/type';
+@use '@carbon/styles/scss/spacing';
+
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .sectionTitle {
@@ -9,7 +11,7 @@
 }
 
 .section {
-  margin: layout.$spacing-03;
+  margin: spacing.$spacing-02 spacing.$spacing-05 0
 }
 
 .sectionHidden {

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/existing-visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/existing-visit-form.component.tsx
@@ -1,0 +1,119 @@
+import React, { useCallback, useState } from 'react';
+import { Button, ButtonSet, Form, Row, Stack } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
+import {
+  type ConfigObject,
+  ExtensionSlot,
+  showSnackbar,
+  useConfig,
+  useLayoutType,
+  type Visit,
+} from '@openmrs/esm-framework';
+import { addQueueEntry, useVisitQueueEntries } from '../../active-visits/active-visits-table.resource';
+import { type SearchTypes } from '../../types';
+import styles from './visit-form.scss';
+
+interface ExistingVisitFormProps {
+  toggleSearchType: (searchMode: SearchTypes, patientUuid) => void;
+  visit: Visit;
+  closePanel: () => void;
+}
+
+const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, toggleSearchType, closePanel }) => {
+  const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const config = useConfig() as ConfigObject;
+  const visitQueueNumberAttributeUuid = config.visitQueueNumberAttributeUuid;
+  const { mutate } = useVisitQueueEntries('', '');
+
+  if (!visit) {
+    return null;
+  }
+
+  const handleSubmit = useCallback(
+    (event) => {
+      event.preventDefault();
+
+      // retrieve values from queue extension
+      const queueLocation = event?.target['queueLocation']?.value;
+      const serviceUuid = event?.target['service']?.value;
+      const priority = event?.target['priority']?.value;
+      const status = event?.target['status']?.value;
+      const sortWeight = event?.target['sortWeight']?.value;
+
+      setIsSubmitting(true);
+
+      addQueueEntry(
+        visit.uuid,
+        serviceUuid,
+        visit.patient.uuid,
+        priority,
+        status,
+        sortWeight,
+        queueLocation,
+        visitQueueNumberAttributeUuid,
+      ).then(
+        ({ status }) => {
+          if (status === 201) {
+            showSnackbar({
+              kind: 'success',
+              isLowContrast: true,
+              title: t('startAVisit', 'Start a visit'),
+              subtitle: t('queueEntryAddedSuccessfully', 'Queue entry added successfully'),
+            });
+            closePanel();
+            setIsSubmitting(false);
+            mutate();
+          }
+        },
+        (error) => {
+          let subtitle = error?.message;
+          const err = error?.responseBody?.error?.message;
+          if (err && err === '[queue.entry.duplicate.patient]') {
+            subtitle = t('patientAlreadyInQueue', 'Patient is already in the queue');
+          }
+          showSnackbar({
+            title: t('queueEntryError', 'Error adding patient to the queue'),
+            kind: 'error',
+            subtitle,
+          });
+          setIsSubmitting(false);
+        },
+      );
+    },
+    [closePanel, mutate, visit, t, visitQueueNumberAttributeUuid],
+  );
+
+  return (
+    <div>
+      {isTablet && (
+        <Row className={styles.headerGridRow}>
+          <ExtensionSlot
+            name="visit-form-header-slot"
+            className={styles.dataGridRow}
+            state={{ patientUuid: visit.patient.uuid }}
+          />
+        </Row>
+      )}
+      <Stack gap={8} className={styles.container}>
+        <Form className={styles.form} onSubmit={handleSubmit}>
+          <ExtensionSlot name="add-queue-entry-slot" />
+          <section className={styles.buttonSet}>
+            <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
+              <Button className={styles.button} kind="secondary" onClick={closePanel}>
+                {t('discard', 'Discard')}
+              </Button>
+              <Button className={styles.button} disabled={isSubmitting} kind="primary" type="submit">
+                {t('addPatientToQueue', 'Add patient to queue')}
+              </Button>
+            </ButtonSet>
+          </section>
+        </Form>
+      </Stack>
+    </div>
+  );
+};
+
+export default ExistingVisitForm;

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
@@ -342,17 +342,18 @@ const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchTyp
               />
             </section>
           )}
+
+          <ExtensionSlot name="add-queue-entry-slot" />
+          <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
+            <Button className={styles.button} kind="secondary" onClick={closePanel}>
+              {t('discard', 'Discard')}
+            </Button>
+            <Button className={styles.button} disabled={isSubmitting} kind="primary" type="submit">
+              {t('startVisit', 'Start visit')}
+            </Button>
+          </ButtonSet>
         </Stack>
-        <ExtensionSlot name="add-queue-entry-slot" />
       </div>
-      <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
-        <Button className={styles.button} kind="secondary" onClick={closePanel}>
-          {t('discard', 'Discard')}
-        </Button>
-        <Button className={styles.button} disabled={isSubmitting} kind="primary" type="submit">
-          {t('startVisit', 'Start visit')}
-        </Button>
-      </ButtonSet>
     </Form>
   );
 };

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.scss
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.scss
@@ -1,5 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
+@use '@carbon/layout';
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .container {
@@ -55,6 +56,7 @@
   align-content: flex-start;
   align-items: baseline;
   min-width: 50%;
+  margin-top: layout.$spacing-05;
 }
 
 .tablet {

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -147,6 +147,7 @@
   "orderIndefiniteDuration": "Indefinite duration",
   "orInProperFormat": "Or",
   "orPatientName": "OR the patient's name(s)",
+  "patientAlreadyInQueue": "Patient is already in the queue",
   "patientAttendingService": "Patient attending service",
   "patientHasActiveVisit": "The patient already has an active visit",
   "patientList": "Patient list",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

When using the service queues app, there is an option to "Add patient to queue", however the form this enables will always attempt to first start a visit before adding a new queue entry associated with that visit.  This fails to correctly handle two scenarios:
1. If the patient selected already has a currently active visit, then the user should not be prompted to complete a start visit form that includes queue fields, but should just be prompted to fill out a form with queue fields, and this should be associated with the already active visit.
2. If the patient selected is already active on the queue, then there needs to be improved validation letting the user know that the patient cannot be added because they are already on the queue

## Screenshots
![adding-to-queue-existing-visit](https://github.com/openmrs/openmrs-esm-patient-management/assets/356297/e1dd2475-7d94-4f0a-bd90-224be85756b2)

## Related Issue
https://openmrs.atlassian.net/browse/O3-2474
https://openmrs.atlassian.net/browse/O3-2624
