### PR TITLE
(fix) O3-3013 appointment time validation should match entire string

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -51,7 +51,7 @@ import {
 import styles from './appointments-form.scss';
 import SelectedDateContext from '../hooks/selectedDateContext';
 
-const time12HourFormatRegexPattern = '(1[0-2]|0?[1-9]):[0-5][0-9]';
+const time12HourFormatRegexPattern = '^(1[0-2]|0?[1-9]):[0-5][0-9]$';
 function isValidTime(timeStr) {
   return timeStr.match(new RegExp(time12HourFormatRegexPattern));
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).

Bug fix to previous commit to ensure the entire time string is matched on the regex.
