### PR TITLE
(fix) O3-3088: Appointments form accepts zero as a value for the appointment duration

### DIFF
--- a/packages/esm-appointments-app/src/constants.ts
+++ b/packages/esm-appointments-app/src/constants.ts
@@ -4,6 +4,8 @@ export const spaHomePage = ` ${window.getOpenmrsSpaBase()}home`;
 export const omrsDateFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZZ';
 export const appointmentLocationTagName = 'Appointment Location';
 
+export const moduleName = '@openmrs/esm-appointments-app';
+
 export const datePickerPlaceHolder = 'dd/mm/yyyy';
 export const dateFormat = 'DD/MM/YYYY';
 export const datePickerFormat = 'd/m/Y';

--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -26,6 +26,7 @@ import { z } from 'zod';
 import {
   ResponsiveWrapper,
   showSnackbar,
+  translateFrom,
   useConfig,
   useLayoutType,
   useLocations,
@@ -50,6 +51,7 @@ import {
 } from '../constants';
 import styles from './appointments-form.scss';
 import SelectedDateContext from '../hooks/selectedDateContext';
+import { moduleName } from '../constants';
 
 const time12HourFormatRegexPattern = '^(1[0-2]|0?[1-9]):[0-5][0-9]$';
 function isValidTime(timeStr) {
@@ -57,7 +59,9 @@ function isValidTime(timeStr) {
 }
 
 const appointmentsFormSchema = z.object({
-  duration: z.number().refine((duration) => duration > 0),
+  duration: z.number().refine((duration) => duration > 0, {
+    message: translateFrom(moduleName, 'durationErrorMessage', 'Duration should be greater than zero'),
+  }),
   location: z.string().refine((value) => value !== ''),
   provider: z.string().refine((value) => value !== ''),
   appointmentStatus: z.string().optional(),

--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -57,7 +57,7 @@ function isValidTime(timeStr) {
 }
 
 const appointmentsFormSchema = z.object({
-  duration: z.number(),
+  duration: z.number().refine((duration) => duration > 0),
   location: z.string().refine((value) => value !== ''),
   provider: z.string().refine((value) => value !== ''),
   appointmentStatus: z.string().optional(),

--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -77,6 +77,7 @@
   "errorCreatingAppointmentService": "Error creating appointment service",
   "expected": "Expected",
   "filterTable": "Filter table",
+  "durationErrorMessage": "Duration should be greater than zero",
   "gender": "Gender",
   "highestServiceVolume": "Highest volume service: {{time}}",
   "home": "Home",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.


# Summary
The duration field in the appointments form will submit when a value of 0 is given.