### PR TITLE
(fix) service queues - unescape queue name when passed into t()

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.component.tsx
@@ -156,7 +156,10 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({ qu
                     key={uuid}
                     text={
                       uuid == queueEntry.queue.uuid
-                        ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
+                        ? t('currentValueFormatted', '{{value}} (Current)', {
+                            value: display,
+                            interpolation: { escapeValue: false },
+                          })
                         : display
                     }
                     value={uuid}
@@ -187,7 +190,10 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({ qu
                       name={display}
                       labelText={
                         uuid == queueEntry.status.uuid
-                          ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
+                          ? t('currentValueFormatted', '{{value}} (Current)', {
+                              value: display,
+                              interpolation: { escapeValue: false },
+                            })
                           : display
                       }
                       value={uuid}
@@ -220,7 +226,10 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({ qu
                       name={uuid}
                       text={
                         uuid == queueEntry.priority.uuid
-                          ? t('currentValueFormatted', '{{value}} (Current)', { value: display })
+                          ? t('currentValueFormatted', '{{value}} (Current)', {
+                              value: display,
+                              interpolation: { escapeValue: false },
+                            })
                           : display
                       }
                       key={uuid}

--- a/react-i18next.js
+++ b/react-i18next.js
@@ -33,7 +33,9 @@ const useMock = [(k) => k, {}];
 useMock.t = (key, defaultValue, options = {}) => {
   let translatedString = defaultValue;
   Object.keys(options).forEach((key) => {
-    translatedString = defaultValue.replace(`{{${key}}}`, `${options[key]}`);
+    if (key != 'interpolation') {
+      translatedString = defaultValue.replace(`{{${key}}}`, `${options[key]}`);
+    }
   });
 
   return translatedString ?? key;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
minor fix to tell the `t()` function not to escape the queue name we pass in. Prior to the fix, `/` character in the queue name got incorrectly HTML-escaped 

I verified that this isn't a data /escaping issue elsewhere by seeing in the debugger that the `display` value of the queue is correctly set to "Pre-Op/PACU" prior to being passed to the `t()` function.

## Screenshots
<!-- Required if you are making UI changes. -->
before:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/49aaf8d6-6d37-4783-9a4b-4c5baa0dadcd)

after:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/57de117a-a71d-4af0-ab91-504e2d314fb4)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
