### PR TITLE
(feat) O3-3375: Align visit form queue fields to work in visit start form on patient chart

### DIFF
--- a/packages/esm-service-queues-app/src/index.ts
+++ b/packages/esm-service-queues-app/src/index.ts
@@ -10,6 +10,7 @@ import outpatientSideNavComponent from './side-menu/side-menu.component';
 import homeDashboardComponent from './home.component';
 import patientInfoBannerSlotComponent from './patient-info/patient-info.component';
 import pastVisitSummaryComponent from './past-visit/past-visit.component';
+import VisitFormQueueFields from './patient-search/visit-form-queue-fields/visit-form-queue-fields.component';
 
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
@@ -146,6 +147,8 @@ export const addnewQueueServiceRoomWorkspace = getAsyncLifecycle(
     moduleName,
   },
 );
+
+export const visitFormQueueFields = getSyncLifecycle(VisitFormQueueFields, options);
 
 // t('searchPatient', 'Search Patient')
 export const patientSearchWorkspace = getAsyncLifecycle(() => import('./patient-search/patient-search.workspace'), {

--- a/packages/esm-service-queues-app/src/routes.json
+++ b/packages/esm-service-queues-app/src/routes.json
@@ -97,6 +97,11 @@
       "name": "active-visits-row-actions",
       "component": "activeVisitsRowActions",
       "slot": "queue-table-extension-column-slot"
+    },
+    {
+      "name": "visit-form-queue-fields",
+      "component": "visitFormQueueFields",
+      "slot":"visit-form-queue-slot"
     }
   ],
   "workspaces": [


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Export `VisitFormQueueFields` to enable use on patient chart visit form

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
