### PR TITLE
(chore) O3-2989 service queues - refactor <PatientSearch> to not have…

### DIFF
--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -97,7 +97,6 @@
   "medications": "Medications",
   "missed": "Missed",
   "missingVisitType": "Missing visit type",
-  "monthly": "Monthly",
   "name": "Name",
   "no": "No",
   "noAppointmentsScheduledForTodayToDisplay": "There are no appointments scheduled for today to display for this location",
@@ -168,6 +167,5 @@
   "visitType": "Visit Type",
   "vitals": "Vitals",
   "week": "Week",
-  "weekly": "Weekly",
   "yes": "Yes"
 }

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-tab.component.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-tab.component.tsx
@@ -12,10 +12,8 @@ import styles from './active-visits-table.scss';
 function ActiveVisitsTabs() {
   const { t } = useTranslation();
   const [showOverlay, setShowOverlay] = useState(false);
-  const [view, setView] = useState('');
   const [viewState, setViewState] = useState<{ selectedPatientUuid: string }>(null);
   const [selectedTab, setSelectedTab] = useState(0);
-  const [overlayHeader, setOverlayTitle] = useState('');
 
   return (
     <div className={styles.container} data-testid="active-visits-tabs">
@@ -32,9 +30,7 @@ function ActiveVisitsTabs() {
             },
             selectPatientAction: (selectedPatientUuid) => {
               setShowOverlay(true);
-              setView(SearchTypes.SCHEDULED_VISITS);
               setViewState({ selectedPatientUuid });
-              setOverlayTitle(t('addPatientToQueue', 'Add patient to queue'));
             },
           }}
         />
@@ -56,14 +52,7 @@ function ActiveVisitsTabs() {
           </TabPanel>
         </TabPanels>
       </Tabs>
-      {showOverlay && (
-        <PatientSearch
-          view={view}
-          closePanel={() => setShowOverlay(false)}
-          viewState={viewState}
-          headerTitle={overlayHeader}
-        />
-      )}
+      {showOverlay && <PatientSearch closePanel={() => setShowOverlay(false)} viewState={viewState} />}
     </div>
   );
 }

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
@@ -160,7 +160,6 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
 
   const currentServiceUuid = useSelectedServiceUuid();
   const [showOverlay, setShowOverlay] = useState(false);
-  const [view, setView] = useState('');
   const [viewState, setViewState] = useState<{ selectedPatientUuid: string }>(null);
   const layout = useLayoutType();
   const { showQueueTableTab: useQueueTableTabs, customPatientChartUrl } = useConfig<ConfigObject>();
@@ -176,7 +175,6 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
   const isPermanentProviderQueueRoom = useIsPermanentProviderQueueRoom();
   const pageSizes = [10, 20, 30, 40, 50];
   const [currentPageSize, setPageSize] = useState(10);
-  const [overlayHeader, setOverlayTitle] = useState('');
   const [providerRoomModalShown, setProviderRoomModalShown] = useState(false);
 
   const {
@@ -329,9 +327,7 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
                     },
                     selectPatientAction: (selectedPatientUuid) => {
                       setShowOverlay(true);
-                      setView(SearchTypes.SCHEDULED_VISITS);
                       setViewState({ selectedPatientUuid });
-                      setOverlayTitle(t('addPatientToQueue', 'Add patient to queue'));
                     },
                   }}
                 />
@@ -470,16 +466,7 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
             </TableContainer>
           )}
         </DataTable>
-        {showOverlay && (
-          <PatientSearch
-            view={view}
-            closePanel={() => setShowOverlay(false)}
-            viewState={{
-              selectedPatientUuid: viewState.selectedPatientUuid,
-            }}
-            headerTitle={overlayHeader}
-          />
-        )}
+        {showOverlay && <PatientSearch closePanel={() => setShowOverlay(false)} viewState={viewState} />}
       </div>
     );
   }
@@ -505,9 +492,7 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
                   },
                   selectPatientAction: (selectedPatientUuid) => {
                     setShowOverlay(true);
-                    setView(SearchTypes.SCHEDULED_VISITS);
                     setViewState({ selectedPatientUuid });
-                    setOverlayTitle(t('addPatientToQueue', 'Add patient to queue'));
                   },
                 }}
               />
@@ -531,23 +516,14 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
                 },
                 selectPatientAction: (selectedPatientUuid) => {
                   setShowOverlay(true);
-                  setView(SearchTypes.SCHEDULED_VISITS);
                   setViewState({ selectedPatientUuid });
-                  setOverlayTitle(t('addPatientToQueue', 'Add patient to queue'));
                 },
               }}
             />
           </div>
         </Tile>
       </div>
-      {showOverlay && (
-        <PatientSearch
-          view={view}
-          closePanel={() => setShowOverlay(false)}
-          viewState={viewState}
-          headerTitle={overlayHeader}
-        />
-      )}
+      {showOverlay && <PatientSearch closePanel={() => setShowOverlay(false)} viewState={viewState} />}
     </div>
   );
 }

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/metrics-header.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/metrics-header.component.tsx
@@ -5,9 +5,10 @@ import { MessageQueue, ArrowRight } from '@carbon/react/icons';
 import { Button, ComboButton, MenuItem } from '@carbon/react';
 import { navigate, UserHasAccess, useLayoutType } from '@openmrs/esm-framework';
 import { spaBasePath } from '../constants';
-import { SearchTypes } from '../types';
-import PatientSearch from '../patient-search/patient-search.component';
 import styles from './metrics-header.scss';
+import Overlay from '../overlay.component';
+import QueueRoomForm from '../queue-rooms/queue-room-form.component';
+import QueueServiceForm from '../queue-services/queue-service-form.component';
 
 const MetricsHeader = () => {
   const { t } = useTranslation();
@@ -15,13 +16,15 @@ const MetricsHeader = () => {
   const isPhone = useLayoutType() == 'phone';
   const metricsTitle = t('clinicMetrics', 'Clinic metrics');
   const queueScreenText = t('queueScreen', 'Queue screen');
-  const [showOverlay, setShowOverlay] = useState(false);
-  const [view, setView] = useState('');
-  const [viewState, setViewState] = useState<{ selectedPatientUuid: string }>(null);
-  const [overlayHeader, setOverlayTitle] = useState('');
+  const [showQueueServiceFormOverlay, setShowQueueServiceFormOverlay] = useState(false);
+  const [showQueueRoomFormOverlay, setShowQueueRoomFormOverlay] = useState(false);
 
   const navigateToQueueScreen = () => {
     navigate({ to: `${spaBasePath}/service-queues/screen` });
+  };
+  const closeOverlays = () => {
+    setShowQueueServiceFormOverlay(false);
+    setShowQueueRoomFormOverlay(false);
   };
   if (isTablet || isPhone) {
     return (
@@ -31,33 +34,25 @@ const MetricsHeader = () => {
           <ComboButton label={t('actions', 'Actions')} menuAlignment="bottom-end" className={styles.comboBtn}>
             <MenuItem
               label={t('addNewService', 'Add new service')}
-              onClick={(selectedPatientUuid) => {
-                setShowOverlay(true);
-                setView(SearchTypes.QUEUE_SERVICE_FORM);
-                setViewState({ selectedPatientUuid });
-                setOverlayTitle(t('addNewQueueService', 'Add new queue service'));
-              }}
+              onClick={() => setShowQueueServiceFormOverlay(true)}
             />
 
             <MenuItem
               label={t('addNewServiceRoom', 'Add new service room')}
-              onClick={(selectedPatientUuid) => {
-                setShowOverlay(true);
-                setView(SearchTypes.QUEUE_ROOM_FORM);
-                setViewState({ selectedPatientUuid });
-                setOverlayTitle(t('addNewQueueServiceRoom', 'Add new queue service room'));
-              }}
+              onClick={() => setShowQueueRoomFormOverlay(true)}
             />
             <MenuItem label={queueScreenText} onClick={navigateToQueueScreen} />
           </ComboButton>
         </UserHasAccess>
-        {showOverlay && (
-          <PatientSearch
-            view={view}
-            closePanel={() => setShowOverlay(false)}
-            viewState={viewState}
-            headerTitle={overlayHeader}
-          />
+        {showQueueServiceFormOverlay && (
+          <Overlay header={t('addNewQueueService', 'Add new queue service')} closePanel={closeOverlays}>
+            <QueueServiceForm closePanel={closeOverlays} />
+          </Overlay>
+        )}
+        {showQueueRoomFormOverlay && (
+          <Overlay header={t('addNewQueueServiceRoom', 'Add new queue service room')} closePanel={closeOverlays}>
+            <QueueRoomForm closePanel={closeOverlays} />
+          </Overlay>
         )}
       </div>
     );
@@ -70,24 +65,14 @@ const MetricsHeader = () => {
           <Button
             kind="tertiary"
             renderIcon={(props) => <ArrowRight size={16} {...props} />}
-            onClick={(selectedPatientUuid) => {
-              setShowOverlay(true);
-              setView(SearchTypes.QUEUE_SERVICE_FORM);
-              setViewState({ selectedPatientUuid });
-              setOverlayTitle(t('addNewQueueService', 'Add new queue service'));
-            }}
+            onClick={() => setShowQueueServiceFormOverlay(true)}
             iconDescription={t('addNewQueueService', 'Add new queue service')}>
             {t('addNewService', 'Add new service')}
           </Button>
           <Button
             kind="tertiary"
             renderIcon={(props) => <ArrowRight size={16} {...props} />}
-            onClick={(selectedPatientUuid) => {
-              setShowOverlay(true);
-              setView(SearchTypes.QUEUE_ROOM_FORM);
-              setViewState({ selectedPatientUuid });
-              setOverlayTitle(t('addNewQueueServiceRoom', 'Add new queue service room'));
-            }}
+            onClick={() => setShowQueueRoomFormOverlay(true)}
             iconDescription={t('addNewQueueServiceRoom', 'Add new queue service room')}>
             {t('addNewServiceRoom', 'Add new service room')}
           </Button>
@@ -100,13 +85,15 @@ const MetricsHeader = () => {
           {queueScreenText}
         </Button>
       </div>
-      {showOverlay && (
-        <PatientSearch
-          view={view}
-          closePanel={() => setShowOverlay(false)}
-          viewState={viewState}
-          headerTitle={overlayHeader}
-        />
+      {showQueueServiceFormOverlay && (
+        <Overlay header={t('addNewQueueService', 'Add new queue service')} closePanel={closeOverlays}>
+          <QueueServiceForm closePanel={closeOverlays} />
+        </Overlay>
+      )}
+      {showQueueRoomFormOverlay && (
+        <Overlay header={t('addNewQueueServiceRoom', 'Add new queue service room')} closePanel={closeOverlays}>
+          <QueueRoomForm closePanel={closeOverlays} />
+        </Overlay>
       )}
     </div>
   );

--- a/packages/esm-service-queues-app/src/patient-search/patient-search.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/patient-search.component.tsx
@@ -11,25 +11,17 @@ import ExistingVisitFormComponent from './visit-form/existing-visit-form.compone
 
 interface PatientSearchProps {
   closePanel: () => void;
-  view?: string;
   viewState: {
     selectedPatientUuid?: string;
   };
-  headerTitle?: string;
 }
 
-const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel, view, viewState, headerTitle }) => {
+const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel, viewState }) => {
   const { t } = useTranslation();
   const { selectedPatientUuid } = viewState;
   const { patient } = usePatient(selectedPatientUuid);
   const { activeVisit } = useVisit(selectedPatientUuid);
-  const [searchType, setSearchType] = useState<SearchTypes>(
-    view === 'queue_service_form'
-      ? SearchTypes.QUEUE_SERVICE_FORM
-      : view === 'queue_room_form'
-        ? SearchTypes.QUEUE_ROOM_FORM
-        : SearchTypes.SCHEDULED_VISITS,
-  );
+  const [searchType, setSearchType] = useState<SearchTypes>(SearchTypes.SCHEDULED_VISITS);
   const [newVisitMode, setNewVisitMode] = useState<boolean>(false);
 
   const toggleSearchType = (searchType: SearchTypes, mode: boolean = false) => {
@@ -39,7 +31,7 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel, view, viewSta
 
   return (
     <>
-      <Overlay header={headerTitle} closePanel={closePanel}>
+      <Overlay header={t('addPatientToQueue', 'Add patient to queue')} closePanel={closePanel}>
         {patient && (
           <ExtensionSlot
             name="patient-header-slot"
@@ -52,11 +44,7 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel, view, viewSta
         )}
         <div className="omrs-main-content">
           {activeVisit ? (
-            <ExistingVisitFormComponent
-              toggleSearchType={toggleSearchType}
-              visit={activeVisit}
-              closePanel={closePanel}
-            />
+            <ExistingVisitFormComponent visit={activeVisit} closePanel={closePanel} />
           ) : searchType === SearchTypes.SCHEDULED_VISITS ? (
             <PatientScheduledVisits
               patientUuid={selectedPatientUuid}
@@ -70,10 +58,6 @@ const PatientSearch: React.FC<PatientSearchProps> = ({ closePanel, view, viewSta
               closePanel={closePanel}
               mode={newVisitMode}
             />
-          ) : searchType === SearchTypes.QUEUE_SERVICE_FORM ? (
-            <QueueServiceForm toggleSearchType={toggleSearchType} closePanel={closePanel} />
-          ) : searchType === SearchTypes.QUEUE_ROOM_FORM ? (
-            <QueueRoomForm toggleSearchType={toggleSearchType} closePanel={closePanel} />
           ) : null}
         </div>
       </Overlay>

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/existing-visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/existing-visit-form.component.tsx
@@ -14,12 +14,11 @@ import { type SearchTypes } from '../../types';
 import styles from './visit-form.scss';
 
 interface ExistingVisitFormProps {
-  toggleSearchType: (searchMode: SearchTypes, patientUuid) => void;
   visit: Visit;
   closePanel: () => void;
 }
 
-const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, toggleSearchType, closePanel }) => {
+const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, closePanel }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-rooms/queue-room-form.component.tsx
@@ -13,7 +13,6 @@ import {
   InlineNotification,
 } from '@carbon/react';
 import { restBaseUrl, showSnackbar, useLayoutType } from '@openmrs/esm-framework';
-import { type SearchTypes } from '../types';
 import { mutate } from 'swr';
 import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
 import { saveQueueRoom } from './queue-room.resource';
@@ -21,11 +20,10 @@ import styles from './queue-room-form.scss';
 import { useQueues } from '../helpers/useQueues';
 
 interface QueueRoomFormProps {
-  toggleSearchType: (searchMode: SearchTypes) => void;
   closePanel: () => void;
 }
 
-const QueueRoomForm: React.FC<QueueRoomFormProps> = ({ toggleSearchType, closePanel }) => {
+const QueueRoomForm: React.FC<QueueRoomFormProps> = ({ closePanel }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const [queueRoomName, setQueueRoomName] = useState('');

--- a/packages/esm-service-queues-app/src/queue-services/queue-service-form.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-services/queue-service-form.component.tsx
@@ -20,11 +20,10 @@ import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
 import styles from './queue-service-form.scss';
 
 interface QueueServiceFormProps {
-  toggleSearchType: (searchMode: SearchTypes) => void;
   closePanel: () => void;
 }
 
-const QueueServiceForm: React.FC<QueueServiceFormProps> = ({ toggleSearchType, closePanel }) => {
+const QueueServiceForm: React.FC<QueueServiceFormProps> = ({ closePanel }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const { queueConcepts } = useServiceConcepts();

--- a/packages/esm-service-queues-app/src/types/index.ts
+++ b/packages/esm-service-queues-app/src/types/index.ts
@@ -7,8 +7,6 @@ export enum SearchTypes {
   SEARCH_RESULTS = 'search_results',
   SCHEDULED_VISITS = 'scheduled-visits',
   VISIT_FORM = 'visit_form',
-  QUEUE_SERVICE_FORM = 'queue_service_form',
-  QUEUE_ROOM_FORM = 'queue_room_form',
 }
 
 export interface Attribute {


### PR DESCRIPTION
… things unrelated to patient serach

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
In service queues app, the `<PatientSearch>` component is an overlay workspace for user to serach for a patient and add them to the queue. However, the component is overloaded with other use cases of overlay workspaces. Refactor that out of the component.

There are really 3 types of workspace overlays used in the queues app: PatientSearch form, New Queue Service form, and New Queue Room form. There is additional logic in PatientSearch to show different forms depending on whether the user has an active visit or not. The logic is also overloaded with logic to display the other 2 forms. This PR factors out those logic.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
