### PR TITLE
(chore) O3-3069 tweak syling for queue table

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
@@ -15,7 +15,7 @@ import {
   TableToolbarContent,
   Tile,
 } from '@carbon/react';
-import { usePagination } from '@openmrs/esm-framework';
+import { isDesktop, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import React, { useEffect, useState, type FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type QueueEntry, type QueueTableColumn } from '../types';
@@ -31,22 +31,16 @@ interface QueueTableProps {
 
   // if provided, adds addition table toolbar elements
   tableFilter?: React.ReactNode[];
-
-  showSearchBar?: boolean;
 }
 
-function QueueTable({
-  queueEntries,
-  queueTableColumns,
-  ExpandedRow,
-  tableFilter,
-  showSearchBar = true,
-}: QueueTableProps) {
+function QueueTable({ queueEntries, queueTableColumns, ExpandedRow, tableFilter }: QueueTableProps) {
   const { t } = useTranslation();
   const [currentPageSize, setPageSize] = useState(10);
   const pageSizes = [10, 20, 30, 40, 50];
 
   const { goTo, results: paginatedQueueEntries, currentPage } = usePagination(queueEntries, currentPageSize);
+  const layout = useLayoutType();
+  const responsiveSize = isDesktop(layout) ? 'sm' : 'lg';
 
   useEffect(() => {
     goTo(1);
@@ -63,8 +57,14 @@ function QueueTable({
     }) ?? [];
 
   return (
-    <DataTable rows={rowsData} headers={headers} useZebraStyles>
-      {({ rows, headers, getTableProps, getHeaderProps, getRowProps, getToolbarProps }) => (
+    <DataTable
+      data-floating-menu-container
+      overflowMenuOnHover={isDesktop(layout)}
+      rows={rowsData}
+      headers={headers}
+      size={responsiveSize}
+      useZebraStyles>
+      {({ rows, headers, getTableProps, getHeaderProps, getRowProps, getToolbarProps, getExpandHeaderProps }) => (
         <TableContainer className={styles.tableContainer}>
           {tableFilter && (
             <TableToolbar {...getToolbarProps()}>
@@ -74,7 +74,7 @@ function QueueTable({
           <Table {...getTableProps()} className={styles.queueTable} useZebraStyles>
             <TableHead>
               <TableRow>
-                {ExpandedRow && <TableExpandHeader />}
+                {ExpandedRow && <TableExpandHeader enableToggle {...getExpandHeaderProps()} />}
                 {headers.map((header) => (
                   <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
                 ))}

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
@@ -65,42 +65,44 @@ function QueueTable({ queueEntries, queueTableColumns, ExpandedRow, tableFilter 
       size={responsiveSize}
       useZebraStyles>
       {({ rows, headers, getTableProps, getHeaderProps, getRowProps, getToolbarProps, getExpandHeaderProps }) => (
-        <TableContainer className={styles.tableContainer}>
-          {tableFilter && (
-            <TableToolbar {...getToolbarProps()}>
-              <TableToolbarContent className={styles.toolbarContent}>{tableFilter}</TableToolbarContent>
-            </TableToolbar>
-          )}
-          <Table {...getTableProps()} className={styles.queueTable} useZebraStyles>
-            <TableHead>
-              <TableRow>
-                {ExpandedRow && <TableExpandHeader enableToggle {...getExpandHeaderProps()} />}
-                {headers.map((header) => (
-                  <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {rows.map((row, i) => {
-                const Row = ExpandedRow ? TableExpandRow : TableRow;
+        <>
+          <TableContainer className={styles.tableContainer}>
+            {tableFilter && (
+              <TableToolbar {...getToolbarProps()}>
+                <TableToolbarContent className={styles.toolbarContent}>{tableFilter}</TableToolbarContent>
+              </TableToolbar>
+            )}
+            <Table {...getTableProps()} className={styles.queueTable} useZebraStyles>
+              <TableHead>
+                <TableRow>
+                  {ExpandedRow && <TableExpandHeader enableToggle {...getExpandHeaderProps()} />}
+                  {headers.map((header) => (
+                    <TableHeader {...getHeaderProps({ header })}>{header.header}</TableHeader>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.map((row, i) => {
+                  const Row = ExpandedRow ? TableExpandRow : TableRow;
 
-                return (
-                  <React.Fragment key={row.id}>
-                    <Row {...getRowProps({ row })}>
-                      {row.cells.map((cell) => (
-                        <TableCell key={cell.id}>{cell.value}</TableCell>
-                      ))}
-                    </Row>
-                    {ExpandedRow && (
-                      <TableExpandedRow className={styles.expandedActiveVisitRow} colSpan={headers.length + 1}>
-                        <ExpandedRow queueEntry={paginatedQueueEntries[i]} />
-                      </TableExpandedRow>
-                    )}
-                  </React.Fragment>
-                );
-              })}
-            </TableBody>
-          </Table>
+                  return (
+                    <React.Fragment key={row.id}>
+                      <Row {...getRowProps({ row })}>
+                        {row.cells.map((cell) => (
+                          <TableCell key={cell.id}>{cell.value}</TableCell>
+                        ))}
+                      </Row>
+                      {ExpandedRow && (
+                        <TableExpandedRow className={styles.expandedActiveVisitRow} colSpan={headers.length + 1}>
+                          <ExpandedRow queueEntry={paginatedQueueEntries[i]} />
+                        </TableExpandedRow>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
           {rows.length === 0 && (
             <div className={styles.tileContainer}>
               <Tile className={styles.tile}>
@@ -127,7 +129,7 @@ function QueueTable({ queueEntries, queueTableColumns, ExpandedRow, tableFilter 
               }
             }}
           />
-        </TableContainer>
+        </>
       )}
     </DataTable>
   );

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.scss
@@ -33,6 +33,7 @@
 
 .tableContainer {
   background-color: $ui-01;
+  margin: 0 spacing.$spacing-05;
   padding: 0;
 
   a {

--- a/packages/esm-service-queues-app/src/views/queue-tables-for-all-statuses.component.tsx
+++ b/packages/esm-service-queues-app/src/views/queue-tables-for-all-statuses.component.tsx
@@ -116,12 +116,7 @@ const QueueTablesForAllStatuses: React.FC<QueueTablesForAllStatusesProps> = ({ s
         return (
           <div className={styles.statusTableContainer}>
             <h5 className={styles.statusTableHeader}>{status.display}</h5>
-            <QueueTable
-              key={uuid}
-              queueEntries={filteredQueueEntries}
-              queueTableColumns={tableConfig.columns}
-              showSearchBar={false}
-            />
+            <QueueTable key={uuid} queueEntries={filteredQueueEntries} queueTableColumns={tableConfig.columns} />
           </div>
         );
       })}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR applies styling fixes to the service queues table. [Similar fixes](https://github.com/openmrs/openmrs-esm-patient-management/pull/1092) were done to the appointments table.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/56787708-8243-40ab-af64-3e566b00a858)

After:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/cb0ed0c5-55d4-4719-bc63-569033965f4f)
- Smaller table header
- table header has an expander button to expand all rows


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
