### PR TITLE
(fix) O3-2471 recommended visit type tab should only show if configur…

### DIFF
--- a/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
@@ -302,14 +302,16 @@ const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchTyp
           )}
           <section>
             <div className={styles.sectionTitle}>{t('visitType', 'Visit Type')}</div>
-            <ContentSwitcher
-              selectedIndex={contentSwitcherIndex}
-              className={styles.contentSwitcher}
-              onChange={({ index }) => setContentSwitcherIndex(index)}>
-              <Switch name="recommended" text={t('recommended', 'Recommended')} />
-              <Switch name="all" text={t('all', 'All')} />
-            </ContentSwitcher>
-            {contentSwitcherIndex === 0 && !isLoading && (
+            {config.showRecommendedVisitTypeTab && (
+              <ContentSwitcher
+                selectedIndex={contentSwitcherIndex}
+                className={styles.contentSwitcher}
+                onChange={({ index }) => setContentSwitcherIndex(index)}>
+                <Switch name="recommended" text={t('recommended', 'Recommended')} />
+                <Switch name="all" text={t('all', 'All')} />
+              </ContentSwitcher>
+            )}
+            {config.showRecommendedVisitTypeTab && contentSwitcherIndex === 0 && !isLoading && (
               <MemoizedRecommendedVisitType
                 onChange={(visitType) => {
                   setVisitType(visitType);
@@ -320,7 +322,7 @@ const StartVisitForm: React.FC<VisitFormProps> = ({ patientUuid, toggleSearchTyp
                 locationUuid={selectedLocation}
               />
             )}
-            {contentSwitcherIndex === 1 && (
+            {(!config.showRecommendedVisitTypeTab || contentSwitcherIndex === 1) && (
               <BaseVisitType
                 onChange={(visitType) => {
                   setVisitType(visitType);


### PR DESCRIPTION
…ed to do so

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
Displays the content switcher that displays recommended visit types if the existing config.showRecommendedVisitTypeTab configuration property is toggled to true, does not show this otherwise.

## Related Issue
https://openmrs.atlassian.net/browse/O3-2471

