### PR TITLE
Chore/more robust refetch mechanism for service queues #3263

### DIFF
--- a/packages/esm-service-queues-app/src/helpers/http-events.ts
+++ b/packages/esm-service-queues-app/src/helpers/http-events.ts
@@ -1,0 +1,4 @@
+export const emitRefetchQueuesEvent = (queueUUID: string = '') => {
+  const event = new CustomEvent('refetchQueues', { detail: queueUUID });
+  window.dispatchEvent(event);
+};

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/existing-visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/existing-visit-form.component.tsx
@@ -10,10 +10,10 @@ import {
   type Visit,
 } from '@openmrs/esm-framework';
 import { postQueueEntry } from '../../active-visits/active-visits-table.resource';
-import { useMutateQueueEntries } from '../../hooks/useQueueEntries';
 import styles from './visit-form.scss';
 import classNames from 'classnames';
 import VisitFormQueueFields from '../visit-form-queue-fields/visit-form-queue-fields.component';
+import { emitRefetchQueuesEvent } from '../../helpers/http-events';
 
 interface ExistingVisitFormProps {
   closeWorkspace: () => void;
@@ -27,7 +27,6 @@ const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, closeWorks
 
   const config = useConfig<ConfigObject>();
   const visitQueueNumberAttributeUuid = config.visitQueueNumberAttributeUuid;
-  const { mutateQueueEntries } = useMutateQueueEntries();
   const [{ service, priority, status, sortWeight, queueLocation }, setVisitFormFields] = useState({
     service: null,
     priority: null,
@@ -62,7 +61,7 @@ const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, closeWorks
             });
             closeWorkspace();
             setIsSubmitting(false);
-            mutateQueueEntries();
+            emitRefetchQueuesEvent();
           }
         },
         (error) => {
@@ -80,7 +79,7 @@ const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, closeWorks
         },
       );
     },
-    [closeWorkspace, mutateQueueEntries, visit, t, visitQueueNumberAttributeUuid],
+    [closeWorkspace, visit, t, visitQueueNumberAttributeUuid],
   );
 
   return visit ? (

--- a/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-search/visit-form/visit-form.component.tsx
@@ -41,10 +41,10 @@ import { type NewVisitPayload, type PatientProgram } from '../../types';
 import styles from './visit-form.scss';
 import { useDefaultLoginLocation } from '../hooks/useDefaultLocation';
 import isEmpty from 'lodash-es/isEmpty';
-import { useMutateQueueEntries } from '../../hooks/useQueueEntries';
 import { type ConfigObject } from '../../config-schema';
 import { datePickerFormat, datePickerPlaceHolder } from '../../constants';
 import VisitFormQueueFields from '../visit-form-queue-fields/visit-form-queue-fields.component';
+import { emitRefetchQueuesEvent } from '../../helpers/http-events';
 
 interface VisitFormProps {
   patientUuid: string;
@@ -69,7 +69,6 @@ const VisitForm: React.FC<VisitFormProps> = ({ patientUuid, closeWorkspace }) =>
   const [ignoreChanges, setIgnoreChanges] = useState(true);
   const { activePatientEnrollment, isLoading } = useActivePatientEnrollment(patientUuid);
   const [enrollment, setEnrollment] = useState<PatientProgram>(activePatientEnrollment[0]);
-  const { mutateQueueEntries } = useMutateQueueEntries();
   const visitQueueNumberAttributeUuid = config.visitQueueNumberAttributeUuid;
   const [selectedLocation, setSelectedLocation] = useState('');
   const [visitType, setVisitType] = useState('');
@@ -145,7 +144,7 @@ const VisitForm: React.FC<VisitFormProps> = ({ patientUuid, closeWorkspace }) =>
                       ),
                     });
                     closeWorkspace();
-                    mutateQueueEntries();
+                    emitRefetchQueuesEvent();
                   }
                 },
                 (error) => {
@@ -169,7 +168,6 @@ const VisitForm: React.FC<VisitFormProps> = ({ patientUuid, closeWorkspace }) =>
     },
     [
       closeWorkspace,
-      mutateQueueEntries,
       patientUuid,
       selectedLocation,
       t,

--- a/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
@@ -35,7 +35,7 @@ This is used in the main dashboard of the queues app. (Currently behind a featur
 function DefaultQueueTable() {
   const selectedQueueUuid = useSelectedServiceUuid();
   const currentLocationUuid = useSelectedQueueLocationUuid();
-  const { queueEntries, isLoading, isValidating, error } = useQueueEntries({
+  const { queueEntries, isLoading, isValidating, error, mutate } = useQueueEntries({
     queue: selectedQueueUuid,
     location: currentLocationUuid,
     isEnded: false,
@@ -82,6 +82,15 @@ function DefaultQueueTable() {
       });
     });
   }, [queueEntries, searchTerm]);
+
+  useEffect(() => {
+    const handlePatientAddedToQueue = () => mutate();
+
+    window.addEventListener('refetchQueues', handlePatientAddedToQueue);
+    return () => {
+      window.removeEventListener('refetchQueues', handlePatientAddedToQueue);
+    };
+  }, []);
 
   if (isLoading && !queueEntries.length) {
     return <DataTableSkeleton role="progressbar" />;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR addresses an incosistency in re-retching the table contents in the services queues page when a write operation like adding a patient, clearing the queue or transitioning the patient fails to repopulate the table with the updated data.
We achieve this by employing custom events
```
export const emitRefetchQueuesEvent = (queueUUID: string = '') => {
  const event = new CustomEvent('refetchQueues', { detail: queueUUID });
  window.dispatchEvent(event);
};
```

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-3418

## Other
<!-- Anything not covered above -->
