### PR TITLE
(feat) O3-2991 Registration obs should support Date type obs

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -12,6 +12,7 @@ export interface FieldDefinition {
   label?: string;
   uuid: string;
   placeholder?: string;
+  dateFormat?: string;
   showHeading: boolean;
   validation?: {
     required: boolean;

--- a/packages/esm-patient-registration-app/src/patient-registration/field/obs/obs-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/obs/obs-field.component.tsx
@@ -1,14 +1,16 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import { Field } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { InlineNotification, Layer, Select, SelectItem } from '@carbon/react';
-import { useConfig } from '@openmrs/esm-framework';
+import { OpenmrsDatePicker, parseDate, useConfig } from '@openmrs/esm-framework';
 import { type ConceptResponse } from '../../patient-registration.types';
 import { type FieldDefinition, type RegistrationConfig } from '../../../config-schema';
 import { Input } from '../../input/basic-input/input/input.component';
 import { useConcept, useConceptAnswers } from '../field.resource';
 import styles from './../field.scss';
+import { PatientRegistrationContext } from '../../patient-registration-context';
+import { generateFormatting } from '../../date-util';
 
 export interface ObsFieldProps {
   fieldDefinition: FieldDefinition;
@@ -49,6 +51,16 @@ export function ObsField({ fieldDefinition }: ObsFieldProps) {
           concept={concept}
           label={fieldDefinition.label}
           required={fieldDefinition.validation.required}
+        />
+      );
+    case 'Date':
+      return (
+        <DateObsField
+          concept={concept}
+          label={fieldDefinition.label}
+          required={fieldDefinition.validation.required}
+          dateFormat={fieldDefinition.dateFormat}
+          placeholder={fieldDefinition.placeholder}
         />
       );
     case 'Coded':
@@ -142,6 +154,57 @@ function NumericObsField({ concept, label, required }: NumericObsFieldProps) {
         }}
       </Field>
     </div>
+  );
+}
+
+interface DateObsFieldProps {
+  concept: ConceptResponse;
+  label: string;
+  required?: boolean;
+  dateFormat?: string;
+  placeholder?: string;
+}
+
+function DateObsField({ concept, label, required, placeholder }: DateObsFieldProps) {
+  const { t } = useTranslation();
+  const fieldName = `obs.${concept.uuid}`;
+  const { setFieldValue } = useContext(PatientRegistrationContext);
+  const { format, placeHolder, dateFormat } = generateFormatting(['d', 'm', 'Y'], '/');
+
+  const onDateChange = useCallback(
+    (date: Date) => {
+      //const refinedDate = date instanceof Date ? new Date(date.setHours(0, 0, 0, 0)) : date;
+      setFieldValue(fieldName, date);
+    },
+    [setFieldValue],
+  );
+
+  return (
+    <Layer>
+      <div className={styles.dobField}>
+        <Field name={fieldName}>
+          {({ field, form: { touched, errors }, meta }) => {
+            const dateValue = field.value ? parseDate(field.value) : field.value;
+            return (
+              <OpenmrsDatePicker
+                id={fieldName}
+                {...field}
+                required={required}
+                dateFormat={dateFormat}
+                onChange={onDateChange}
+                labelText={label ?? concept.display}
+                invalid={errors[fieldName] && touched[fieldName]}
+                invalidText={meta.error && t(meta.error)}
+                value={dateValue}
+                carbonOptions={{
+                  placeholder: placeholder ?? placeHolder,
+                }}
+              />
+            );
+          }}
+        </Field>
+      </div>
+    </Layer>
   );
 }
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR introduces the ability to capture obs of type `Date` in patient registration. It uses the `OpenMRSDatepicker` in order to support other locales such as Ethiopia (See video recording attached)

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-management/assets/12844964/599960eb-b184-422a-a43a-0d89cb5c0ddf



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
