### PR TITLE
(fix) O3-2956 Service queues - Sort queues/locations/services alphabetically wherever we list them

### DIFF
--- a/packages/esm-service-queues-app/src/hooks/useQueues.ts
+++ b/packages/esm-service-queues-app/src/hooks/useQueues.ts
@@ -1,6 +1,7 @@
-import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { getLocale, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
 import { type Queue } from '../types';
+import { useMemo } from 'react';
 
 export function useQueues(locationUuid?: string) {
   const customRepresentation =
@@ -9,8 +10,13 @@ export function useQueues(locationUuid?: string) {
 
   const { data, ...rest } = useSWRImmutable<{ data: { results: Array<Queue> } }, Error>(apiUrl, openmrsFetch);
 
+  const queues = useMemo(
+    () => data?.data?.results.sort((a, b) => a.display.localeCompare(b.display, getLocale())) ?? [],
+    [data?.data?.results],
+  );
+
   return {
-    queues: data?.data?.results ?? [],
+    queues,
     ...rest,
   };
 }

--- a/packages/esm-service-queues-app/src/patient-search/hooks/useQueueLocations.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/hooks/useQueueLocations.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { fhirBaseUrl, openmrsFetch } from '@openmrs/esm-framework';
+import { fhirBaseUrl, getLocale, openmrsFetch } from '@openmrs/esm-framework';
 
 interface FHIRResponse {
   entry: Array<{ resource: fhir.Location }>;
@@ -13,8 +13,11 @@ export function useQueueLocations() {
   const { data, error, isLoading } = useSWR<{ data: FHIRResponse }>(apiUrl, openmrsFetch);
 
   const queueLocations = useMemo(
-    () => data?.data?.entry?.map((response) => response.resource) ?? [],
+    () =>
+      data?.data?.entry
+        ?.map((response) => response.resource)
+        .sort((a, b) => a.name.localeCompare(b.name, getLocale())) ?? [],
     [data?.data?.entry],
   );
-  return { queueLocations: queueLocations ? queueLocations : [], isLoading, error };
+  return { queueLocations, isLoading, error };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Sorts queue locations and queues alphabetically. I'm not sure what's meant by "services" here, but when I look for where services are listed, it appears to just be populated with queues. See e.g. [here](https://github.com/openmrs/openmrs-esm-patient-management/blob/79a5ddd923dbf04fbb38f1f3e5a55474c7e7103a/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.component.tsx#L99).

## Screenshots

Before

https://github.com/openmrs/openmrs-esm-patient-management/assets/1031876/1b31b7b3-8c9e-42ba-b962-3e0ee8011bd2

After


https://github.com/openmrs/openmrs-esm-patient-management/assets/1031876/e78efe9c-9969-4add-97b7-32efa18898e5




## Related Issue
https://openmrs.atlassian.net/issues/O3-2956

## Other
<!-- Anything not covered above -->
