### PR TITLE
(feat) O3-3207: Navigate to appointments on clicking day section from appointments calendar

### DIFF
--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view.component.tsx
@@ -50,6 +50,7 @@ const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({ dateTime, eve
 
   return (
     <div
+      onClick={() => navigateToAppointmentsByDate('')}
       className={classNames(
         styles[isSameMonth(dateTime, dayjs(selectedDate)) ? 'monthly-cell' : 'monthly-cell-disabled'],
         showAllServices
@@ -61,7 +62,7 @@ const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({ dateTime, eve
       )}>
       {isSameMonth(dateTime, dayjs(selectedDate)) && (
         <p>
-          <div className={classNames(styles.totals)} onClick={() => navigateToAppointmentsByDate('')}>
+          <div className={classNames(styles.totals)}>
             {currentData?.services ? (
               <div role="button" tabIndex={0}>
                 <User size={16} />


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
PR adds that one can navigate to appointments of a given day, when clicking that day section from the appointments calendar

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/openmrs/openmrs-esm-patient-management/assets/53287480/84988517-de66-4a0e-8178-3cd2d69dedca

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
[O3-3207](https://openmrs.atlassian.net/browse/O3-3207)

[O3-3207]: https://openmrs.atlassian.net/browse/O3-3207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ