### PR TITLE
(fix) Handle null start date on patient list details

### DIFF
--- a/packages/esm-patient-list-management-app/src/list-details/list-details.component.tsx
+++ b/packages/esm-patient-list-management-app/src/list-details/list-details.component.tsx
@@ -45,7 +45,7 @@ const ListDetails = () => {
               name: member?.patient?.person?.display,
               identifier: member?.patient?.identifiers[0]?.identifier ?? null,
               sex: member?.patient?.person?.gender,
-              startDate: formatDate(parseDate(member?.startDate)),
+              startDate: member?.startDate ? formatDate(parseDate(member?.startDate)) : null,
               uuid: `${member?.patient?.uuid}`,
               membershipUuid: member?.uuid,
             }))


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This development addresses an issue where an error is raised upon opening a patient list containing members with null start dates.