### PR TITLE
Disallow zero duration for appointments to prevent scheduling errors.

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -57,7 +57,7 @@ function isValidTime(timeStr) {
 }
 
 const appointmentsFormSchema = z.object({
-  duration: z.number(),
+  duration: z.number().positive(),,
   location: z.string().refine((value) => value !== ''),
   provider: z.string().refine((value) => value !== ''),
   appointmentStatus: z.string().optional(),
@@ -761,13 +761,13 @@ function TimeAndDuration({ isTablet, t, watch, control, services }) {
             <NumberInput
               hideSteppers
               id="duration"
-              min={0}
+              min={1}  // Ensure the minimum value is 1
               max={1440}
               label={t('durationInMinutes', 'Duration (minutes)')}
               invalidText={t('invalidNumber', 'Number is not valid')}
               size="md"
               onBlur={onBlur}
-              onChange={(event) => onChange(Number(event.target.value))}
+              onChange={(event) => onChange(Math.max(1, Number(event.target.value)))} // This ensures the value is at least 1
               value={value}
               ref={ref}
             />

--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -57,7 +57,7 @@ function isValidTime(timeStr) {
 }
 
 const appointmentsFormSchema = z.object({
-  duration: z.number().positive(),,
+  duration: z.number().positive(),
   location: z.string().refine((value) => value !== ''),
   provider: z.string().refine((value) => value !== ''),
   appointmentStatus: z.string().optional(),
@@ -761,13 +761,13 @@ function TimeAndDuration({ isTablet, t, watch, control, services }) {
             <NumberInput
               hideSteppers
               id="duration"
-              min={1}  // Ensure the minimum value is 1
+              min={1}  
               max={1440}
               label={t('durationInMinutes', 'Duration (minutes)')}
               invalidText={t('invalidNumber', 'Number is not valid')}
               size="md"
               onBlur={onBlur}
-              onChange={(event) => onChange(Math.max(1, Number(event.target.value)))} // This ensures the value is at least 1
+              onChange={(event) => onChange(Math.max(1, Number(event.target.value)))} 
               value={value}
               ref={ref}
             />


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Disallow zero duration for appointments

Updated validation to ensure appointment durations are greater than zero, preventing impractical zero-minute appointments.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue

https://openmrs.atlassian.net/browse/O3-3088

## Other
<!-- Anything not covered above -->
