### PR TITLE
(BREAKING) O3-3068 - service queues - show new default queue table

### DIFF
--- a/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/active-visits-table.component.tsx
@@ -99,8 +99,6 @@ function ActiveVisitsTable() {
     location: currentLocationUuid,
     isEnded: false,
   });
-
-  const useNewActiveVisitsTable = useFeatureFlag('new-queue-table');
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -114,11 +112,9 @@ function ActiveVisitsTable() {
   }, [error?.message]);
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" />;
-  } else if (useNewActiveVisitsTable) {
-    return <DefaultQueueTable queueEntries={queueEntries ?? []} />;
-  } else {
-    return <OldQueueTable queueEntries={queueEntries ?? []} />;
   }
+
+  return <OldQueueTable queueEntries={queueEntries ?? []} />;
 }
 
 // older implementation of the ActiveVisitsTable that we plan on deprecating

--- a/packages/esm-service-queues-app/src/config-schema.ts
+++ b/packages/esm-service-queues-app/src/config-schema.ts
@@ -142,6 +142,11 @@ export const configSchema = {
     _default: '',
     _description: 'Custom label for patient chart button',
   },
+  useActiveVisitsTable: {
+    _type: Type.Boolean,
+    _default: false,
+    _description: 'If true, renders the ActiveVisitsTable instead of the default queue table',
+  },
 };
 
 export interface ConfigObject {
@@ -173,6 +178,7 @@ export interface ConfigObject {
   customPatientChartUrl: string;
   defaultFacilityUrl: string;
   customPatientChartText: string;
+  useActiveVisitsTable: boolean;
 }
 
 export interface OutpatientConfig {

--- a/packages/esm-service-queues-app/src/home.component.tsx
+++ b/packages/esm-service-queues-app/src/home.component.tsx
@@ -1,19 +1,27 @@
 import React from 'react';
-import { type ConfigObject, useConfig } from '@openmrs/esm-framework';
+import { useConfig, useFeatureFlag } from '@openmrs/esm-framework';
 import ActiveVisitsTable from './active-visits/active-visits-table.component';
 import ActiveVisitsTabs from './active-visits/active-visits-tab.component';
 import ClinicMetrics from './patient-queue-metrics/clinic-metrics.component';
 import PatientQueueHeader from './patient-queue-header/patient-queue-header.component';
+import { type ConfigObject } from './config-schema';
+import DefaultQueueTable from './queue-table/default-queue-table.component';
 
 const Home: React.FC = () => {
-  const config = useConfig<ConfigObject>();
-  const useQueueTableTabs: boolean = config.showQueueTableTab;
+  const { showQueueTableTab, useActiveVisitsTable } = useConfig<ConfigObject>();
+  const useActiveVisitsTableViaFeatureFlag = useFeatureFlag('active-visits-table');
 
   return (
     <>
       <PatientQueueHeader />
       <ClinicMetrics />
-      {useQueueTableTabs ? <ActiveVisitsTabs /> : <ActiveVisitsTable />}
+      {showQueueTableTab ? (
+        <ActiveVisitsTabs />
+      ) : useActiveVisitsTable || useActiveVisitsTableViaFeatureFlag ? (
+        <ActiveVisitsTable />
+      ) : (
+        <DefaultQueueTable />
+      )}
     </>
   );
 };

--- a/packages/esm-service-queues-app/src/index.ts
+++ b/packages/esm-service-queues-app/src/index.ts
@@ -141,8 +141,8 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 
   registerFeatureFlag(
-    'new-queue-table',
-    'New Queue Table',
-    'Use a newer implementation of the queue table in the home dashboard of the queues app.',
+    'active-visits-table',
+    'Active Visits Table',
+    'Use the ActiveVisitsTable instead of the default queue table in the service queue app.',
   );
 }

--- a/packages/esm-service-queues-app/src/queue-table/default-queue-table.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/default-queue-table.test.tsx
@@ -7,7 +7,7 @@ import { renderWithSwr } from 'tools';
 import { useQueueEntries } from '../hooks/useQueueEntries';
 import { useQueueRooms } from '../add-provider-queue-room/add-provider-queue-room.resource';
 import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
-import ActiveVisitsTable from './active-visits-table.component';
+import DefaultQueueTable from '../queue-table/default-queue-table.component';
 
 const mockedUseConfig = useConfig as jest.Mock;
 const mockUseQueueEntries = useQueueEntries as jest.Mock;
@@ -65,7 +65,7 @@ jest.mock('../helpers/helpers', () => {
   };
 });
 
-describe('ActiveVisitsTable: ', () => {
+describe('DefaultQueueTable: ', () => {
   beforeEach(() => {
     mockUseSession.mockReturnValue(mockSession),
       mockedUseConfig.mockReturnValue({
@@ -82,6 +82,8 @@ describe('ActiveVisitsTable: ', () => {
     mockUseQueueEntries.mockReturnValue({ queueEntries: [], isLoading: false });
 
     renderActiveVisitsTable();
+
+    await screen.findByRole('table');
 
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     expect(screen.getByText(/patients currently in queue/i)).toBeInTheDocument();
@@ -104,7 +106,7 @@ describe('ActiveVisitsTable: ', () => {
     expect(john).toBeInTheDocument();
     expect(john).toHaveAttribute('href', 'someUrl');
 
-    const expectedColumnHeaders = [/name/, /priority/, /status/, /wait time/];
+    const expectedColumnHeaders = [/name/, /priority/, /status/, /waitTime/];
     expectedColumnHeaders.forEach((header) => {
       expect(
         screen.getByRole('columnheader', {
@@ -116,5 +118,5 @@ describe('ActiveVisitsTable: ', () => {
 });
 
 function renderActiveVisitsTable() {
-  renderWithSwr(<ActiveVisitsTable />);
+  renderWithSwr(<DefaultQueueTable />);
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR makes the new default queue table load by default in the service queues app.

Attn @ojwanganto , @makombe , @donaldkibet, this is a breaking change to the queue table UI. In particular:
- The Actions column in each row has different actions
  - Old actions: 
    - bell icon (which edit status to "In Service")
    - Transfer (which edits the queue of the patient)
    - Overflow menu to "Edit patient detail" or "End visit"
  - New actions:
    - Delete or Undo Transition
    - Edit
    - Transition 
- There is no "Clear queue" button to remove all queue entries and end all visit of patients in the queue table.

 You can still get the older table to show by doing any of the following:
- add a new frontend config `useActiveVisitsTable` and set it to true
- use the Implementor Tool to turn on the feature flag `active-visits-table`
- open up the browser's dev console and do: `localStorage.setItem("openmrs:feature-flag:active-visits-table", true)`

## Screenshots
<!-- Required if you are making UI changes. -->
With feature flag off:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/2630dc69-0161-4f82-a644-b510e3eacf68)
With feature flag on:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/69996c31-3b95-4219-8f02-e307a70c972e)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
