### PR TITLE
(fix) O3-3336 - Service Queues - fix extension column

### DIFF
--- a/packages/esm-service-queues-app/src/config-schema.ts
+++ b/packages/esm-service-queues-app/src/config-schema.ts
@@ -54,7 +54,7 @@ export const defaultColumnConfig: ColumnConfig = {
   visitQueueNumberAttributeUuid: null,
 };
 
-export const defaultQueueTable = {
+export const defaultQueueTable: TableDefinitions = {
   columns: ['patient-name', 'coming-from', 'priority', 'status', 'queue', 'wait-time', 'actions'],
   appliedTo: [{ queue: null, status: null }],
 };

--- a/packages/esm-service-queues-app/src/queue-table/cells/queue-table-extension-cell.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/cells/queue-table-extension-cell.component.tsx
@@ -4,7 +4,7 @@ import { type QueueTableColumnFunction, type QueueTableCellComponentProps } from
 
 export const queueTableExtensionColumn: QueueTableColumnFunction = (key, header) => {
   const QueueTableExtensionCell = ({ queueEntry }: QueueTableCellComponentProps) => {
-    return <ExtensionSlot name={`queue-table-${key}-slot`} state={queueEntry} />;
+    return <ExtensionSlot name={`queue-table-${key}-slot`} state={{ queueEntry }} />;
   };
 
   return {

--- a/packages/esm-service-queues-app/src/routes.json
+++ b/packages/esm-service-queues-app/src/routes.json
@@ -96,7 +96,7 @@
     {
       "name": "active-visits-row-actions",
       "component": "activeVisitsRowActions",
-      "slot": "queue-table-serve-slot"
+      "slot": "queue-table-serve-patient-slot"
     },
     {
       "name": "visit-form-queue-fields",

--- a/packages/esm-service-queues-app/src/routes.json
+++ b/packages/esm-service-queues-app/src/routes.json
@@ -96,7 +96,7 @@
     {
       "name": "active-visits-row-actions",
       "component": "activeVisitsRowActions",
-      "slot": "queue-table-extension-column-slot"
+      "slot": "queue-table-serve-slot"
     },
     {
       "name": "visit-form-queue-fields",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The queue table supports adding an extension column. This was slightly broken from recent changes. This PR fixes that.

Testing done:
Tested by hard-coding changes to the default config values, see: https://github.com/openmrs/openmrs-esm-patient-management/pull/1176
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
This change will supercede https://github.com/openmrs/openmrs-esm-patient-management/pull/1175.

@donaldkibet The following config should be added in [here](https://github.com/palladiumkenya/openmrs-config-kenyaemr/blob/main/configuration/dev-config.json#L503-L519) to get the `serve patient` button back. (untested)

```
    "queueTables": {
      "columnDefinitions": [
        {
          "id": "serve-patient",
          "columnType": "extension",
          "header": "actions",
        },
      ],
      "tableDefinitions": [
        {
          "columns": [
            "patient-name",
            "queue-number",
            "coming-from",
            "priority",
            "status",
            "queue",
            "wait-time",
            "serve-patient"
          ]
        }
      ]
    }
```