### PR TITLE
(fix)O3-3221: All the available location should be displayed

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -127,7 +127,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
       : 'AM';
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
-  const locations = useLocations(appointmentLocationTagName);
+  const locations = useLocations();
   const providers = useProviders();
   const session = useSession();
   const { selectedDate } = useContext(SelectedDateContext);


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I removed the `appointmentLocationTagName` tag associated with appointment locations that is used within the useLocations hook to filter or identify specific locations related to appointments instead of displaying all the the available locations


## Screenshots


https://github.com/openmrs/openmrs-esm-patient-management/assets/33891016/cf4ae5c4-6662-47c7-8262-b8981b3b95b9


## Related Issue
https://openmrs.atlassian.net/browse/O3-3221

## Other
<!-- Anything not covered above -->
