### PR TITLE
(fix)O3-3206: Fix the queue entries for followed queue entries responses

### DIFF
--- a/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
+++ b/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
@@ -29,7 +29,7 @@ export function useQueueEntries(searchCriteria?: QueueEntrySearchCriteria, rep: 
         const nextUrl = new URL(previousPageData.data.links.find((link) => link.rel === 'next')?.uri);
         // default for production
         if (nextUrl.origin === window.location.origin) {
-          return nextUrl;
+          return nextUrl.toString();
         }
 
         // in development, the request should be funnelled through the local proxy


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
For the following Queue Entries responses, the URL object needs to be converted to a string before passing it to `openmrsFetch`.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-3206

## Other
None
