### PR TITLE
(feat) 03-3371: Queue services duplicates during queue transition

### DIFF
--- a/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -78,7 +78,9 @@ function ClinicMetrics() {
             type="inline"
             label={currentServiceName ?? `${t('all', 'All')}`}
             items={[{ display: `${t('all', 'All')}` }, ...queues]}
-            itemToString={(item) => (item ? item.display : '')}
+            itemToString={(item) =>
+              item ? `${item.display} ${item.location?.display ? `- ${item.location.display}` : ''}` : ''
+            }
             onChange={handleServiceChange}
           />
         </MetricsCard>

--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.component.tsx
@@ -198,16 +198,16 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({
                 invalidText="Required"
                 value={formState.selectedQueue}
                 onChange={(event) => setSelectedQueueUuid(event.target.value)}>
-                {queues?.map(({ uuid, display }) => (
+                {queues?.map(({ uuid, display, location }) => (
                   <SelectItem
                     key={uuid}
                     text={
                       uuid == queueEntry.queue.uuid
                         ? t('currentValueFormatted', '{{value}} (Current)', {
-                            value: display,
+                            value: `${display} - ${location?.display}`,
                             interpolation: { escapeValue: false },
                           })
-                        : display
+                        : `${display} - ${location?.display}`
                     }
                     value={uuid}
                   />

--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.test.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.test.tsx
@@ -66,7 +66,9 @@ describe('TransitionQueueEntryModal: ', () => {
     // change queue
     const queueDropdown = screen.getByRole('combobox', { name: /Select a queue/ });
     await queueDropdown.click();
-    const queueSelection = screen.getByRole('option', { name: nextQueue.display });
+    const queueSelection = screen.getByRole('option', {
+      name: `${nextQueue.display} - ${nextQueue.location?.display}`,
+    });
     await user.selectOptions(queueDropdown, queueSelection);
 
     // change status
@@ -131,7 +133,9 @@ describe('EditQueueEntryModal: ', () => {
     // change queue
     const queueDropdown = screen.getByRole('combobox', { name: /Select a queue/ });
     await queueDropdown.click();
-    const queueSelection = screen.getByRole('option', { name: nextQueue.display });
+    const queueSelection = screen.getByRole('option', {
+      name: `${nextQueue.display} - ${nextQueue.location?.display}`,
+    });
     await user.selectOptions(queueDropdown, queueSelection);
 
     // change status


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR appends the location of where the service is located. This is where we have service with the same name being offered in different locations. e.g We can have Consultation at MCH, OPD and CCC(HIV). We need to communicate to the user that the service they intend to transition the patient is located at a certain location.

## Screenshots
https://github.com/openmrs/openmrs-esm-patient-management/assets/28008754/a8a9f9ea-96e2-48a4-9818-dfd8bdcecd8b


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
