### PR TITLE
(feat) O3-3127: Make the All Day feature in the appointments form disabled by default

### DIFF
--- a/packages/esm-appointments-app/src/config-schema.ts
+++ b/packages/esm-appointments-app/src/config-schema.ts
@@ -88,7 +88,7 @@ export const configSchema = {
   allowAllDayAppointments: {
     _type: Type.Boolean,
     _description: 'Whether to allow scheduling of all-day appointments (vs appointments with start time and end time)',
-    _default: true,
+    _default: false,
   },
   checkInButton: {
     enabled: {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [X] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [X] My work includes tests or is validated by existing tests.

## Summary
The All Day appointments feature is currently enabled by default in the ref app. This PR aims at making it disabled by default such that any implementers who want to use it will have to enable it by themselves through configuration. 

To achieve this the PR changes the default value of the allowAllDayAppointment property in the config-schema from true to false

##Screenshots
Here is the before:

https://github.com/openmrs/openmrs-esm-patient-management/assets/121826239/3d935852-7850-42db-8f42-3ee1d0e8c588

Here is the after

https://github.com/openmrs/openmrs-esm-patient-management/assets/121826239/4d1980e5-ba6a-4ed7-a7a8-3197afe42fad



## Related Issue
https://openmrs.atlassian.net/browse/O3-3127

