### PR TITLE
Appointments: The appointments metrics aren't tally correctly

### DIFF
--- a/packages/esm-appointments-app/src/metrics/appointments-metrics.component.tsx
+++ b/packages/esm-appointments-app/src/metrics/appointments-metrics.component.tsx
@@ -18,7 +18,6 @@ const AppointmentsMetrics: React.FC<AppointmentMetricsProps> = ({ appointmentSer
   const { highestServiceLoad, error: clinicalMetricsError } = useClinicalMetrics();
   const { totalProviders } = useAllAppointmentsByDate();
   const { totalScheduledAppointments } = useScheduledAppointment(appointmentServiceType);
-
   const { selectedDate } = useContext(SelectedDateContext);
   const formattedStartDate = formatDate(parseDate(selectedDate), { mode: 'standard', time: false });
 
@@ -32,6 +31,7 @@ const AppointmentsMetrics: React.FC<AppointmentMetricsProps> = ({ appointmentSer
   const filteredPendingAppointments = appointmentServiceType
     ? pendingAppointments.filter(({ service }) => service.uuid === appointmentServiceType)
     : pendingAppointments;
+  const totalPatients = filteredArrivedAppointments.length + filteredPendingAppointments.length;
 
   if (clinicalMetricsError) {
     return (
@@ -45,7 +45,7 @@ const AppointmentsMetrics: React.FC<AppointmentMetricsProps> = ({ appointmentSer
       <div className={styles.cardContainer} data-testid="clinic-metrics">
         <MetricsCard
           label={t('patients', 'Patients')}
-          value={totalScheduledAppointments}
+          value={totalPatients}
           headerLabel={t('scheduledAppointments', 'Scheduled appointments')}
           count={{ pendingAppointments: filteredPendingAppointments, arrivedAppointments: filteredArrivedAppointments }}
         />

--- a/packages/esm-appointments-app/src/metrics/appointments-metrics.test.tsx
+++ b/packages/esm-appointments-app/src/metrics/appointments-metrics.test.tsx
@@ -44,6 +44,21 @@ describe('Appointment metrics', () => {
   });
 });
 
+const filteredArrivedAppointments = [];
+
+const filteredPendingAppointments = [];
+
+function getTotalPatients(filteredArrivedAppointments: any[], filteredPendingAppointments: any[]) {
+  return filteredArrivedAppointments.length + filteredPendingAppointments.length;
+}
+
+describe('Total Patients Calculation', () => {
+  it('should calculate the total patients correctly', () => {
+    const totalPatients = getTotalPatients(filteredArrivedAppointments, filteredPendingAppointments);
+    expect(totalPatients);
+  });
+});
+
 function renderAppointmentMetrics() {
   render(<AppointmentsMetrics appointmentServiceType="consultation-service-uuid" />);
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->
Appointments: The appointment metrics aren't tally correctly. The number of patients is not equal to the total of check-in and Not arrived
![metricsNotTallying](https://github.com/openmrs/openmrs-esm-patient-management/assets/8075969/ece0615d-2217-4adf-9d1a-b6d1d2b826c4)

This is the modified part
![metricsTallying](https://github.com/openmrs/openmrs-esm-patient-management/assets/8075969/0e1a67f8-e2fc-434c-9441-30971e3c4d72)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
