### PR TITLE
(fix) O3-3519: Identifier source should be mapped to the defined identifierType only

### DIFF
--- a/packages/esm-patient-registration-app/src/offline.resources.ts
+++ b/packages/esm-patient-registration-app/src/offline.resources.ts
@@ -83,11 +83,13 @@ export async function fetchPatientIdentifierTypesWithSources(): Promise<Array<Pa
   const allIdentifierSources = identifierSourcesResponse.data.results;
 
   for (let i = 0; i < identifierTypes?.length; i++) {
-    identifierTypes[i].identifierSources = allIdentifierSources.map((source) => {
-      const option = find(autoGenOptions.data.results, { source: { uuid: source.uuid } });
-      source.autoGenerationOption = option;
-      return source;
-    });
+    identifierTypes[i].identifierSources = allIdentifierSources
+      .filter((source) => source.identifierType.uuid === identifierTypes[i].uuid)
+      .map((source) => {
+        const option = find(autoGenOptions.data.results, { source: { uuid: source.uuid } });
+        source.autoGenerationOption = option;
+        return source;
+      });
   }
 
   return identifierTypes;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
In the current implementations, when the identifier type sources were fetched, they were directly assigned to all identifiers. The identifier sources have their own `identifierType` property and are only allotted to the specific identifierType.

## Screenshots
### Before
**DEV3**
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/51502471/a777100d-fb61-4dd5-b4ee-b6738404372f)


**ETHIOHRI**
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/51502471/acc24f47-8a7b-4352-ac38-135baaeb0180)

### After
**DEV3**
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/51502471/0f7f4087-e224-43c0-bbff-ee366d4b2467)

**EHTIOHRI**
![image](https://github.com/openmrs/openmrs-esm-patient-management/assets/51502471/0432a785-8076-4310-a7d4-61a61dd7b5d7)

## Related Issue

https://issues.openmrs.org/browse/O3-3519

## Other
<!-- Anything not covered above -->
