### PR TITLE
(fix) add `@openmrs/esm-patient-common-lib` as peer dependency and register appointment workspace correctly.

### DIFF
--- a/packages/esm-appointments-app/package.json
+++ b/packages/esm-appointments-app/package.json
@@ -44,6 +44,7 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
+    "@openmrs/esm-patient-common-lib": "7.x",
     "react": "18.x",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/packages/esm-appointments-app/src/index.ts
+++ b/packages/esm-appointments-app/src/index.ts
@@ -51,12 +51,6 @@ export function startupApp() {
   defineExtensionConfigSchema('cancelled-appointments-panel', cancelledAppointmentsPanelConfigSchema);
   defineExtensionConfigSchema('early-appointments-panel', earlyAppointmentsPanelConfigSchema);
 
-  registerWorkspace({
-    name: 'appointments-form-workspace',
-    load: getAsyncLifecycle(() => import('./form/appointments-form.component'), options),
-    title: translateFrom(moduleName, 'createNewAppointment', 'Create new appointment'),
-  });
-
   registerBreadcrumbs([
     {
       title: 'Appointments',
@@ -109,3 +103,9 @@ export const patientAppointmentsCancelConfirmationDialog = getAsyncLifecycle(
   () => import('./patient-chart/patient-appointments-cancel-modal.component'),
   options,
 );
+
+registerWorkspace({
+  name: 'appointments-form-workspace',
+  load: getAsyncLifecycle(() => import('./form/appointments-form.component'), options),
+  title: translateFrom(moduleName, 'createNewAppointment', 'Create new appointment'),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2918,6 +2918,7 @@ __metadata:
     yup: "npm:^0.32.11"
   peerDependencies:
     "@openmrs/esm-framework": 5.x
+    "@openmrs/esm-patient-common-lib": 7.x
     react: 18.x
     react-i18next: 11.x
     react-router-dom: 6.x


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR moves `registerWorkspace` call outside of `startupApp` function. In addition to this I have added `@openmrs/esm-patient-common-lib` as a peer dependency. This is to fix an error when trying to launch `appointment-form-workspace` from the form-engine. cc @brandones @denniskigen @ibacher  referencing [o3 docs](https://o3-docs.openmrs.org/docs/workspaces/creating-workspaces.en-US#registering-a-workspace) should the registration for workspace happen inside `startupApp` function?

## Error
<img width="1451" alt="Screenshot 2024-03-20 at 18 34 51" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/2aa0c26c-823a-473b-b0d0-757aa5d6c119">

### form schema used
```json
{
  "questions": [
    {
      "label": "Appointments",
      "required": false,
      "id": "labsWorkspaceLauncher",
      "questionOptions": {
        "rendering": "workspace-launcher",
        "buttonLabel": "Schedule appointments",
        "workspaceName": "appointments-form-workspace"
      }
    }
  ]
}
```
## Screenshots
## Fix
https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/a1b5a5f4-57c4-4d36-a367-d31e26a75afb


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
