### PR TITLE
(fix) O3-3533 & O3-3535: Improvements to previous implementation for O3-3224

### DIFF
--- a/packages/esm-ward-app/src/hooks/useAdmissionLocation.ts
+++ b/packages/esm-ward-app/src/hooks/useAdmissionLocation.ts
@@ -1,13 +1,12 @@
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
-import useSWR from 'swr';
 import { type AdmissionLocation } from '../types/index';
+import useSWRImmutable from 'swr/immutable';
 
 export function useAdmissionLocation(locationUuid: string, rep: string = 'full') {
-  const apiUrl = `${restBaseUrl}/admissionLocation/${locationUuid}` + (rep ? `?v=${rep}` : '');
-  const { data, ...rest } = useSWR<{ data: AdmissionLocation }, Error>(apiUrl, openmrsFetch);
-
+  const apiUrl = locationUuid ? `${restBaseUrl}/admissionLocation/${locationUuid}?v=${rep}` : null;
+  const { data, ...rest } = useSWRImmutable<{ data: AdmissionLocation }, Error>(apiUrl, openmrsFetch);
   return {
-    admissionLocation: data?.data ?? null,
+    admissionLocation: data?.data,
     ...rest,
   };
 }

--- a/packages/esm-ward-app/src/hooks/useInpatientRequest.ts
+++ b/packages/esm-ward-app/src/hooks/useInpatientRequest.ts
@@ -1,13 +1,14 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, restBaseUrl, useOpenmrsSWR } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 import type { InpatientRequest } from '../types';
 
 export function useInpatientRequest(locationUuid: string) {
-  const apiUrl = `/ws/rest/emrapi/inpatient/admissionRequests?admissionLocation=${locationUuid}`;
-  const { data, ...rest } = useSWR<{ data: Array<InpatientRequest> }, Error>(apiUrl, openmrsFetch);
+  const { data, ...rest } = useSWR<FetchResponse<Array<InpatientRequest>>, Error>(
+    locationUuid ? `${restBaseUrl}/emrapi/inpatient/admissionRequests?admissionLocation=${locationUuid}` : null,
+  );
 
   return {
-    inpatientRequests: data?.data || null,
+    inpatientRequests: data?.data,
     ...rest,
   };
 }

--- a/packages/esm-ward-app/src/hooks/useInpatientRequest.ts
+++ b/packages/esm-ward-app/src/hooks/useInpatientRequest.ts
@@ -1,10 +1,11 @@
-import { type FetchResponse, openmrsFetch, restBaseUrl, useOpenmrsSWR } from '@openmrs/esm-framework';
-import useSWR from 'swr';
+import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import type { InpatientRequest } from '../types';
+import useSWR from 'swr';
 
 export function useInpatientRequest(locationUuid: string) {
   const { data, ...rest } = useSWR<FetchResponse<Array<InpatientRequest>>, Error>(
     locationUuid ? `${restBaseUrl}/emrapi/inpatient/admissionRequests?admissionLocation=${locationUuid}` : null,
+    openmrsFetch,
   );
 
   return {

--- a/packages/esm-ward-app/src/hooks/useLocation.test.ts
+++ b/packages/esm-ward-app/src/hooks/useLocation.test.ts
@@ -1,0 +1,42 @@
+import { cleanup, renderHook } from '@testing-library/react';
+import useLocation from './useLocation';
+import useSWRImmutable from 'swr/immutable';
+import { restBaseUrl } from '@openmrs/esm-framework';
+
+jest.mock('swr/immutable', () =>
+  jest.fn().mockReturnValue({
+    data: {},
+    error: null,
+    isValidating: false,
+    mutate: jest.fn(),
+  }),
+);
+
+const useSWRImmutableMock = useSWRImmutable as jest.Mock;
+
+describe('Testing useLocation', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should call useLocation', () => {
+    const { result } = renderHook(() => useLocation('testUUID'));
+    expect(useSWRImmutableMock).toHaveBeenCalledWith(
+      `${restBaseUrl}/location/testUUID?v=custom:(display,uuid)`,
+      expect.any(Function),
+    );
+  });
+
+  it('should call useLocation with given rep', () => {
+    const { result } = renderHook(() => useLocation('testUUID', 'custom:(display,uuid,links)'));
+    expect(useSWRImmutableMock).toHaveBeenCalledWith(
+      `${restBaseUrl}/location/testUUID?v=custom:(display,uuid,links)`,
+      expect.any(Function),
+    );
+  });
+
+  it('should call useSWR with key=null', () => {
+    const { result } = renderHook(() => useLocation(null, 'custom:(display,uuid,links)'));
+    expect(useSWRImmutableMock).toHaveBeenCalledWith(null, expect.any(Function));
+  });
+});

--- a/packages/esm-ward-app/src/hooks/useLocation.ts
+++ b/packages/esm-ward-app/src/hooks/useLocation.ts
@@ -1,0 +1,11 @@
+import { type Location, openmrsFetch, restBaseUrl, useOpenmrsSWR } from '@openmrs/esm-framework';
+
+export default function useLocation(locationUuid: string, rep: string = 'custom:(display,uuid)') {
+  return useOpenmrsSWR<Location>(locationUuid ? `${restBaseUrl}/location/${locationUuid}?v=${rep}` : null, {
+    swrConfig: {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnMount: false,
+    },
+  });
+}

--- a/packages/esm-ward-app/src/hooks/useLocation.ts
+++ b/packages/esm-ward-app/src/hooks/useLocation.ts
@@ -1,11 +1,9 @@
-import { type Location, openmrsFetch, restBaseUrl, useOpenmrsSWR } from '@openmrs/esm-framework';
+import { type Location, openmrsFetch, restBaseUrl, type FetchResponse } from '@openmrs/esm-framework';
+import useSWRImmutable from 'swr/immutable';
 
 export default function useLocation(locationUuid: string, rep: string = 'custom:(display,uuid)') {
-  return useOpenmrsSWR<Location>(locationUuid ? `${restBaseUrl}/location/${locationUuid}?v=${rep}` : null, {
-    swrConfig: {
-      revalidateIfStale: false,
-      revalidateOnFocus: false,
-      revalidateOnMount: false,
-    },
-  });
+  return useSWRImmutable<FetchResponse<Location>>(
+    locationUuid ? `${restBaseUrl}/location/${locationUuid}?v=${rep}` : null,
+    openmrsFetch,
+  );
 }

--- a/packages/esm-ward-app/src/hooks/useWardLocation.test.ts
+++ b/packages/esm-ward-app/src/hooks/useWardLocation.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react';
+import { useSession } from '@openmrs/esm-framework';
+import { useParams } from 'react-router-dom';
+import useWardLocation from './useWardLocation';
+import useLocation from './useLocation';
+
+jest.mock('@openmrs/esm-framework', () => ({
+  useSession: jest.fn(),
+}));
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(),
+}));
+jest.mock('./useLocation', () => jest.fn());
+
+const mockedUseParams = useParams as jest.Mock;
+const mockedUseSession = useSession as jest.Mock;
+const mockedUseLocation = useLocation as jest.Mock;
+
+describe('useWardLocation', () => {
+  it('returns session location when locationUuidFromUrl is not provided', async () => {
+    mockedUseParams.mockReturnValue({});
+    mockedUseSession.mockReturnValue({ sessionLocation: 'sessionLocation' });
+    mockedUseLocation.mockReturnValue({});
+
+    const { result } = renderHook(() => useWardLocation());
+
+    expect(result.current.location).toBe('sessionLocation');
+  });
+
+  it('returns location from useLocation when locationUuidFromUrl is provided', async () => {
+    mockedUseParams.mockReturnValue({ locationUuid: 'uuid' });
+    mockedUseLocation.mockReturnValue({
+      data: { data: 'locationData' },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useWardLocation());
+
+    expect(result.current.location).toBe('locationData');
+    expect(result.current.invalidLocation).toBeFalsy();
+  });
+
+  it('handles loading state correctly', async () => {
+    mockedUseParams.mockReturnValue({ locationUuid: 'uuid' });
+    mockedUseLocation.mockReturnValue({
+      isLoading: true,
+    });
+
+    const { result } = renderHook(() => useWardLocation());
+
+    expect(result.current.isLoadingLocation).toBe(true);
+  });
+
+  it('handles error state correctly when fetching location fails', async () => {
+    const error = new Error('Error fetching location');
+    mockedUseParams.mockReturnValue({ locationUuid: 'uuid' });
+    mockedUseLocation.mockReturnValue({
+      error,
+    });
+
+    const { result } = renderHook(() => useWardLocation());
+
+    expect(result.current.errorFetchingLocation).toBe(error);
+  });
+
+  it('identifies invalid location correctly', async () => {
+    const error = new Error('Error fetching location');
+    mockedUseParams.mockReturnValue({ locationUuid: 'uuid' });
+    mockedUseLocation.mockReturnValue({
+      error,
+    });
+
+    const { result } = renderHook(() => useWardLocation());
+
+    expect(result.current.invalidLocation).toBeTruthy();
+  });
+});

--- a/packages/esm-ward-app/src/hooks/useWardLocation.ts
+++ b/packages/esm-ward-app/src/hooks/useWardLocation.ts
@@ -6,6 +6,7 @@ export default function useWardLocation(): {
   location: Location;
   isLoadingLocation: boolean;
   errorFetchingLocation: Error;
+  invalidLocation: boolean;
 } {
   const { locationUuid: locationUuidFromUrl } = useParams();
   const { sessionLocation } = useSession();
@@ -20,5 +21,6 @@ export default function useWardLocation(): {
     location: locationUuidFromUrl ? locationResponse?.data : sessionLocation,
     isLoadingLocation,
     errorFetchingLocation,
+    invalidLocation,
   };
 }

--- a/packages/esm-ward-app/src/hooks/useWardLocation.ts
+++ b/packages/esm-ward-app/src/hooks/useWardLocation.ts
@@ -1,0 +1,24 @@
+import { type Location, useLocations, useSession } from '@openmrs/esm-framework';
+import { useParams } from 'react-router-dom';
+import useLocation from './useLocation';
+
+export default function useWardLocation(): {
+  location: Location;
+  isLoadingLocation: boolean;
+  errorFetchingLocation: Error;
+} {
+  const { locationUuid: locationUuidFromUrl } = useParams();
+  const { sessionLocation } = useSession();
+  const {
+    data: locationResponse,
+    isLoading: isLoadingLocation,
+    error: errorFetchingLocation,
+  } = useLocation(locationUuidFromUrl ? locationUuidFromUrl : null);
+  const invalidLocation = locationUuidFromUrl && errorFetchingLocation;
+
+  return {
+    location: locationUuidFromUrl ? locationResponse?.data : sessionLocation,
+    isLoadingLocation,
+    errorFetchingLocation,
+  };
+}

--- a/packages/esm-ward-app/src/index.ts
+++ b/packages/esm-ward-app/src/index.ts
@@ -1,8 +1,13 @@
-import { defineConfigSchema, getSyncLifecycle, registerBreadcrumbs, registerFeatureFlag } from '@openmrs/esm-framework';
+import {
+  defineConfigSchema,
+  getAsyncLifecycle,
+  getSyncLifecycle,
+  registerBreadcrumbs,
+  registerFeatureFlag,
+} from '@openmrs/esm-framework';
 import { configSchema } from './config-schema';
 import rootComponent from './root.component';
 import { moduleName } from './constant';
-import admissionRequestsWorkspace from "./ward-workspace/admission-requests-workspace.component"
 
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
@@ -13,7 +18,11 @@ const options = {
 
 export const root = getSyncLifecycle(rootComponent, options);
 
-export const admissionRequestWorkspace = getSyncLifecycle(admissionRequestsWorkspace, options);
+export const admissionRequestWorkspace = getAsyncLifecycle(
+  () => import('./ward-workspace/admission-requests-workspace.component'),
+  options,
+);
+
 export function startupApp() {
   registerBreadcrumbs([]);
   defineConfigSchema(moduleName, configSchema);

--- a/packages/esm-ward-app/src/routes.json
+++ b/packages/esm-ward-app/src/routes.json
@@ -16,7 +16,7 @@
   },
    "workspaces": [
     {
-      "name":"admission-requests-cards",
+      "name":"admission-requests-workspace",
       "component": "admissionRequestWorkspace",
       "title":"admissionRequests",
        "type":"admission-requests"

--- a/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
+++ b/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
@@ -15,7 +15,7 @@ const AdmissionRequestsBar = () => {
   const { t } = useTranslation();
   const layout = useLayoutType();
 
-  if (isLoading || !admissionRequests.length) {
+  if (isLoading || !admissionRequests?.length) {
     return null;
   }
 

--- a/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
+++ b/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
@@ -10,7 +10,7 @@ import { Button } from '@carbon/react';
 
 const AdmissionRequestsBar = () => {
   const { location } = useWardLocation();
-  const { inpatientRequests, isLoading, error } = useInpatientRequest(location.uuid);
+  const { inpatientRequests, isLoading, error } = useInpatientRequest(location?.uuid);
   const admissionRequests = inpatientRequests?.filter((request) => request.type == 'ADMISSION');
   const { t } = useTranslation();
   const layout = useLayoutType();
@@ -42,7 +42,7 @@ const AdmissionRequestsBar = () => {
         renderIcon={ArrowRightIcon}
         kind="ghost"
         size={isDesktop(layout) ? 'sm' : 'lg'}>
-        t('manage', 'Manage')
+        {t('manage', 'Manage')}
       </Button>
     </div>
   );

--- a/packages/esm-ward-app/src/ward-view-header/admission-requests.scss
+++ b/packages/esm-ward-app/src/ward-view-header/admission-requests.scss
@@ -3,12 +3,19 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 
 .admissionRequestsContainer {
-  width: fit-content;
-  border-left: 2px solid $color-blue-60-2;
   background-color: $color-gray-70;
   display: flex;
   align-items: center;
-  padding: spacing.$spacing-02;
+  padding: spacing.$spacing-02 0 spacing.$spacing-02 spacing.$spacing-04;
+  background-color: #393939;
+
+  & > button {
+    color: #78a9ff;
+
+    svg {
+      fill: #78a9ff !important;
+    }
+  }
 }
 
 .movementIcon {
@@ -16,27 +23,11 @@
   border-radius: 50%;
   fill: $ui-03;
   background-color: $color-blue-60-2;
-}
-
-.manageButton {
-  background-color: transparent;
-  border: none;
-  color: $inverse-link;
-  cursor: pointer;
-  margin-left: spacing.$spacing-04;
-  &::after {
-    content: '→';
-    padding: spacing.$spacing-02;
-  }
+  margin-right: spacing.$spacing-03;
 }
 
 .content {
   @include type.type-style('heading-compact-01');
   color: $ui-02;
-  margin-left: spacing.$spacing-02;
-}
-
-.skeleton {
-  height: 20px;
-  width: 120px;
+  margin-right: spacing.$spacing-03;
 }

--- a/packages/esm-ward-app/src/ward-view-header/ward-view-header.component.tsx
+++ b/packages/esm-ward-app/src/ward-view-header/ward-view-header.component.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import styles from './ward-view-header.scss';
 import AdmissionRequestsBar from './admission-requests-bar.component';
-import { type Location } from '@openmrs/esm-framework';
+import useWardLocation from '../hooks/useWardLocation';
 
-interface WardViewHeaderProps {
-  location: Location;
-}
-const WardViewHeader: React.FC<WardViewHeaderProps> = ({ location }) => {
+interface WardViewHeaderProps {}
+
+const WardViewHeader: React.FC<WardViewHeaderProps> = () => {
+  const { location } = useWardLocation();
   return (
     <div className={styles.wardViewHeader}>
-      <h4>{location.display}</h4>
-      <AdmissionRequestsBar location={location} />
+      <h4>{location?.display}</h4>
+      <AdmissionRequestsBar />
     </div>
   );
 };

--- a/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
@@ -2,7 +2,6 @@ import { InlineNotification } from '@carbon/react';
 import { WorkspaceContainer, useFeatureFlag, useLocations, useSession, type Location } from '@openmrs/esm-framework';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 import EmptyBedSkeleton from '../beds/empty-bed-skeleton';
 import { useAdmissionLocation } from '../hooks/useAdmissionLocation';
 import WardBed from './ward-bed.component';
@@ -11,47 +10,41 @@ import styles from './ward-view.scss';
 import WardViewHeader from '../ward-view-header/ward-view-header.component';
 import { type AdmittedPatient, type WardPatient } from '../types';
 import { useAdmittedPatients } from '../hooks/useAdmittedPatients';
+import useWardLocation from '../hooks/useWardLocation';
 
 const WardView = () => {
-  const { locationUuid: locationUuidFromUrl } = useParams();
-  const { sessionLocation } = useSession();
-  const allLocations = useLocations();
+  const { isLoadingLocation, errorFetchingLocation } = useWardLocation();
+
   const { t } = useTranslation();
   const isBedManagementModuleInstalled = useFeatureFlag('bedmanagement-module');
-  const locationFromUrl = allLocations.find((l) => l.uuid === locationUuidFromUrl);
-  const invalidLocation = Boolean(locationUuidFromUrl && !locationFromUrl);
-  const location = (locationFromUrl ?? sessionLocation) as any as Location;
+
   //TODO:Display patients with admitted status (based on their observations) that have no beds assigned
-  if (!isBedManagementModuleInstalled) {
+  if (!isBedManagementModuleInstalled || isLoadingLocation) {
     return <></>;
   }
 
-  return invalidLocation ? (
-    <InlineNotification
-      kind="error"
-      lowContrast={true}
-      title={t('invalidLocationSpecified', 'Invalid location specified')}
-      subtitle={t('unknownLocationUuid', 'Unknown location uuid: {{locationUuidFromUrl}}', {
-        locationUuidFromUrl,
-      })}
-    />
-  ) : (
+  if (errorFetchingLocation) {
+    return <InlineNotification kind="error" title={t('invalidLocationSpecified', 'Invalid location specified')} />;
+  }
+
+  return (
     <div className={styles.wardView}>
-      <WardViewHeader location={location} />
+      <WardViewHeader />
       <div className={styles.wardViewMain}>
-        <WardViewByLocation location={location} />
+        <WardViewByLocation />
       </div>
       <WorkspaceContainer contextKey="ward" />
     </div>
   );
 };
 
-const WardViewByLocation = ({ location }: { location: Location }) => {
+const WardViewByLocation = () => {
+  const { location } = useWardLocation();
   const {
     admissionLocation,
     isLoading: isLoadingLocation,
     error: errorLoadingLocation,
-  } = useAdmissionLocation(location.uuid);
+  } = useAdmissionLocation(location?.uuid);
   const {
     admittedPatients,
     isLoading: isLoadingPatients,

--- a/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
@@ -14,7 +14,7 @@ import useWardLocation from '../hooks/useWardLocation';
 
 const WardView = () => {
   const response = useWardLocation();
-  const { isLoadingLocation, errorFetchingLocation } = response;
+  const { isLoadingLocation, errorFetchingLocation, invalidLocation } = response;
 
   const { t } = useTranslation();
   const isBedManagementModuleInstalled = useFeatureFlag('bedmanagement-module');
@@ -24,7 +24,7 @@ const WardView = () => {
     return <></>;
   }
 
-  if (errorFetchingLocation) {
+  if (invalidLocation) {
     return <InlineNotification kind="error" title={t('invalidLocationSpecified', 'Invalid location specified')} />;
   }
 

--- a/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
@@ -13,7 +13,8 @@ import { useAdmittedPatients } from '../hooks/useAdmittedPatients';
 import useWardLocation from '../hooks/useWardLocation';
 
 const WardView = () => {
-  const { isLoadingLocation, errorFetchingLocation } = useWardLocation();
+  const response = useWardLocation();
+  const { isLoadingLocation, errorFetchingLocation } = response;
 
   const { t } = useTranslation();
   const isBedManagementModuleInstalled = useFeatureFlag('bedmanagement-module');

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -4,6 +4,7 @@
   "bedShare": "Bed share",
   "emptyBed": "Empty bed",
   "errorLoadingPatientAdmissionRequests": "Error Loading patient admission requests",
+  "errorLoadingPatients": "Error loading admitted patients",
   "errorLoadingWardLocation": "Error loading ward location",
   "invalidLocationSpecified": "Invalid location specified",
   "invalidWardLocation": "Invalid ward location: {{location}}",

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -2,6 +2,11 @@
   "admissionRequestsCount_one": "{{count}} admission request",
   "admissionRequestsCount_other": "{{count}} admission requests",
   "bedShare": "Bed share",
-  "emptyBed": "Empty bed"
- 
+  "emptyBed": "Empty bed",
+  "errorLoadingPatientAdmissionRequests": "Error Loading patient admission requests",
+  "errorLoadingWardLocation": "Error loading ward location",
+  "invalidLocationSpecified": "Invalid location specified",
+  "invalidWardLocation": "Invalid ward location: {{location}}",
+  "manage": "Manage",
+  "noBedsConfigured": "No beds configured for this location"
 }

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -1,10 +1,7 @@
 {
+  "admissionRequestsCount_one": "{{count}} admission request",
+  "admissionRequestsCount_other": "{{count}} admission requests",
   "bedShare": "Bed share",
-  "emptyBed": "Empty bed",
-  "errorLoadingPatientAdmissionRequests": "Error Loading Patient Admission Requests",
-  "errorLoadingWardLocation": "Error loading ward location",
-  "invalidLocationSpecified": "Invalid location specified",
-  "invalidWardLocation": "Invalid ward location: {{location}}",
-  "noBedsConfigured": "No beds configured for this location",
-  "unknownLocationUuid": "Unknown location uuid: {{locationUuidFromUrl}}"
+  "emptyBed": "Empty bed"
+ 
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR brings some code and UI improvements from #1191.

This PR also introduces `useWardLocation`, which will be the only source of truth to be considered for Ward locations, given that the location Is either fetched from the UUID mentioned in the URL or returning the session location.

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/51502471/7b333722-a59d-49f5-9434-1381f0026963)


## Related Issue
https://issues.openmrs.org/browse/O3-3533
https://issues.openmrs.org/browse/O3-3535

## Other
<!-- Anything not covered above -->
