### PR TITLE
(fix) service queues fails to re-fetch after delete ops #3418

### DIFF
--- a/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
+++ b/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
@@ -99,6 +99,11 @@ export function useQueueEntries(searchCriteria?: QueueEntrySearchCriteria, rep: 
       if (pageData?.data?.totalCount && pageData?.data?.totalCount !== totalCount) {
         setTotalCount(pageData?.data?.totalCount);
       }
+      //edge case when the new Data is an empty array E.g. you deleted the last patient, or you cleared the queue
+      if (pageData?.data?.totalCount === 0) {
+        setTotalCount(0);
+        setData([]);
+      }
       if (pageData?.data?.results?.length) {
         const newData = [...data];
         newData[currentPage] = pageData?.data?.results;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
The services queues would fail to refetch under the following scenarios

1. Only one patient is present in the service queue and you **remove** that patient from the queue.
2. **Clearing the queue**. i.e. deleting all entries from the current queue

I introduced a conditional that caters for this cases i.e. when there's existent stale data but the incoming data is an empty array with a **totalCount** of zero.

```
      if (pageData?.data?.totalCount === 0) {
        setTotalCount(0);
        setData([]);
      }
```

- `setTotalCount(0)` set this to zero to prevent the infinite loading scenario that happens when the number of items in 'data` doesn't match the total count
- `setData([])` set the queue entries to an empty array.  

## Screenshots
The bug
[3418-bug.webm](https://github.com/openmrs/openmrs-esm-patient-management/assets/39379012/05e42d5d-f93b-4cf8-a3c8-f27b94e1a188)

The fix
[3418-fix.webm](https://github.com/openmrs/openmrs-esm-patient-management/assets/39379012/41aacd96-89e1-4161-bd24-2e281679a5d4)


## Related Issue
[LINK TO JIRA](https://openmrs.atlassian.net/browse/O3-3418)

## Other
<!-- Anything not covered above -->
