### PR TITLE
(fix) O3-3013 Appointment Form should validate invalid time values

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -4,34 +4,33 @@ import dayjs from 'dayjs';
 import {
   Button,
   ButtonSet,
-  DatePickerInput,
   DatePicker,
+  DatePickerInput,
   Form,
   InlineLoading,
   MultiSelect,
   NumberInput,
+  RadioButton,
+  RadioButtonGroup,
   Select,
   SelectItem,
   Stack,
-  RadioButtonGroup,
-  RadioButton,
   TextArea,
-  TimePickerSelect,
   TimePicker,
+  TimePickerSelect,
   Toggle,
 } from '@carbon/react';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import {
+  ResponsiveWrapper,
+  showSnackbar,
+  useConfig,
+  useLayoutType,
   useLocations,
   useSession,
-  showSnackbar,
-  useLayoutType,
-  useConfig,
-  ResponsiveWrapper,
 } from '@openmrs/esm-framework';
-import { convertTime12to24 } from '@openmrs/esm-patient-common-lib';
 import {
   saveAppointment,
   saveRecurringAppointments,
@@ -51,8 +50,11 @@ import {
 } from '../constants';
 import styles from './appointments-form.scss';
 import SelectedDateContext from '../hooks/selectedDateContext';
-import uniqBy from 'lodash-es/uniqBy';
-import { useController, Control } from 'react-hook-form';
+
+const time12HourFormatRegexPattern = '(1[0-2]|0?[1-9]):[0-5][0-9]';
+function isValidTime(timeStr) {
+  return timeStr.match(new RegExp(time12HourFormatRegexPattern));
+}
 
 const appointmentsFormSchema = z.object({
   duration: z.number(),
@@ -66,7 +68,7 @@ const appointmentsFormSchema = z.object({
   recurringPatternPeriod: z.number(),
   recurringPatternDaysOfWeek: z.array(z.string()),
   selectedDaysOfWeekText: z.string().optional(),
-  startTime: z.string(),
+  startTime: z.string().refine((value) => isValidTime(value)),
   timeFormat: z.enum(['AM', 'PM']),
   appointmentDateTime: z.object({
     startDate: z.date(),
@@ -289,7 +291,9 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
     } = data;
 
     const serviceUuid = services?.find((service) => service.name === selectedService)?.uuid;
-    const [hours, minutes] = convertTime12to24(startTime, timeFormat);
+    const hoursAndMinutes = startTime.split(':').map((item) => parseInt(item, 10));
+    const hours = (hoursAndMinutes[0] % 12) + (timeFormat === 'PM' ? 12 : 0);
+    const minutes = hoursAndMinutes[1];
     const startDatetime = startDate.setHours(hours, minutes);
     const endDatetime = dayjs(startDatetime).add(duration, 'minutes').toDate();
 
@@ -725,7 +729,9 @@ function TimeAndDuration({ isTablet, t, watch, control, services }) {
           render={({ field: { onChange, value } }) => (
             <TimePicker
               id="time-picker"
-              pattern="([\d]+:[\d]{2})"
+              pattern={time12HourFormatRegexPattern}
+              invalid={!isValidTime(value)}
+              invalidText={t('invalidTime', 'Invalid time')}
               onChange={(event) => onChange(event.target.value)}
               value={value}
               style={{ marginLeft: '0.125rem', flex: 'none' }}

--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -92,6 +92,7 @@
   "home": "Home",
   "identifier": "Identifier",
   "invalidNumber": "Number is not valid",
+  "invalidTime": "Invalid time",
   "isRecurringAppointment": "Is this a recurring appointment?",
   "loading": "Loading",
   "location": "Location",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
If you enter an invalid time in the time field input when scheduling an appointment, nothing prevents the form submission, and the invalid time is discarded and the time is set to midnight on the appointment.  This is problematic, particularly since times like "11" might be entered, which are invalid, and are just silently saved as midnight.

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/356297/4326c2f5-3b38-446b-bec0-05c82691c0e7)

## Related Issue
https://openmrs.atlassian.net/browse/O3-3013
