### PR TITLE
(feat) O3-3179: Change the styling of the Patient search for deceased patients

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
@@ -3,7 +3,8 @@
 @use '@carbon/styles/scss/type';
 @import '~@openmrs/esm-styleguide/src/vars';
 
-.patientSearchResult {
+.patientSearchResult,
+.deceased.patientSearchResult {
   color: unset !important;
   margin: unset !important;
   text-decoration: none;
@@ -25,25 +26,6 @@
   background: none;
   cursor: pointer;
   width: 100%;
-}
-
-.deceased.patientSearchResult {
-  background-color: colors.$gray-80;
-
-  .patientName {
-    color: $ui-01;
-  }
-
-  .demographics,
-  .patientIdentifiers,
-  .identifierTag {
-    color: $ui-02;
-  }
-
-  &:focus,
-  &:hover {
-    background-color: colors.$gray-90;
-  }
 }
 
 .patientBanner {
@@ -106,10 +88,6 @@
 .configuredLabel {
   @include type.type-style('label-01');
   color: $ui-05;
-}
-
-.deceased .configuredLabel {
-  color: $ui-01;
 }
 
 .flexRow {

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.scss
@@ -3,7 +3,8 @@
 @use '@carbon/styles/scss/type';
 @import '~@openmrs/esm-styleguide/src/vars';
 
-.container {
+.container,
+.deceasedPatientContainer {
   border-bottom: 0.063rem solid $ui-03;
   background-color: $ui-02;
   display: grid;
@@ -18,28 +19,6 @@
   width: 1rem;
   height: 1rem;
   margin-left: 0.5rem;
-}
-
-.deceasedPatientContainer {
-  background-color: colors.$gray-80;
-
-  .patientName {
-    color: $ui-01;
-  }
-
-  .demographics,
-  .identifiers {
-    color: $ui-02;
-  }
-
-  .menu {
-    fill: colors.$blue-40;
-  }
-
-  &:focus,
-  &:hover {
-    background-color: colors.$gray-90;
-  }
 }
 
 .patientBanner {


### PR DESCRIPTION

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The current styling for the deceased patient is too high-contrast so I had to remove all the inverted colour styling for deceased patients and append the Deceased tag to their name in the Patient Header and Visit Header.

## Screenshots

https://github.com/openmrs/openmrs-esm-patient-management/assets/33891016/11f90512-9880-4fb2-8f97-c720142c8756


## Related Issue
https://openmrs.atlassian.net/browse/O3-3179

## Other
<!-- Anything not covered above -->
