### PR TITLE
O3-2115: Use formatted patient display name throughout esm-service-queues-app

### DIFF
--- a/packages/esm-service-queues-app/src/patient-info/patient-info.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-info/patient-info.component.tsx
@@ -23,7 +23,7 @@ interface PatientInfoProps {
 const PatientInfo: React.FC<PatientInfoProps> = ({ patient, handlePatientInfoClick }) => {
   const { t } = useTranslation();
   const [showContactDetails, setShowContactDetails] = useState<boolean>(false);
-  const patientName = `${patient.name?.[0].given?.join(' ')} ${patient?.name?.[0].family}`;
+  const patientName = patient.name?.[0]?.text ?? `${patient.name?.[0].given?.join(' ')} ${patient?.name?.[0].family}`;
 
   const toggleShowMore = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/packages/esm-service-queues-app/src/patient-info/patient-info.test.tsx
+++ b/packages/esm-service-queues-app/src/patient-info/patient-info.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
 import { age } from '@openmrs/esm-framework';
-import { mockPatient } from 'tools';
+import { mockPatient, mockPatientWithLongName, mockPatientWithoutFormattedName } from 'tools';
 import PatientInfo from './patient-info.component';
 
 const mockAge = age as jest.Mock;
@@ -16,14 +16,18 @@ jest.mock('@openmrs/esm-framework', () => {
 });
 
 describe('Patient Info', () => {
-  test('should render patient info correctly', async () => {
+  it.each([
+    [mockPatient, 'Wilson, John'],
+    [mockPatientWithLongName, 'family name, Some very long given name'],
+    [mockPatientWithoutFormattedName, 'given middle family name'],
+  ])(`should render patient info correctly`, async (patient, displayName) => {
     const user = userEvent.setup();
 
     mockAge.mockReturnValue(35);
 
-    renderPatientInfo();
+    renderPatientInfo(patient);
 
-    expect(screen.getByText(/John Wilson/)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(displayName))).toBeInTheDocument();
     expect(screen.getByText(/35/)).toBeInTheDocument();
     expect(screen.getByText(/Male/i)).toBeInTheDocument();
     expect(screen.getByText(/04 — Apr — 1972/i)).toBeInTheDocument();
@@ -34,6 +38,6 @@ describe('Patient Info', () => {
   });
 });
 
-const renderPatientInfo = () => {
-  render(<PatientInfo handlePatientInfoClick={() => {}} patient={mockPatient} />);
+const renderPatientInfo = (patient) => {
+  render(<PatientInfo handlePatientInfoClick={() => {}} patient={patient} />);
 };

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -2,6 +2,7 @@ export {
   getByTextWithMarkup,
   mockPatient,
   mockPatientWithLongName,
+  mockPatientWithoutFormattedName,
   patientChartBasePath,
   renderWithSwr,
   waitForLoadingToFinish,

--- a/tools/test-utils.tsx
+++ b/tools/test-utils.tsx
@@ -70,6 +70,7 @@ const mockPatient = {
       use: 'usual',
       family: 'Wilson',
       given: ['John'],
+      text: 'Wilson, John',
     },
   ],
   gender: 'male',
@@ -86,6 +87,19 @@ const mockPatientWithLongName = {
       use: 'usual',
       family: 'family name',
       given: ['Some very long given name'],
+      text: 'family name, Some very long given name',
+    },
+  ],
+};
+
+const mockPatientWithoutFormattedName = {
+  ...mockPatient,
+  name: [
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
+      use: 'usual',
+      family: 'family name',
+      given: ['given', 'middle'],
     },
   ],
 };
@@ -98,5 +112,6 @@ export {
   getByTextWithMarkup,
   mockPatient,
   mockPatientWithLongName,
+  mockPatientWithoutFormattedName,
   patientChartBasePath,
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [X] My work includes tests or is validated by existing tests.  

## Summary
Despite the fact that a well-formatted patient display name is included in REST and FHIR responses, the service queue patient info component was displaying a patient name with a hard-coded format.

Evident if using an alternative name format, e.g. `latinamerica`, as per [Wiki: Customizing Name Layouts](https://openmrs.atlassian.net/wiki/spaces/docs/pages/25477289/Customizing+Name+Layouts)

The well-formatted patient display name is included as a `name.text` attribute in FHIR responses, as per [FM2-631](https://openmrs.atlassian.net/browse/FM2-631), or as the `user.person.display` attribute in REST responses as per [RESTWS-925](https://openmrs.atlassian.net/browse/RESTWS-925).

## Screenshots
N/A

## Related Issue
https://openmrs.atlassian.net/browse/O3-2115

## Other
Similar fixes needed for some components in esm-patient-search-app (#1141); esm-appointments-app (#1142); esm-patient-registration-app. To be delivered in separate PRs.
