### PR TITLE
(fix) service queues - make edit queue entry modal body scrollable if…

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.component.tsx
@@ -136,122 +136,120 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({ qu
   const selectedPriorityIndex = priorities.findIndex((p) => p.uuid == formState.selectedPriority);
 
   return (
-    <div>
-      <Form onSubmit={submitForm}>
-        <ModalHeader closeModal={closeModal} title={modalTitle} />
-        <ModalBody>
-          <div className={styles.modalBody}>
-            <Stack gap={4}>
-              <h5>{queueEntry.display}</h5>
-              <p>{modalInstruction}</p>
-              <section className={styles.section}>
-                <div className={styles.sectionTitle}>{t('serviceQueue', 'Service queue')}</div>
-                <Select
-                  labelText={t('selectQueue', 'Select a queue')}
-                  id="queue"
-                  invalidText="Required"
-                  value={formState.selectedQueue}
-                  onChange={(event) => setSelectedQueueUuid(event.target.value)}>
-                  {queues?.map(({ uuid, display }) => (
-                    <SelectItem
+    <>
+      <ModalHeader closeModal={closeModal} title={modalTitle} />
+      <ModalBody>
+        <div className={styles.queueEntryActionModalBody}>
+          <Stack gap={4}>
+            <h5>{queueEntry.display}</h5>
+            <p>{modalInstruction}</p>
+            <section className={styles.section}>
+              <div className={styles.sectionTitle}>{t('serviceQueue', 'Service queue')}</div>
+              <Select
+                labelText={t('selectQueue', 'Select a queue')}
+                id="queue"
+                invalidText="Required"
+                value={formState.selectedQueue}
+                onChange={(event) => setSelectedQueueUuid(event.target.value)}>
+                {queues?.map(({ uuid, display }) => (
+                  <SelectItem
+                    key={uuid}
+                    text={
+                      uuid == queueEntry.queue.uuid
+                        ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
+                        : display
+                    }
+                    value={uuid}
+                  />
+                ))}
+              </Select>
+            </section>
+
+            <section>
+              <div className={styles.sectionTitle}>{t('queueStatus', 'Queue status')}</div>
+              {hasNoStatusesConfigured ? (
+                <InlineNotification
+                  kind={'error'}
+                  lowContrast
+                  subtitle={t('configureStatus', 'Please configure status to continue.')}
+                  title={t('noStatusConfigured', 'No status configured')}
+                />
+              ) : (
+                <RadioButtonGroup
+                  name="status"
+                  valueSelected={formState.selectedStatus}
+                  onChange={(uuid) => {
+                    setSelectedStatusUuid(uuid);
+                  }}>
+                  {statuses?.map(({ uuid, display }) => (
+                    <RadioButton
                       key={uuid}
-                      text={
-                        uuid == queueEntry.queue.uuid
+                      name={display}
+                      labelText={
+                        uuid == queueEntry.status.uuid
                           ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
                           : display
                       }
                       value={uuid}
                     />
                   ))}
-                </Select>
-              </section>
+                </RadioButtonGroup>
+              )}
+            </section>
 
-              <section>
-                <div className={styles.sectionTitle}>{t('queueStatus', 'Queue status')}</div>
-                {hasNoStatusesConfigured ? (
-                  <InlineNotification
-                    kind={'error'}
-                    lowContrast
-                    subtitle={t('configureStatus', 'Please configure status to continue.')}
-                    title={t('noStatusConfigured', 'No status configured')}
-                  />
-                ) : (
-                  <RadioButtonGroup
-                    name="status"
-                    valueSelected={formState.selectedStatus}
-                    onChange={(uuid) => {
-                      setSelectedStatusUuid(uuid);
-                    }}>
-                    {statuses?.map(({ uuid, display }) => (
-                      <RadioButton
-                        key={uuid}
-                        name={display}
-                        labelText={
-                          uuid == queueEntry.status.uuid
-                            ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
-                            : display
-                        }
-                        value={uuid}
-                      />
-                    ))}
-                  </RadioButtonGroup>
-                )}
-              </section>
-
-              <section className={styles.section}>
-                <div className={styles.sectionTitle}>{t('queuePriority', 'Queue priority')}</div>
-                {hasNoPrioritiesConfigured ? (
-                  <InlineNotification
-                    className={styles.inlineNotification}
-                    kind={'error'}
-                    lowContrast
-                    subtitle={t('configurePriorities', 'Please configure priorities to continue.')}
-                    title={t('noPrioritiesConfigured', 'No priorities configured')}
-                  />
-                ) : (
-                  <ContentSwitcher
-                    size="sm"
-                    selectedIndex={selectedPriorityIndex}
-                    onChange={(event) => {
-                      setSelectedPriorityUuid(event.name as string);
-                    }}>
-                    {priorities?.map(({ uuid, display }) => (
-                      <Switch
-                        role="radio"
-                        name={uuid}
-                        text={
-                          uuid == queueEntry.priority.uuid
-                            ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
-                            : display
-                        }
-                        key={uuid}
-                        value={uuid}
-                      />
-                    ))}
-                  </ContentSwitcher>
-                )}
-              </section>
-              <section className={styles.section}>
-                <div className={styles.sectionTitle}>{t('priorityComment', 'Priority comment')}</div>
-                <TextArea
-                  value={formState.prioritycomment}
-                  onChange={(e) => setPriorityComment(e.target.value)}
-                  placeholder={t('enterCommentHere', 'Enter comment here')}
+            <section className={styles.section}>
+              <div className={styles.sectionTitle}>{t('queuePriority', 'Queue priority')}</div>
+              {hasNoPrioritiesConfigured ? (
+                <InlineNotification
+                  className={styles.inlineNotification}
+                  kind={'error'}
+                  lowContrast
+                  subtitle={t('configurePriorities', 'Please configure priorities to continue.')}
+                  title={t('noPrioritiesConfigured', 'No priorities configured')}
                 />
-              </section>
-            </Stack>
-          </div>
-        </ModalBody>
-        <ModalFooter>
-          <Button kind="secondary" onClick={closeModal}>
-            {t('cancel', 'Cancel')}
-          </Button>
-          <Button disabled={isSubmitting || disableSubmit(queueEntry, formState)} type="submit">
-            {submitButtonText}
-          </Button>
-        </ModalFooter>
-      </Form>
-    </div>
+              ) : (
+                <ContentSwitcher
+                  size="sm"
+                  selectedIndex={selectedPriorityIndex}
+                  onChange={(event) => {
+                    setSelectedPriorityUuid(event.name as string);
+                  }}>
+                  {priorities?.map(({ uuid, display }) => (
+                    <Switch
+                      role="radio"
+                      name={uuid}
+                      text={
+                        uuid == queueEntry.priority.uuid
+                          ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
+                          : display
+                      }
+                      key={uuid}
+                      value={uuid}
+                    />
+                  ))}
+                </ContentSwitcher>
+              )}
+            </section>
+            <section className={styles.section}>
+              <div className={styles.sectionTitle}>{t('priorityComment', 'Priority comment')}</div>
+              <TextArea
+                value={formState.prioritycomment}
+                onChange={(e) => setPriorityComment(e.target.value)}
+                placeholder={t('enterCommentHere', 'Enter comment here')}
+              />
+            </section>
+          </Stack>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={closeModal}>
+          {t('cancel', 'Cancel')}
+        </Button>
+        <Button disabled={isSubmitting || disableSubmit(queueEntry, formState)} onClick={submitForm}>
+          {submitButtonText}
+        </Button>
+      </ModalFooter>
+    </>
   );
 };
 

--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actons-modal.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actons-modal.scss
@@ -27,6 +27,14 @@ section {
   margin-bottom: spacing.$spacing-04;
 }
 
-.modalBody {
+.queueEntryActionModalBody {
   padding-bottom: spacing.$spacing-05;
+}
+
+// This is a hack to get the modal to scroll
+// vertically. Ideally, this should have be fixed by having
+// the extension slot in showModal not warp its content
+// in a div
+:global(.cds--modal-container):has(.queueEntryActionModalBody) {
+  overflow: auto;
 }


### PR DESCRIPTION
… content is too long

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

Minor CSS fix for when the viewport height is too small for the queue entry modal to render its buttons.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/eed1ca12-3bb9-4e2a-b307-415f9c8a2126)

After: (Note the scrollbar)
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/f90ad308-764f-4658-ae3e-4d005bde023d)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
This fix really isn't ideal. I believe it's a bug in the `showModal` function from styleguide, as it wraps the `<ModalHeader>` and `<ModalBody>` within a div. Removing that div wrapper fixes it, but it's difficult to make breaking changes in styleguide.