### PR TITLE
(fix) Remove implementation-specific default identifier types

### DIFF
--- a/packages/esm-patient-search-app/src/config-schema.ts
+++ b/packages/esm-patient-search-app/src/config-schema.ts
@@ -43,8 +43,8 @@ export const configSchema = {
     },
     _description:
       'A list of identifier types to be displayed in the patient search results as banner tags. If no defaultIdentifierTypes are provided, the defaultIdentifier will be displayed.',
-    // These values correspond to the Patient Clinic Number and National Unique Patient Identifier (NUPI) identifier types respectively
-    _default: ['b4d66522-11fc-45c7-83e3-39a1af21ae0d', 'f85081e2-b4be-4e48-b3a4-7994b69bb101'],
+    // This UUID is for the OpenMRS ID
+    _default: ['05a29f94-c0ed-11e2-94be-8c13b969e334'],
   },
   defaultIdentifier: {
     _type: Type.String,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes two Palladium-specific identifier types from the `defaultIdentifierTypes` configuration property in the Search app's configuration schema - the `Patient clinic number` and the `NUPI` identifiers. These two identifier types have been moved to Palladium's frontend config. In their place, I've set `OpenMRS ID` as the default identifier type. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
