### PR TITLE
'(fix)O3-2473': Visit Type selector fails and is not needed

### DIFF
--- a/packages/esm-service-queues-app/src/patient-search/visit-form/base-visit-type.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/base-visit-type.component.tsx
@@ -12,9 +12,10 @@ interface BaseVisitTypeProps {
   onChange: (event) => void;
   patientUuid: string;
   visitTypes: Array<VisitType>;
+  enableSearch?: boolean;
 }
 
-const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) => {
+const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes, enableSearch = false }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -39,7 +40,7 @@ const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) =
         [styles.tablet]: isTablet,
         [styles.desktop]: !isTablet,
       })}>
-      {results.length ? (
+      {enableSearch && (
         <>
           {isTablet ? (
             <Layer>
@@ -56,19 +57,21 @@ const BaseVisitType: React.FC<BaseVisitTypeProps> = ({ onChange, visitTypes }) =
               labelText=""
             />
           )}
-
-          <RadioButtonGroup
-            className={styles.radioButtonGroup}
-            defaultSelected={defaultVisitType}
-            orientation="vertical"
-            onChange={onChange}
-            name="radio-button-group"
-            valueSelected={results?.length >= 1 && results[0].uuid}>
-            {results.map(({ uuid, display, name }) => (
-              <RadioButton key={uuid} className={styles.radioButton} id={name} labelText={display} value={uuid} />
-            ))}
-          </RadioButtonGroup>
         </>
+      )}
+
+      {results.length ? (
+        <RadioButtonGroup
+          className={styles.radioButtonGroup}
+          defaultSelected={defaultVisitType}
+          orientation="vertical"
+          onChange={onChange}
+          name="radio-button-group"
+          valueSelected={results?.length >= 1 && results[0].uuid}>
+          {results.map(({ uuid, display, name }) => (
+            <RadioButton key={uuid} className={styles.radioButton} id={name} labelText={display} value={uuid} />
+          ))}
+        </RadioButtonGroup>
       ) : (
         <Layer>
           <Tile className={styles.tile}>

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/base-visit-type.test.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/base-visit-type.test.tsx
@@ -11,7 +11,14 @@ jest.mock('@openmrs/esm-framework', () => ({
 
 describe('BaseVisitType', () => {
   it('renders visit types correctly', () => {
-    render(<BaseVisitType patientUuid={mockPatient.uuid} onChange={() => {}} visitTypes={mockVisitTypes} />);
+    render(
+      <BaseVisitType
+        patientUuid={mockPatient.uuid}
+        onChange={() => {}}
+        visitTypes={mockVisitTypes}
+        enableSearch={true}
+      />,
+    );
 
     const searchInput = screen.getByRole('searchbox');
     expect(searchInput).toBeInTheDocument();
@@ -25,7 +32,14 @@ describe('BaseVisitType', () => {
   it('handles search input correctly', async () => {
     const user = userEvent.setup();
 
-    render(<BaseVisitType patientUuid={mockPatient.uuid} onChange={() => {}} visitTypes={mockVisitTypes} />);
+    render(
+      <BaseVisitType
+        patientUuid={mockPatient.uuid}
+        onChange={() => {}}
+        visitTypes={mockVisitTypes}
+        enableSearch={true}
+      />,
+    );
 
     const searchInput: HTMLInputElement = screen.getByRole('searchbox');
     await user.type(searchInput, 'Visit Type 1');
@@ -37,7 +51,14 @@ describe('BaseVisitType', () => {
     const user = userEvent.setup();
 
     const mockOnChange = jest.fn();
-    render(<BaseVisitType patientUuid={mockPatient.uuid} onChange={mockOnChange} visitTypes={mockVisitTypes} />);
+    render(
+      <BaseVisitType
+        patientUuid={mockPatient.uuid}
+        onChange={() => {}}
+        visitTypes={mockVisitTypes}
+        enableSearch={true}
+      />,
+    );
 
     const radioButton: HTMLInputElement = screen.getByLabelText(mockVisitTypes[0].display);
     await user.click(radioButton);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
I modify the code to remove the search by default and allow it to be toggled back on with a configuration property by following these steps:

1. Added a new prop enableSearch to control the visibility of the search functionality.
2. Updated the component's logic to conditionally render the search based on the value of enableSearch.
3. Provided a default value for enableSearch as false.
4. Allowed the search to be toggled back on by setting enableSearch to true via a configuration property.
By doing these, when you use <BaseVisitType />, by default, the search functionality will be disabled and If you want to enable it, you can set enableSearch to true.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-management/assets/33891016/78080333-4f2e-43b4-ade6-21a033296eba




## Related Issue
https://openmrs.atlassian.net/browse/O3-2473

## Other
<!-- Anything not covered above -->
