### PR TITLE
(feat) O3-3083: Show skeletons when loading queues and queue locations

### DIFF
--- a/packages/esm-service-queues-app/src/add-patient-toqueue/add-patient-toqueue-dialog.component.tsx
+++ b/packages/esm-service-queues-app/src/add-patient-toqueue/add-patient-toqueue-dialog.component.tsx
@@ -20,6 +20,8 @@ import { useQueueLocations } from '../patient-search/hooks/useQueueLocations';
 import { useQueues } from '../hooks/useQueues';
 import { useMutateQueueEntries } from '../hooks/useMutateQueueEntries';
 import { type ConfigObject } from '../config-schema';
+import { RadioButtonSkeleton } from '@carbon/react';
+import { SelectSkeleton } from '@carbon/react';
 
 interface AddVisitToQueueDialogProps {
   visitDetails: ActiveVisit;
@@ -36,8 +38,8 @@ const AddVisitToQueue: React.FC<AddVisitToQueueDialogProps> = ({ visitDetails, c
   const patientAge = visitDetails?.age;
   const patientSex = visitDetails?.gender;
   const [selectedQueueLocation, setSelectedQueueLocation] = useState('');
-  const { queues } = useQueues(selectedQueueLocation);
-  const { queueLocations } = useQueueLocations();
+  const { queues, isLoading: isLoadingQueues } = useQueues(selectedQueueLocation);
+  const { queueLocations, isLoading: isLoadingQueueLocations } = useQueueLocations();
   const [isMissingPriority, setIsMissingPriority] = useState(false);
   const [isMissingService, setIsMissingService] = useState(false);
   const config = useConfig<ConfigObject>();
@@ -118,40 +120,48 @@ const AddVisitToQueue: React.FC<AddVisitToQueueDialogProps> = ({ visitDetails, c
             </h5>
           </div>
           <section>
-            <Select
-              labelText={t('selectQueueLocation', 'Select a queue location')}
-              id="location"
-              invalidText="Required"
-              value={selectedQueueLocation}
-              onChange={(event) => setSelectedQueueLocation(event.target.value)}>
-              {!selectedQueueLocation ? (
-                <SelectItem text={t('selectQueueLocation', 'Select a queue location')} value="" />
-              ) : null}
-              {queueLocations?.length > 0 &&
-                queueLocations.map((location) => (
-                  <SelectItem key={location.id} text={location.name} value={location.id}>
-                    {location.name}
-                  </SelectItem>
-                ))}
-            </Select>
+            {isLoadingQueueLocations ? (
+              <SelectSkeleton />
+            ) : (
+              <Select
+                labelText={t('selectQueueLocation', 'Select a queue location')}
+                id="location"
+                invalidText="Required"
+                value={selectedQueueLocation}
+                onChange={(event) => setSelectedQueueLocation(event.target.value)}>
+                {!selectedQueueLocation ? (
+                  <SelectItem text={t('selectQueueLocation', 'Select a queue location')} value="" />
+                ) : null}
+                {queueLocations?.length > 0 &&
+                  queueLocations.map((location) => (
+                    <SelectItem key={location.id} text={location.name} value={location.id}>
+                      {location.name}
+                    </SelectItem>
+                  ))}
+              </Select>
+            )}
           </section>
 
           <section className={styles.section}>
             <div className={styles.sectionTitle}>{t('queueService', 'Queue service')}</div>
-            <Select
-              labelText={t('selectService', 'Select a service')}
-              id="service"
-              invalidText="Required"
-              value={queueUuid}
-              onChange={(event) => setQueueUuid(event.target.value)}>
-              {!queueUuid ? <SelectItem text={t('chooseService', 'Select a service')} value="" /> : null}
-              {queues?.length > 0 &&
-                queues.map((service) => (
-                  <SelectItem key={service.uuid} text={service.display} value={service.uuid}>
-                    {service.display}
-                  </SelectItem>
-                ))}
-            </Select>
+            {isLoadingQueues ? (
+              <SelectSkeleton />
+            ) : (
+              <Select
+                labelText={t('selectService', 'Select a service')}
+                id="service"
+                invalidText="Required"
+                value={queueUuid}
+                onChange={(event) => setQueueUuid(event.target.value)}>
+                {!queueUuid ? <SelectItem text={t('chooseService', 'Select a service')} value="" /> : null}
+                {queues?.length > 0 &&
+                  queues.map((service) => (
+                    <SelectItem key={service.uuid} text={service.display} value={service.uuid}>
+                      {service.display}
+                    </SelectItem>
+                  ))}
+              </Select>
+            )}
           </section>
           {isMissingService && (
             <section>
@@ -166,7 +176,13 @@ const AddVisitToQueue: React.FC<AddVisitToQueueDialogProps> = ({ visitDetails, c
 
           <section className={styles.section}>
             <div className={styles.sectionTitle}>{t('queueStatus', 'Queue status')}</div>
-            {!priorities?.length ? (
+            {isLoadingQueues ? (
+              <RadioButtonGroup>
+                <RadioButtonSkeleton />
+                <RadioButtonSkeleton />
+                <RadioButtonSkeleton />
+              </RadioButtonGroup>
+            ) : !priorities?.length ? (
               <InlineNotification
                 className={styles.inlineNotification}
                 kind={'error'}

--- a/packages/esm-service-queues-app/src/patient-search/patient-scheduled-visits.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/patient-scheduled-visits.component.tsx
@@ -64,7 +64,7 @@ const ScheduledVisits: React.FC<{
   const [userLocation, setUserLocation] = useState('');
   const locations = useLocations();
   const session = useSession();
-  const { queues } = useQueues(userLocation);
+  const { queues, isLoading: isLoadingQueues } = useQueues(userLocation);
   const { mutateQueueEntries } = useMutateQueueEntries();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [timeFormat, setTimeFormat] = useState<amPm>(new Date().getHours() >= 12 ? 'PM' : 'AM');
@@ -224,7 +224,7 @@ const ScheduledVisits: React.FC<{
 
                     {!visit.service ? (
                       <DataTableSkeleton />
-                    ) : !priorities?.length ? (
+                    ) : isLoadingQueues ? null : !priorities?.length ? (
                       <InlineNotification
                         className={styles.inlineNotification}
                         kind={'error'}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR looks into the missed-out scenarios in the previous PR #1125. We display the respective skeletons when data is being fetched.

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/51502471/e070d1bf-cdee-4539-b5f5-118702a41ec4)


## Related Issue
https://issues.openmrs.org/browse/O3-3083

## Other
<!-- Anything not covered above -->
