### PR TITLE
(fix) O3-3009 Appointment form should limit location to those tagged …

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -42,7 +42,13 @@ import { useProviders } from '../hooks/useProviders';
 import Workload from '../workload/workload.component';
 import type { Appointment, AppointmentPayload, RecurringPattern } from '../types';
 import { type ConfigObject } from '../config-schema';
-import { dateFormat, datePickerFormat, datePickerPlaceHolder, weekDays } from '../constants';
+import {
+  appointmentLocationTagName,
+  dateFormat,
+  datePickerFormat,
+  datePickerPlaceHolder,
+  weekDays,
+} from '../constants';
 import styles from './appointments-form.scss';
 import SelectedDateContext from '../hooks/selectedDateContext';
 import uniqBy from 'lodash-es/uniqBy';
@@ -96,7 +102,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
       : 'AM';
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
-  const locations = useLocations();
+  const locations = useLocations(appointmentLocationTagName);
   const providers = useProviders();
   const session = useSession();
   const { selectedDate } = useContext(SelectedDateContext);
@@ -325,10 +331,6 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
       <InlineLoading className={styles.loader} description={`${t('loading', 'Loading')} ...`} role="progressbar" />
     );
 
-  const updateLocations = uniqBy(
-    [...locations, { uuid: session.sessionLocation.uuid, display: session.sessionLocation.display }],
-    'uuid',
-  );
   return (
     <Form className={styles.formWrapper}>
       <Stack gap={4}>
@@ -348,8 +350,8 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
                   value={value}
                   ref={ref}>
                   <SelectItem text={t('chooseLocation', 'Choose a location')} value="" />
-                  {updateLocations?.length > 0 &&
-                    updateLocations.map((location) => (
+                  {locations?.length > 0 &&
+                    locations.map((location) => (
                       <SelectItem key={location.uuid} text={location.display} value={location.uuid}>
                         {location.display}
                       </SelectItem>


### PR DESCRIPTION
…as 'Appointment Location'

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
The appointment module creates / requires a specific Location tag to be associated with any Location at which an appointment can be scheduled.  This tag is already used within the appointments esm, but it is not used within the appointment form.  The result is that appointments can be scheduled for locations at which appointments are not supported, and the list of available locations is not filtered to the appropriate list of sub-locations.

## Related Issue
https://openmrs.atlassian.net/browse/O3-3009
