### PR TITLE
(fix) - O3-03130 - fix 'Add Provider Queue Room' dialog popping up wh…

### DIFF
--- a/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.resource.ts
+++ b/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.resource.ts
@@ -1,10 +1,6 @@
-import { openmrsFetch, restBaseUrl, showModal, useSession } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 import { type ProvidersQueueRoom, type QueueRoom } from '../types';
-import { useIsPermanentProviderQueueRoom, useSelectedServiceUuid } from '../helpers/helpers';
-import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
-import { timeDiffInMinutes } from '../helpers/functions';
-import { useEffect } from 'react';
 
 export function useQueueRooms(location: string, queueUuid: string) {
   const apiUrl = queueUuid
@@ -77,32 +73,4 @@ export function useProvidersQueueRoom(providerUuid: string) {
     isLoading,
     mutate,
   };
-}
-
-// show the modal dialog if one is not configured
-export function useShowProviderQueueRoomModal() {
-  const currentServiceUuid = useSelectedServiceUuid();
-  const { queueLocations } = useQueueLocations();
-  const { rooms, isLoading: loading } = useQueueRooms(queueLocations[0]?.id, currentServiceUuid);
-  const isPermanentProviderQueueRoom = useIsPermanentProviderQueueRoom();
-  const currentUserSession = useSession();
-  const providerUuid = currentUserSession?.currentProvider?.uuid;
-  const differenceInTime = timeDiffInMinutes(
-    new Date(),
-    new Date(localStorage.getItem('lastUpdatedQueueRoomTimestamp')),
-  );
-
-  useEffect(() => {
-    if (
-      !loading &&
-      rooms?.length > 0 &&
-      differenceInTime >= 1 &&
-      (isPermanentProviderQueueRoom == 'false' || isPermanentProviderQueueRoom === null)
-    ) {
-      const dispose = showModal('add-provider-to-room-modal', {
-        closeModal: () => dispose(),
-        providerUuid,
-      });
-    }
-  }, [rooms, isPermanentProviderQueueRoom]);
 }

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.test.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.test.tsx
@@ -67,8 +67,6 @@ describe('Clinic metrics', () => {
     expect(screen.getByText(/Average wait time today/i)).toBeInTheDocument();
     expect(screen.getByText(/minutes/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /queue screen/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /add new service$/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /add new service room/i })).toBeInTheDocument();
     expect(screen.getByText(/69/i)).toBeInTheDocument();
   });
 });

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/metrics-header.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/metrics-header.component.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { PatientBannerActionsMenu } from '@openmrs/esm-framework';
+import { PatientBannerActionsMenu, showModal, useSession } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { MessageQueue, ArrowRight } from '@carbon/react/icons';
 import { Button, ComboButton, MenuItem } from '@carbon/react';
@@ -12,12 +12,12 @@ import QueueServiceForm from '../queue-services/queue-service-form.component';
 
 const MetricsHeader = () => {
   const { t } = useTranslation();
-  const isTablet = useLayoutType() === 'tablet';
-  const isPhone = useLayoutType() == 'phone';
   const metricsTitle = t('clinicMetrics', 'Clinic metrics');
   const queueScreenText = t('queueScreen', 'Queue screen');
   const [showQueueServiceFormOverlay, setShowQueueServiceFormOverlay] = useState(false);
   const [showQueueRoomFormOverlay, setShowQueueRoomFormOverlay] = useState(false);
+  const currentUserSession = useSession();
+  const providerUuid = currentUserSession?.currentProvider?.uuid;
 
   const navigateToQueueScreen = () => {
     navigate({ to: `${spaBasePath}/service-queues/screen` });
@@ -26,65 +26,35 @@ const MetricsHeader = () => {
     setShowQueueServiceFormOverlay(false);
     setShowQueueRoomFormOverlay(false);
   };
-  if (isTablet || isPhone) {
-    return (
-      <div className={styles.metricsContainer}>
-        <span className={styles.metricsTitle}>{metricsTitle}</span>
-        <UserHasAccess privilege="Emr: View Legacy Interface">
-          <ComboButton label={t('actions', 'Actions')} menuAlignment="bottom-end" className={styles.comboBtn}>
-            <MenuItem
-              label={t('addNewService', 'Add new service')}
-              onClick={() => setShowQueueServiceFormOverlay(true)}
-            />
-
-            <MenuItem
-              label={t('addNewServiceRoom', 'Add new service room')}
-              onClick={() => setShowQueueRoomFormOverlay(true)}
-            />
-            <MenuItem label={queueScreenText} onClick={navigateToQueueScreen} />
-          </ComboButton>
-        </UserHasAccess>
-        {showQueueServiceFormOverlay && (
-          <Overlay header={t('addNewQueueService', 'Add new queue service')} closePanel={closeOverlays}>
-            <QueueServiceForm closePanel={closeOverlays} />
-          </Overlay>
-        )}
-        {showQueueRoomFormOverlay && (
-          <Overlay header={t('addNewQueueServiceRoom', 'Add new queue service room')} closePanel={closeOverlays}>
-            <QueueRoomForm closePanel={closeOverlays} />
-          </Overlay>
-        )}
-      </div>
-    );
-  }
   return (
     <div className={styles.metricsContainer}>
       <span className={styles.metricsTitle}>{metricsTitle}</span>
-      <div className={styles.actionBtn}>
+      <ComboButton
+        label={queueScreenText}
+        menuAlignment="bottom-end"
+        className={styles.comboBtn}
+        tooltipAlignment="top-right"
+        onClick={navigateToQueueScreen}>
         <UserHasAccess privilege="Emr: View Legacy Interface">
-          <Button
-            kind="tertiary"
-            renderIcon={(props) => <ArrowRight size={16} {...props} />}
+          <MenuItem
+            label={t('addNewService', 'Add new service')}
             onClick={() => setShowQueueServiceFormOverlay(true)}
-            iconDescription={t('addNewQueueService', 'Add new queue service')}>
-            {t('addNewService', 'Add new service')}
-          </Button>
-          <Button
-            kind="tertiary"
-            renderIcon={(props) => <ArrowRight size={16} {...props} />}
+          />
+          <MenuItem
+            label={t('addNewServiceRoom', 'Add new service room')}
             onClick={() => setShowQueueRoomFormOverlay(true)}
-            iconDescription={t('addNewQueueServiceRoom', 'Add new queue service room')}>
-            {t('addNewServiceRoom', 'Add new service room')}
-          </Button>
+          />
         </UserHasAccess>
-        <Button
-          onClick={navigateToQueueScreen}
-          kind="tertiary"
-          renderIcon={(props) => <MessageQueue size={16} {...props} />}
-          iconDescription={queueScreenText}>
-          {queueScreenText}
-        </Button>
-      </div>
+        <MenuItem
+          label={t('addProviderQueueRoom', 'Add provider queue room')}
+          onClick={() => {
+            const dispose = showModal('add-provider-to-room-modal', {
+              closeModal: () => dispose(),
+              providerUuid,
+            });
+          }}
+        />
+      </ComboButton>
       {showQueueServiceFormOverlay && (
         <Overlay header={t('addNewQueueService', 'Add new queue service')} closePanel={closeOverlays}>
           <QueueServiceForm closePanel={closeOverlays} />

--- a/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
@@ -27,7 +27,6 @@ import { DataTableSkeleton } from '@carbon/react';
 import { type ConfigObject } from '../config-schema';
 import { queueTableVisitAttributeQueueNumberColumn } from './cells/queue-table-visit-attribute-queue-number-cell.component';
 import { activeVisitActionsColumn } from '../active-visits/active-visits-row-actions.component';
-import { useShowProviderQueueRoomModal } from '../add-provider-queue-room/add-provider-queue-room.resource';
 import ClearQueueEntries from '../clear-queue-entries-dialog/clear-queue-entries.component';
 
 /*
@@ -58,8 +57,6 @@ function DefaultQueueTable() {
 
   const [showOverlay, setShowOverlay] = useState(false);
   const [viewState, setViewState] = useState<{ selectedPatientUuid: string }>(null);
-
-  useShowProviderQueueRoomModal();
 
   const config = useConfig<ConfigObject>();
   const { visitQueueNumberAttributeUuid, concepts } = config;

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -9,7 +9,7 @@
   "addNewService": "Add new service",
   "addNewServiceRoom": "Add new service room",
   "addPatientToQueue": "Add patient to queue",
-  "addProviderQueueRoom": "Add provider queue room?",
+  "addProviderQueueRoom": "Add provider queue room",
   "addQueue": "Add queue",
   "addQueueName": "Please add a queue name",
   "addQueueRoom": "Add queue room",


### PR DESCRIPTION
…en it should not

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The "Add Provider Queue Room" modal pops up unexpectedly sometimes when navigating to the service queues app. The current implementation has the dialog popping up when certain conditions are met. The PR changes it to appear by pressing a button in the "Clinics Metrics" section instead. 

A [previous commit](https://github.com/openmrs/openmrs-esm-patient-management/pull/1046) added some UI changes to show the buttons at the "Clinic Metrics" section has a ComboButton on mobile. However, it also made a (probably) unintentional change to hide the "Queue Screen" button behind the `Emr: View Legacy Interface` privilege. This PR reverts it to the old behavior.

I just made it always use the ComboButton, regardless of whether the browser is on mobile or desktop. Let me know if that's not ok.


## Screenshots
<!-- Required if you are making UI changes. -->
When logged in as admin:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/52c029b3-0233-4410-9ec7-a91882e86f9a)

When logged in as nurse:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/509602/e184da47-a5d0-4d72-b142-16e7350e330d)



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
