### PR TITLE
(fix):O3-3039-Fix Incorrect Client Selection Issue When Navigating Pages in Queue Table

### DIFF
--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
@@ -215,6 +215,11 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
         header: t('waitTime', 'Wait time'),
         key: 'waitTime',
       },
+      {
+        id: 6,
+        header: t('actions', 'Actions'),
+        key: 'actions',
+      },
     ],
     [t],
   );
@@ -249,6 +254,13 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
       waitTime: {
         content: <QueueDuration startedAt={entry.startedAt} endedAt={entry.endedAt} />,
       },
+      actions: (
+        <div className={styles.actionMenu}>
+          <TransitionMenu queueEntry={entry} />
+          <EditMenu queueEntry={entry} />
+          <ActionsMenu queueEntry={entry} />
+        </div>
+      ),
     }));
   }, [paginatedQueueEntries]);
 
@@ -388,15 +400,6 @@ function OldQueueTable({ queueEntries }: { queueEntries: QueueEntry[] }) {
                           {row.cells.map((cell) => (
                             <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
                           ))}
-                          <TableCell className="cds--table-column-menu">
-                            <TransitionMenu queueEntry={visitQueueEntries?.[index]} />
-                          </TableCell>
-                          <TableCell className="cds--table-column-menu">
-                            <EditMenu queueEntry={visitQueueEntries?.[index]} />
-                          </TableCell>
-                          <TableCell className="cds--table-column-menu">
-                            <ActionsMenu queueEntry={visitQueueEntries?.[index]} />
-                          </TableCell>
                         </TableExpandRow>
                         {row.isExpanded ? (
                           <TableExpandedRow className={styles.expandedActiveVisitRow} colSpan={headers.length + 2}>

--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.scss
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.scss
@@ -263,3 +263,8 @@ html[dir='rtl'] {
     }
   }
 }
+.actionMenu {
+  display: flex; 
+  align-items: center;
+  padding: 0;
+}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This occurs when you have more that 10 patients on the queue, meaning you will have more than one page. Patients on the next page will be incorrectly selected since the index passed is static. For instance use the bell to call a patient on the next page say at number 11 then the first patient on the first page is the when getting picked.
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
