### PR TITLE
(feat) Add optional `Date appointment issued` field to the appointment form

### DIFF
--- a/e2e/specs/appointments.spec.ts
+++ b/e2e/specs/appointments.spec.ts
@@ -15,7 +15,7 @@ test.beforeEach(async ({ api }) => {
 test('Add, edit and cancel an appointment', async ({ page, api }) => {
   const appointmentsPage = new AppointmentsPage(page);
 
-  await test.step('When I go to the appointment tab in the patient chart', async () => {
+  await test.step('When I go to the Appointments page in the patient chart', async () => {
     await appointmentsPage.goto(patient.uuid);
   });
 
@@ -39,7 +39,7 @@ test('Add, edit and cancel an appointment', async ({ page, api }) => {
   await test.step('And I set date for tomorrow', async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    await page.fill('input[placeholder="dd/mm/yyyy"]', tomorrow.toLocaleDateString('en-GB'));
+    await page.getByLabel(/^Date$/i).fill(tomorrow.toLocaleDateString('en-GB'));
   });
 
   await test.step('And I set the “Duration” to 60', async () => {
@@ -79,7 +79,7 @@ test('Add, edit and cancel an appointment', async ({ page, api }) => {
   await test.step('And I change the date to Today', async () => {
     const today = new Date();
     today.setDate(today.getDate());
-    await page.fill('input[placeholder="dd/mm/yyyy"]', today.toLocaleDateString('en-GB'));
+    await page.getByLabel(/^Date$/i).fill(today.toLocaleDateString('en-GB'));
   });
 
   await test.step('And I set the “Duration” of the appointment”', async () => {

--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -154,6 +154,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
         recurringPatternEndDateText: z.string().nullable(),
       }),
       formIsRecurringAppointment: z.boolean(),
+      dateAppointmentScheduled: z.date().optional(),
     })
     .refine(
       (formValues) => {
@@ -169,6 +170,10 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
     );
 
   type AppointmentFormData = z.infer<typeof appointmentsFormSchema>;
+
+  const defaultDateAppointmentScheduled = appointment?.dateAppointmentScheduled
+    ? new Date(appointment?.dateAppointmentScheduled)
+    : new Date();
 
   const { control, getValues, setValue, watch, handleSubmit } = useForm<AppointmentFormData>({
     mode: 'all',
@@ -196,6 +201,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
         recurringPatternEndDateText: defaultEndDateText,
       },
       formIsRecurringAppointment: isRecurringAppointment,
+      dateAppointmentScheduled: defaultDateAppointmentScheduled,
     },
   });
 
@@ -328,6 +334,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
       provider,
       appointmentNote,
       appointmentStatus,
+      dateAppointmentScheduled,
     } = data;
 
     const serviceUuid = services?.find((service) => service.name === selectedService)?.uuid;
@@ -348,6 +355,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
       patientUuid: patientUuid,
       comments: appointmentNote,
       uuid: context === 'editing' ? appointment.uuid : undefined,
+      dateAppointmentScheduled: dayjs(dateAppointmentScheduled).format(),
     };
   };
 
@@ -413,6 +421,31 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
                       </SelectItem>
                     ))}
                 </Select>
+              )}
+            />
+          </ResponsiveWrapper>
+        </section>
+        <section className={styles.formGroup}>
+          <span className={styles.heading}>{t('dateScheduled', 'Date appointment issued')}</span>
+          <ResponsiveWrapper>
+            <Controller
+              name="dateAppointmentScheduled"
+              control={control}
+              render={({ field: { onChange, value, ref } }) => (
+                <DatePicker
+                  datePickerType="single"
+                  dateFormat={datePickerFormat}
+                  value={value}
+                  maxDate={new Date()}
+                  onChange={([date]) => onChange(date)}>
+                  <DatePickerInput
+                    id="dateAppointmentScheduledPickerInput"
+                    labelText={t('dateScheduledDetail', 'Date appointment issued')}
+                    style={{ width: '100%' }}
+                    placeholder={datePickerPlaceHolder}
+                    ref={ref}
+                  />
+                </DatePicker>
               )}
             />
           </ResponsiveWrapper>

--- a/packages/esm-appointments-app/src/form/appointments-form.test.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.test.tsx
@@ -107,12 +107,12 @@ describe('AppointmentForm', () => {
     await waitForLoadingToFinish();
 
     expect(screen.getByLabelText(/Select a location/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Date/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Date$/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Select a service/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Select the type of appointment/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Write an additional note/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Write any additional points here/i)).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(/dd\/mm\/yyyy/i)).toBeInTheDocument();
+    expect(screen.getAllByPlaceholderText(/dd\/mm\/yyyy/i).length).toBe(2);
     expect(screen.getByRole('option', { name: /Mosoriot/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Inpatient Ward/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /AM/i })).toBeInTheDocument();
@@ -120,7 +120,7 @@ describe('AppointmentForm', () => {
     expect(screen.getByRole('option', { name: /Choose appointment type/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Scheduled/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /WalkIn/i })).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: /Date/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /^Date$/i })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /Time/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Discard/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Save and close/i })).toBeInTheDocument();
@@ -152,7 +152,7 @@ describe('AppointmentForm', () => {
     await waitForLoadingToFinish();
 
     const saveButton = screen.getByRole('button', { name: /Save and close/i });
-    const dateInput = screen.getByRole('textbox', { name: /Date/i });
+    const dateInput = screen.getByRole('textbox', { name: /^Date$/i });
     const timeInput = screen.getByRole('textbox', { name: /Time/i });
     const timeFormat = screen.getByRole('combobox', { name: /Time/i });
     const serviceSelect = screen.getByRole('combobox', { name: /Select a service/i });
@@ -190,7 +190,7 @@ describe('AppointmentForm', () => {
     await waitForLoadingToFinish();
 
     const saveButton = screen.getByRole('button', { name: /Save and close/i });
-    const dateInput = screen.getByRole('textbox', { name: /Date/i });
+    const dateInput = screen.getByRole('textbox', { name: /^Date$/i });
     const timeInput = screen.getByRole('textbox', { name: /Time/i });
     const timeFormat = screen.getByRole('combobox', { name: /Time/i });
     const serviceSelect = screen.getByRole('combobox', { name: /Select a service/i });

--- a/packages/esm-appointments-app/src/types/index.ts
+++ b/packages/esm-appointments-app/src/types/index.ts
@@ -48,6 +48,7 @@ export interface Appointment {
   recurring: boolean;
   service: AppointmentService;
   startDateTime: string | any;
+  dateAppointmentScheduled: string | any;
   status: AppointmentStatus;
   uuid: string;
   additionalInfo?: string | null;
@@ -120,6 +121,7 @@ export interface Observation {
 export interface AppointmentPayload {
   patientUuid: string;
   serviceUuid: string;
+  dateAppointmentScheduled: string;
   startDateTime: string;
   endDateTime: string;
   appointmentKind: string;

--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -62,6 +62,8 @@
   "date": "Date",
   "date&Time": "Date & time",
   "dateOfBirth": "Date of birth",
+  "dateScheduled": "Date appointment issued",
+  "dateScheduledDetail": "Date appointment issued",
   "dateTime": "Date & Time",
   "day": "Day",
   "daysOfWeek": "Days of the week",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds an optional date field that captures the date when an appointment was issued.

## Screenshots

[Screencast from 05-30-2024 06:00:34 PM.webm](https://github.com/openmrs/openmrs-esm-patient-management/assets/2161877/dedbe5ee-3516-4da5-b68c-3def5e7717ca)

Payload:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/2161877/b1926fad-fc82-4a1e-8d80-461b437d0512)

Response:
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/2161877/8e797d0a-d5c2-4c0c-bbb8-4dd367fb2f57)

## Related Issue
https://openmrs.atlassian.net/browse/O3-3343
https://bahmni.atlassian.net/browse/BAH-3869

## Other
<!-- Anything not covered above -->
