### PR TITLE
(feat) Show a locale-specific datepicker for Amharic and Tigrinya locales

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     '@openmrs/esm-framework': '@openmrs/esm-framework/mock',
     '^dexie$': require.resolve('dexie'),
     '^lodash-es/(.*)$': 'lodash/$1',
+    'lodash-es': 'lodash',
     '^react-i18next$': path.resolve(__dirname, 'react-i18next.js'),
     '^uuid$': path.resolve(__dirname, 'node_modules', 'uuid', 'dist', 'index.js'),
   },

--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useField } from 'formik';
 import { generateFormatting } from '../../date-util';
 import { PatientRegistrationContext } from '../../patient-registration-context';
-import { useConfig } from '@openmrs/esm-framework';
+import { OpenmrsDatePicker, useConfig } from '@openmrs/esm-framework';
 import { type RegistrationConfig } from '../../../config-schema';
 import styles from '../field.scss';
 
@@ -46,8 +46,8 @@ export const DobField: React.FC = () => {
   );
 
   const onDateChange = useCallback(
-    (birthdate: Date[]) => {
-      setFieldValue('birthdate', birthdate[0]);
+    (birthdate: Date) => {
+      setFieldValue('birthdate', birthdate);
     },
     [setFieldValue],
   );
@@ -101,17 +101,20 @@ export const DobField: React.FC = () => {
       <Layer>
         {!dobUnknown ? (
           <div className={styles.dobField}>
-            <DatePicker dateFormat={dateFormat} datePickerType="single" onChange={onDateChange} maxDate={format(today)}>
-              <DatePickerInput
-                id="birthdate"
-                {...birthdate}
-                placeholder={placeHolder}
-                labelText={t('dateOfBirthLabelText', 'Date of Birth')}
-                invalid={!!(birthdateMeta.touched && birthdateMeta.error)}
-                invalidText={birthdateMeta.error && t(birthdateMeta.error)}
-                value={format(birthdate.value)}
-              />
-            </DatePicker>
+            <OpenmrsDatePicker
+              id="birthdate"
+              {...birthdate}
+              dateFormat={dateFormat}
+              onChange={onDateChange}
+              maxDate={today}
+              labelText={t('dateOfBirthLabelText', 'Date of Birth')}
+              invalid={!!(birthdateMeta.touched && birthdateMeta.error)}
+              invalidText={birthdateMeta.error && t(birthdateMeta.error)}
+              value={birthdate.value}
+              carbonOptions={{
+                placeholder: placeHolder,
+              }}
+            />
           </div>
         ) : (
           <div className={styles.grid}>

--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
@@ -6,6 +6,7 @@ import { DobField } from './dob.component';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import { initialFormValues } from '../../patient-registration.component';
 import { type FormValues } from '../../patient-registration.types';
+import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -19,6 +20,18 @@ jest.mock('@openmrs/esm-framework', () => {
         },
       },
     })),
+    getLocale: jest.fn().mockReturnValue('en'),
+    OpenmrsDatePicker: (datePickerProps) => (
+      <OpenmrsDatePicker
+        id={datePickerProps.id}
+        dateFormat={datePickerProps.dateFormat}
+        onChange={datePickerProps.onChange}
+        maxDate={datePickerProps.maxDate}
+        labelText={datePickerProps.labelText}
+        value={datePickerProps.value}
+        carbonOptions={datePickerProps.carbonOptions}
+      />
+    ),
   };
 });
 

--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.test.tsx
@@ -6,7 +6,6 @@ import { DobField } from './dob.component';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import { initialFormValues } from '../../patient-registration.component';
 import { type FormValues } from '../../patient-registration.types';
-import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -21,17 +20,6 @@ jest.mock('@openmrs/esm-framework', () => {
       },
     })),
     getLocale: jest.fn().mockReturnValue('en'),
-    OpenmrsDatePicker: (datePickerProps) => (
-      <OpenmrsDatePicker
-        id={datePickerProps.id}
-        dateFormat={datePickerProps.dateFormat}
-        onChange={datePickerProps.onChange}
-        maxDate={datePickerProps.maxDate}
-        labelText={datePickerProps.labelText}
-        value={datePickerProps.value}
-        carbonOptions={datePickerProps.carbonOptions}
-      />
-    ),
   };
 });
 

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Form, Formik } from 'formik';
 import { render, screen } from '@testing-library/react';
 import { useConfig } from '@openmrs/esm-framework';
+import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
 import { Field } from './field.component';
 import type { AddressTemplate, FormValues } from '../patient-registration.types';
 import { type Resources, ResourcesContext } from '../../offline.resources';
@@ -10,6 +11,18 @@ import { PatientRegistrationContext } from '../patient-registration-context';
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   useConfig: jest.fn(),
+  getLocale: jest.fn().mockReturnValue('en'),
+  OpenmrsDatePicker: (datePickerProps) => (
+    <OpenmrsDatePicker
+      id={datePickerProps.id}
+      dateFormat={datePickerProps.dateFormat}
+      onChange={datePickerProps.onChange}
+      maxDate={datePickerProps.maxDate}
+      labelText={datePickerProps.labelText}
+      value={datePickerProps.value}
+      carbonOptions={datePickerProps.carbonOptions}
+    />
+  ),
 }));
 
 const predefinedAddressTemplate = {

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Form, Formik } from 'formik';
 import { render, screen } from '@testing-library/react';
 import { useConfig } from '@openmrs/esm-framework';
-import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
 import { Field } from './field.component';
 import type { AddressTemplate, FormValues } from '../patient-registration.types';
 import { type Resources, ResourcesContext } from '../../offline.resources';
@@ -12,17 +11,6 @@ jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   useConfig: jest.fn(),
   getLocale: jest.fn().mockReturnValue('en'),
-  OpenmrsDatePicker: (datePickerProps) => (
-    <OpenmrsDatePicker
-      id={datePickerProps.id}
-      dateFormat={datePickerProps.dateFormat}
-      onChange={datePickerProps.onChange}
-      maxDate={datePickerProps.maxDate}
-      labelText={datePickerProps.labelText}
-      value={datePickerProps.value}
-      carbonOptions={datePickerProps.carbonOptions}
-    />
-  ),
 }));
 
 const predefinedAddressTemplate = {

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -11,7 +11,6 @@ import { PatientRegistration } from './patient-registration.component';
 import { saveEncounter, savePatient } from './patient-registration.resource';
 import { mockedAddressTemplate } from '__mocks__';
 import { mockPatient } from 'tools';
-import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
 
 const mockedUseConfig = useConfig as jest.Mock;
 const mockedUsePatient = usePatient as jest.Mock;
@@ -102,17 +101,6 @@ jest.mock('@openmrs/esm-framework', () => {
     ...originalModule,
     validator: jest.fn(),
     getLocale: jest.fn().mockReturnValue('en'),
-    OpenmrsDatePicker: (datePickerProps) => (
-      <OpenmrsDatePicker
-        id={datePickerProps.id}
-        dateFormat={datePickerProps.dateFormat}
-        onChange={datePickerProps.onChange}
-        maxDate={datePickerProps.maxDate}
-        labelText={datePickerProps.labelText}
-        value={datePickerProps.value}
-        carbonOptions={datePickerProps.carbonOptions}
-      />
-    ),
   };
 });
 

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -11,6 +11,7 @@ import { PatientRegistration } from './patient-registration.component';
 import { saveEncounter, savePatient } from './patient-registration.resource';
 import { mockedAddressTemplate } from '__mocks__';
 import { mockPatient } from 'tools';
+import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
 
 const mockedUseConfig = useConfig as jest.Mock;
 const mockedUsePatient = usePatient as jest.Mock;
@@ -101,6 +102,17 @@ jest.mock('@openmrs/esm-framework', () => {
     ...originalModule,
     validator: jest.fn(),
     getLocale: jest.fn().mockReturnValue('en'),
+    OpenmrsDatePicker: (datePickerProps) => (
+      <OpenmrsDatePicker
+        id={datePickerProps.id}
+        dateFormat={datePickerProps.dateFormat}
+        onChange={datePickerProps.onChange}
+        maxDate={datePickerProps.maxDate}
+        labelText={datePickerProps.labelText}
+        value={datePickerProps.value}
+        carbonOptions={datePickerProps.carbonOptions}
+      />
+    ),
   };
 });
 
@@ -405,7 +417,7 @@ describe('Updating an existing patient record', () => {
     expect(givenNameInput.value).toBe('John');
     expect(familyNameInput.value).toBe('Wilson');
     expect(middleNameInput.value).toBeFalsy();
-    expect(dateOfBirthInput.value).toBe('4/4/1972');
+    expect(dateOfBirthInput.value).toBe('04/04/1972');
     expect(genderInput.value).toBe('male');
 
     // do some edits

--- a/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
@@ -5,6 +5,7 @@ import { initialFormValues } from '../../patient-registration.component';
 import { DemographicsSection } from './demographics-section.component';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import { type FormValues } from '../../patient-registration.types';
+import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -15,6 +16,18 @@ jest.mock('@openmrs/esm-framework', () => {
     useConfig: jest.fn().mockImplementation(() => ({
       fieldConfigurations: { dateOfBirth: { useEstimatedDateOfBirth: { enabled: true, dayOfMonth: 0, month: 0 } } },
     })),
+    getLocale: jest.fn().mockReturnValue('en'),
+    OpenmrsDatePicker: (datePickerProps) => (
+      <OpenmrsDatePicker
+        id={datePickerProps.id}
+        dateFormat={datePickerProps.dateFormat}
+        onChange={datePickerProps.onChange}
+        maxDate={datePickerProps.maxDate}
+        labelText={datePickerProps.labelText}
+        value={datePickerProps.value}
+        carbonOptions={datePickerProps.carbonOptions}
+      />
+    ),
   };
 });
 

--- a/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
@@ -5,7 +5,6 @@ import { initialFormValues } from '../../patient-registration.component';
 import { DemographicsSection } from './demographics-section.component';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import { type FormValues } from '../../patient-registration.types';
-import { OpenmrsDatePicker } from '@openmrs/esm-styleguide/src/public';
 
 jest.mock('@openmrs/esm-framework', () => {
   const originalModule = jest.requireActual('@openmrs/esm-framework');
@@ -17,17 +16,6 @@ jest.mock('@openmrs/esm-framework', () => {
       fieldConfigurations: { dateOfBirth: { useEstimatedDateOfBirth: { enabled: true, dayOfMonth: 0, month: 0 } } },
     })),
     getLocale: jest.fn().mockReturnValue('en'),
-    OpenmrsDatePicker: (datePickerProps) => (
-      <OpenmrsDatePicker
-        id={datePickerProps.id}
-        dateFormat={datePickerProps.dateFormat}
-        onChange={datePickerProps.onChange}
-        maxDate={datePickerProps.maxDate}
-        labelText={datePickerProps.labelText}
-        value={datePickerProps.value}
-        carbonOptions={datePickerProps.carbonOptions}
-      />
-    ),
   };
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,9 +2857,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-api@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-api@npm:5.5.1-pre.1771"
+"@openmrs/esm-api@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-api@npm:5.6.1-pre.1782"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -2868,17 +2868,17 @@ __metadata:
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: 10/ff9cad79ee62bb08b74c2d074a7d5e93e8e17544d5e05491799c6760401a846c71db0cfea8a8e009b6846886b20f755224e28b050ead3aecefe9143a40579819
+  checksum: 10/5cc89a8f8295be2b257cc9213f16665f04fa9b4c269803dd824caf2cbcd6d905f65cf56486db2179f93486b571c6c14b9f7eb04abbce79db756aa139ea5d4153
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-app-shell@npm:5.5.1-pre.1771"
+"@openmrs/esm-app-shell@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-app-shell@npm:5.6.1-pre.1782"
   dependencies:
     "@carbon/react": "npm:~1.37.0"
-    "@openmrs/esm-framework": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-styleguide": "npm:5.5.1-pre.1771"
+    "@openmrs/esm-framework": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-styleguide": "npm:5.6.1-pre.1782"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -2903,7 +2903,7 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 10/a0f9666603ac4109844cda3549b5dddb44a94e329699247aa00db0abe1f73b17ec10d0127058f4fbbfee8c8d898988e554370fad9122b52aa6b198e198dfedee
+  checksum: 10/179c52e508cfe8dfed42b07f985b2a36e7ca035634121f16fa1e03b0658bb9caec2de056919d9ea41296b2da27924472aa22011f6db5d05d8d9d0b97fcc3f5bf
   languageName: node
   linkType: hard
 
@@ -2926,52 +2926,52 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-config@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-config@npm:5.5.1-pre.1771"
+"@openmrs/esm-config@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-config@npm:5.6.1-pre.1782"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/dddf65bb7e1a8c774df4a7fc775ecbfae313c0fd8be363e0ab83672b60865a885f4e0a526cccca5aa821095455d554aca3428099aca4fe8fd9a1a1b5464d9b50
+  checksum: 10/d8c465d2079fcf2addc1f82948cc57f7b0b17f19903f99322fd0aa8077b6e0dc6348824ba680c4671ccca10f57acf4cc0d0c461b9fdff0702d3a51e9273902f0
   languageName: node
   linkType: hard
 
-"@openmrs/esm-context@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-context@npm:5.5.1-pre.1771"
+"@openmrs/esm-context@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-context@npm:5.6.1-pre.1782"
   dependencies:
     immer: "npm:^10.0.4"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
-  checksum: 10/a854346532c6c3207324a7d11b58b81a7cd3016db434d6b4a1b1f9e9615107d20075a147f51cde0a4cee25e534bb66de2d58f26aeba2727e682eed38897d920e
+  checksum: 10/5dabe80acb0be44def3789f33252e842f608605eae1581bec3640ceb384b15b5a1828c749f5cb1005b5b77ad9af50b521affbe24fcc757c225086c27755eb69c
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.5.1-pre.1771"
+"@openmrs/esm-dynamic-loading@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.6.1-pre.1782"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/a347c01a542fccf6abb7671a3124f9dab1d3ea316e6cc08cfb0e2af939a5c63b6ddfe37afec3e4f007aaba312c5aa5d6be264962ded8315ae1b03c0df0dd0b65
+  checksum: 10/609d4fcce4f51963e757463f598a84019563ff401641ff872c650a742dc23de8e383c18a548daea6985e16ce0f1e3d53f56ee5bf294e442457e26fb9cc86e22e
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-error-handling@npm:5.5.1-pre.1771"
+"@openmrs/esm-error-handling@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-error-handling@npm:5.6.1-pre.1782"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/90037a11b1f943989483644c13f042ce41fba77c19a99f5f4428903747af7760fe32357e84b360d52764a0bae49605bfea0b580ac984fca947226f095caa0184
+  checksum: 10/7645a99c4f41fd19f9218dc2fc0b9c097d7bba6d88f98353da86da9b9a7faace3bc111ca9726b4982abaf75f7f1f027ff14c4c0714ce37764254eda6b53580a6
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-extensions@npm:5.5.1-pre.1771"
+"@openmrs/esm-extensions@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-extensions@npm:5.6.1-pre.1782"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -2981,43 +2981,43 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-utils": 5.x
     single-spa: 5.x
-  checksum: 10/e5e1af846157262263abb7287867cd97dd35025a70d7c89e43e6a85fbbc4f28be790ff8b5c6a85db80db532d1e2e1c850c3c729e4d50f7cd43936a63f276ce97
+  checksum: 10/ef658be382b086c4cdfcb849908a756e92e781afb58c413b67a136d284fc03e453874dbbf4bb1bee473e05c37dd46a72add79b08af9b0591a592af2b73701306
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-feature-flags@npm:5.5.1-pre.1771"
+"@openmrs/esm-feature-flags@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-feature-flags@npm:5.6.1-pre.1782"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 10/e83b92dc94a226892325cd0b9de790e914e922c9fb0a1fa853286700dcf0370de296b18635b5512a4431abf06cbc5654581fe204784b02e198d6b1d5a0a17675
+  checksum: 10/38c53d73685d42f616714adfa9c73dba78d6d15f9a7d1d699685e80576572fbda35f8041421f83ebd112e27a8468244d524f4d8274039067631141aa0049b5d8
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:5.5.1-pre.1771, @openmrs/esm-framework@npm:next":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-framework@npm:5.5.1-pre.1771"
+"@openmrs/esm-framework@npm:5.6.1-pre.1782, @openmrs/esm-framework@npm:next":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-framework@npm:5.6.1-pre.1782"
   dependencies:
-    "@openmrs/esm-api": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-config": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-context": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-dynamic-loading": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-error-handling": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-extensions": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-feature-flags": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-globals": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-navigation": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-offline": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-react-utils": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-routes": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-state": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-styleguide": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-translations": "npm:5.5.1-pre.1771"
-    "@openmrs/esm-utils": "npm:5.5.1-pre.1771"
+    "@openmrs/esm-api": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-config": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-context": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-dynamic-loading": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-error-handling": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-extensions": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-feature-flags": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-globals": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-navigation": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-offline": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-react-utils": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-routes": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-state": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-styleguide": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-translations": "npm:5.6.1-pre.1782"
+    "@openmrs/esm-utils": "npm:5.6.1-pre.1782"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
@@ -3028,33 +3028,33 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: 10/89ee6f3aa9e383997105912a2697d3cdb5aa8c910625a707be2a97631236837dde55808d9bd5359910fc4c53f803b84913fedc5f54206bfa2c7fe492ff64e094
+  checksum: 10/df4b2a37de2cbccf668345600dc00b9ecda5576b47b5696e3af9e4fa7f1279e52c83dc5290ea4b1b3912acc01100785c8efe48599d11fe86f9002ccb7bb7f8be
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-globals@npm:5.5.1-pre.1771"
+"@openmrs/esm-globals@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-globals@npm:5.6.1-pre.1782"
   peerDependencies:
     single-spa: 5.x
-  checksum: 10/7fa764687c5843a23b2c9501b9c72cda175e923570f6f5b42608ce894a14071ce8076654ee51e9991e6ff33fedfa1586ca0c9757f7d5447867beb6e9d225ff0a
+  checksum: 10/6418a4e00c02a25afcaae63d48911c7bd8aed97829e0d3052551ccf7deb65eb00f7148264bb4920de9a068d143e27109bc2c21de4e996cf739cfa0a8f5ea9628
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-navigation@npm:5.5.1-pre.1771"
+"@openmrs/esm-navigation@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-navigation@npm:5.6.1-pre.1782"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 5.x
-  checksum: 10/8f7685fba6e3ad9b2049ba91ea249f58b48111123c778ee08e7e249adac7b7c28ba4bb2bc37a1b056972876e205d6899e4970d734649d8f300ce52fdde9544d0
+  checksum: 10/312106392f160f7cb3117e501450a0e2cb44d2d52d3668438aa912130b20aecb8cb68ea4a7842783da6ae7227c9aff7ae82c94bfd3b48469cf5412f7cc3386d1
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-offline@npm:5.5.1-pre.1771"
+"@openmrs/esm-offline@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-offline@npm:5.6.1-pre.1782"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -3065,7 +3065,7 @@ __metadata:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     rxjs: 6.x
-  checksum: 10/d1f3a953fa7486958316dd9dbdc8952f800724ebc91fc8768e60d8497ccd4a83aff409040456d8d950f3a601de28e463480f76ac88efcca9ff14685a79313ec9
+  checksum: 10/4fd8ff7f15aedf0da0d93ba42df9a70773770f0731b412d9086f38232e0b89da2df0075d778f400aa0d6048a6fd2aa868e62128e84a639d40f685ce543ae197e
   languageName: node
   linkType: hard
 
@@ -3203,9 +3203,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-react-utils@npm:5.5.1-pre.1771"
+"@openmrs/esm-react-utils@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-react-utils@npm:5.6.1-pre.1782"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:^6.0.0"
@@ -3226,17 +3226,17 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/8a83d9336551e912f3f04eed022d19141f08eb2c0e6eab599693483bfb63ad7796e12498a9185992d7b3de5e94c4f06273f3d9e027a56ba9fae2a4506128d7d5
+  checksum: 10/cf619462e93d3b358be3cabfcfb9dff0bfaadb3e5185e62b7709302c3889c7e3c456282f5d34b0c86a3c407ed41080537d5b77f2cd4483a2e172a38519d3db91
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-routes@npm:5.5.1-pre.1771"
+"@openmrs/esm-routes@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-routes@npm:5.6.1-pre.1782"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
-  checksum: 10/fd5ffa78fa019c0553283450ffb9ada8b19a504e491379f30148b443068d6aa2cb6ec747ec91a18debf14b254d7c0ab8fb415270073d9f3bd763ddbb0a01cc86
+  checksum: 10/e5e6f50d70aa398bb9ee946aa331441f18fadf6f412048808330d52865aed46230de1434ab7f2c00d6dbbdcc8db245e1adea1254df9ab2bf8635ab2b0a4c651b
   languageName: node
   linkType: hard
 
@@ -3256,20 +3256,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-state@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-state@npm:5.5.1-pre.1771"
+"@openmrs/esm-state@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-state@npm:5.6.1-pre.1782"
   dependencies:
     zustand: "npm:^4.3.6"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 10/b1ec5565d4d89bf582c60d3a881fa41e3cb71d022b77a9bcf103db2d7d17f8210eacdde6c18a3724cde43b47e4f88fd46cac3cd077215e29ff61db8ece9a4c9b
+  checksum: 10/6597605c302bfa2cc35003dfa0978ec9a65eacd16e2fb8ee28a40fd6ee504876a27d17e0b6f4a062b4f863a612e7f974ca835cf754d9c3e7d4940f3ab08d6349
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-styleguide@npm:5.5.1-pre.1771"
+"@openmrs/esm-styleguide@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-styleguide@npm:5.6.1-pre.1782"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
@@ -3294,24 +3294,24 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: 10/4174887b196e4446f6b0cb98b8da58c70c43b2a32933020ddfc44d2ec76f19aad7a9f8b15c26c638351a53214bbf44eedfff63c58cba05e31929adfd40304615
+  checksum: 10/7b7015f43f00f53152a02237affe2a3d950da02bc68736877d56202ecc75b0e6b0ad6c426fb77df84b039f1341049e46860018f917fa0b0a17601163e1442b51
   languageName: node
   linkType: hard
 
-"@openmrs/esm-translations@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-translations@npm:5.5.1-pre.1771"
+"@openmrs/esm-translations@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-translations@npm:5.6.1-pre.1782"
   dependencies:
     i18next: "npm:21.10.0"
   peerDependencies:
     i18next: 21.x
-  checksum: 10/219d9b8ee96f5979547674a599403363f44d372fb0fd5e20d51a7398e501734af5e17be3a843f1e8bb29ee05b5942d97e3e30fb1ec32cf6e318d96655f1e6800
+  checksum: 10/4e08e6f7d13f3823ab931480b0b5612b2d5c6f8b134ab7cd02ddab6963f19b1de9fa7cd43349257c3d3ab9e64248ceb7341d9d7da70602f5a49307d20a02964a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/esm-utils@npm:5.5.1-pre.1771"
+"@openmrs/esm-utils@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/esm-utils@npm:5.6.1-pre.1782"
   dependencies:
     semver: "npm:7.3.2"
   peerDependencies:
@@ -3319,13 +3319,13 @@ __metadata:
     dayjs: 1.x
     i18next: 21.x
     rxjs: 6.x
-  checksum: 10/0df7eb8632c1546f9592908a12a0c45cfed20d1085c03a3154c8eb9919b1c82c7b46c4e223112ffb6f966494b797c7cb8af040bede1e6503a5087a94ba52690d
+  checksum: 10/ed0884c4438d930185fd86088800b8f918f04ab33102f8b77ab4ae26d9072a1e7f348c170db440c6afca8be9bf425f3c0dd2017a460857ab6b6232d8dd7db621
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.5.1-pre.1771":
-  version: 5.5.1-pre.1771
-  resolution: "@openmrs/webpack-config@npm:5.5.1-pre.1771"
+"@openmrs/webpack-config@npm:5.6.1-pre.1782":
+  version: 5.6.1-pre.1782
+  resolution: "@openmrs/webpack-config@npm:5.6.1-pre.1782"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -3342,7 +3342,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: 10/888faabb8dc0069e2b44115c02ac339753efb58a375f57e5d74476f7f034e04f4418351599fa00d59b2bcdd126ef98c35e481d85c877281f5f579eb45c310fa3
+  checksum: 10/75d98df08f9c0ba91ab8b11df72312ba6bbc34744f91d169009549207465d0efb90ae9c4be35989f73c611fc81a5e63cd83a3ae9a48f757cf30ba9ab000875db
   languageName: node
   linkType: hard
 
@@ -13176,12 +13176,12 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 5.5.1-pre.1771
-  resolution: "openmrs@npm:5.5.1-pre.1771"
+  version: 5.6.1-pre.1782
+  resolution: "openmrs@npm:5.6.1-pre.1782"
   dependencies:
     "@carbon/icons-react": "npm:11.26.0"
-    "@openmrs/esm-app-shell": "npm:5.5.1-pre.1771"
-    "@openmrs/webpack-config": "npm:5.5.1-pre.1771"
+    "@openmrs/esm-app-shell": "npm:5.6.1-pre.1782"
+    "@openmrs/webpack-config": "npm:5.6.1-pre.1782"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.2"
@@ -13212,7 +13212,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 10/60895682b3eb4abdb85f343e8e878f38d3e7777b5f610ec1bfa1ac4d29fb713927efc6d129878bd531cdbc09c968e28252466ef4920a5b7307606d2f3d2e30cb
+  checksum: 10/bed9a6b4954b2e0d3227285b860ec66fb222f575c8993cce6358e76d9029198142c1b461c190b1b29646ec344972772ba30cbcc037dc8a3cf827f5b2f3798a46
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR wires up the Date of Birth field in the registration form to use the locale-aware [OpenmrsDatePicker](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs/openmrs-date-picker.component.tsx) component from Core. The OpenmrsDatePicker component is wired to render the default Carbon OpenMRS datepicker for all locales other than  `am` (Amharic), `am_ET` (Amharic Ethiopia), and `ti_ET` (Tigrinya Ethiopia). For these Ethiopic locales, a datepicker based on React Spectrum with support for the Ethiopic calendar is rendered instead.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
