### PR TITLE
(feat) use configured identifier type on appointment table

### DIFF
--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
@@ -58,7 +58,7 @@ const AppointmentsTable: React.FC<AppointmentsTableProps> = ({
   const [searchString, setSearchString] = useState('');
   const searchResults = useSearchResults(appointments, searchString);
   const { results, goTo, currentPage } = usePagination(searchResults, pageSize);
-  const { customPatientChartUrl } = useConfig<ConfigObject>();
+  const { customPatientChartUrl, patientIdentifierType } = useConfig<ConfigObject>();
 
   const headerData = [
     {
@@ -91,7 +91,9 @@ const AppointmentsTable: React.FC<AppointmentsTableProps> = ({
       </ConfigurableLink>
     ),
     nextAppointmentDate: '--',
-    identifier: appointment.patient.identifier,
+    identifier: patientIdentifierType
+      ? appointment.patient[patientIdentifierType.replaceAll(' ', '')] ?? appointment.patient.identifier
+      : appointment.patient.identifier,
     dateTime: formatDatetime(new Date(appointment.startDateTime)),
     serviceType: appointment.service.name,
     provider: appointment.provider,

--- a/packages/esm-appointments-app/src/config-schema.ts
+++ b/packages/esm-appointments-app/src/config-schema.ts
@@ -77,7 +77,7 @@ export const configSchema = {
   patientIdentifierType: {
     _type: Type.String,
     _description: 'The name of the patient identifier type to be used for the patient identifier field',
-    _default: 'OpenMRS ID',
+    _default: '',
   },
   showUnscheduledAppointmentsTab: {
     _type: Type.Boolean,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
       "es2015.promise",
       "es2016.array.include",
       "es2018",
-      "es2020"
+      "es2020",
+      "es2021"
     ],
     "resolveJsonModule": true,
     "noEmit": true,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds ability to display the configured identifier type on appointments table. In the event identifier isn't configured. It defaults back to OpenMRS identifier. This is because identifier as returned by appointments endpoint is a property of patient object as shown below.


<img width="1596" alt="Screenshot 2024-03-20 at 19 13 03" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/5c066b75-b5c3-4970-aef7-38ca239cabba">

cc @mogoodrich @mseaton 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
