### PR TITLE
(fix) O3-3494: Date Mismatch Issue on Patient Registration

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/obs/obs-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/obs/obs-field.component.tsx
@@ -170,29 +170,26 @@ function DateObsField({ concept, label, required, placeholder }: DateObsFieldPro
   const fieldName = `obs.${concept.uuid}`;
   const { setFieldValue } = useContext(PatientRegistrationContext);
 
-  const onDateChange = useCallback(
-    (date: CalendarDate) => {
-      setFieldValue(fieldName, date?.toDate(getLocalTimeZone()));
-    },
-    [setFieldValue],
-  );
+  const onDateChange = ([date]) => {
+    const refinedDate = date instanceof Date ? new Date(date.setHours(0, 0, 0, 0)) : new Date(date);
+    setFieldValue(fieldName, refinedDate);
+  };
 
   return (
     <Layer>
       <div className={styles.dobField}>
         <Field name={fieldName}>
           {({ field, form: { touched, errors }, meta }) => {
-            const dateValue = field.value ? parseDate(field.value) : field.value;
             return (
               <>
                 <OpenmrsDatePicker
                   id={fieldName}
                   {...field}
                   isRequired={required}
-                  onChange={onDateChange}
+                  onChange={(date) => onDateChange([date])}
                   labelText={label ?? concept.display}
                   isInvalid={errors[fieldName] && touched[fieldName]}
-                  value={dateValue}
+                  value={field.value}
                 />
                 {errors[fieldName] && touched[fieldName] && (
                   <div className={styles.radioFieldError}>{meta.error && t(meta.error)}</div>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
When capturing a date as an observation during patient registration, there was an issue where the date selected on the datepicker and the date eventually submitted in the payload were different. For some reason, the submitted date was always one day earlier than the selected date.

## Screenshots
Before the fix:

https://github.com/openmrs/openmrs-esm-patient-management/assets/12844964/34252537-2201-4bd1-acae-dd8e89326c3b

After the fix:

https://github.com/openmrs/openmrs-esm-patient-management/assets/12844964/1ab1425e-50ea-4685-88d8-5310dc90a22a


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
