### PR TITLE
(fix) O3-2748 service queue - fix NPE in undo transition dialog

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/undo-transition-queue-entry-modal.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/undo-transition-queue-entry-modal.component.tsx
@@ -11,9 +11,9 @@ interface UndoTransitionQueueEntryModalProps {
 
 const UndoTransitionQueueEntryModal: React.FC<UndoTransitionQueueEntryModalProps> = ({ queueEntry, closeModal }) => {
   const { t } = useTranslation();
-  const { previousQueueEntry } = queueEntry;
+  const { previousQueueEntry, queueComingFrom } = queueEntry;
 
-  const previousEntrySameQueue = previousQueueEntry.queue.uuid == queueEntry.queue.uuid;
+  const previousEntrySameQueue = queueComingFrom.uuid == queueEntry.queue.uuid;
   const modalInstruction = previousEntrySameQueue ? (
     <p>
       {t('confirmMoveBackStatus', 'Are you sure you want to move patient back to status "{{status}}"?', {
@@ -27,7 +27,7 @@ const UndoTransitionQueueEntryModal: React.FC<UndoTransitionQueueEntryModalProps
         'confirmMoveBackQueueAndStatus',
         'Are you sure you want to move patient back to queue "{{queue}}" with status "{{status}}"?',
         {
-          queue: previousQueueEntry.queue.display,
+          queue: queueComingFrom.display,
           status: previousQueueEntry.status.display,
           interpolation: { escapeValue: false },
         },


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fixes NPE in the undo transition dialog. I'm guessing `previousQueueEntry` field stopped having its `queue` field populated due to some `v=` parameter change. Getting those same values from the `queueCommingFrom` field instead.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
