### PR TITLE
(fix) O3-3524: Add wrapping functions to write value in session storage

### DIFF
--- a/packages/esm-service-queues-app/src/helpers/helpers.test.ts
+++ b/packages/esm-service-queues-app/src/helpers/helpers.test.ts
@@ -1,0 +1,25 @@
+import { cleanup } from '@testing-library/react';
+import { updateValueInSessionStorage } from './helpers';
+
+describe('Testing updateValueInSessionStorage', () => {
+  beforeEach(() => {
+    cleanup();
+    sessionStorage.clear();
+  });
+  it('should save value in the session storage if valid value is passed', () => {
+    updateValueInSessionStorage('key', 'value');
+    expect(sessionStorage.getItem('key')).toBe('value');
+  });
+
+  it('should delete the key of the value passed is null or undefined', () => {
+    updateValueInSessionStorage('key1', 'v1');
+    expect(sessionStorage.getItem('key1')).toBe('v1');
+    updateValueInSessionStorage('key1', null);
+    expect(sessionStorage.getItem('key1')).toBe(null);
+
+    updateValueInSessionStorage('key2', 'v2');
+    expect(sessionStorage.getItem('key2')).toBe('v2');
+    updateValueInSessionStorage('key2', undefined);
+    expect(sessionStorage.getItem('key2')).toBe(null);
+  });
+});

--- a/packages/esm-service-queues-app/src/helpers/helpers.ts
+++ b/packages/esm-service-queues-app/src/helpers/helpers.ts
@@ -15,14 +15,7 @@ export const getServiceCountByAppointmentType = (
 };
 
 /**
- * This function updates the value in session storage if the value is a valid string.
- *
- * In case the value is null or undefined, the key will be removed from session storage.
- *
  * This function is mainly useful for not writing null/ undefined in the session storage
- *
- * @param key
- * @param value
  */
 export function updateValueInSessionStorage(key: string, value: string) {
   if (value === undefined || value === null) {
@@ -34,8 +27,6 @@ export function updateValueInSessionStorage(key: string, value: string) {
 
 /**
  * This function fetches the value for the passed key from session storage
- * @param key
- * @returns
  */
 export function getValueFromSessionStorage(key: string): string | null {
   return sessionStorage.getItem(key);

--- a/packages/esm-service-queues-app/src/helpers/helpers.ts
+++ b/packages/esm-service-queues-app/src/helpers/helpers.ts
@@ -14,17 +14,36 @@ export const getServiceCountByAppointmentType = (
     .reduce((count, val) => count + val, 0);
 };
 
-const initialQueueLocationNameState = { queueLocationName: sessionStorage.getItem('queueLocationName') };
-const initialQueueLocationUuidState = { queueLocationUuid: sessionStorage.getItem('queueLocationUuid') };
-const initialServiceUuidState = {
-  serviceUuid: sessionStorage.getItem('queueServiceUuid'),
-  serviceDisplay: sessionStorage.getItem('queueServiceDisplay'),
+function updateValueInSessionStorage(key: string, value: string) {
+  if (value === undefined || value === null) {
+    sessionStorage.removeItem(key);
+  } else {
+    sessionStorage.setItem(key, value);
+  }
+}
+
+function getValueFromSessionStorage(key: string) {
+  return sessionStorage.getItem(key) && sessionStorage.getItem(key) !== 'null' ? sessionStorage.getItem(key) : null;
+}
+
+const initialQueueLocationNameState = {
+  queueLocationName: getValueFromSessionStorage('queueLocationName'),
 };
-const intialStatusNameState = { status: '' };
-const initialQueueStatusState = { statusUuid: null, statusDisplay: null };
+const initialQueueLocationUuidState = {
+  queueLocationUuid: getValueFromSessionStorage('queueLocationUuid'),
+};
+const initialServiceUuidState = {
+  serviceUuid: getValueFromSessionStorage('queueServiceUuid'),
+  serviceDisplay: getValueFromSessionStorage('queueServiceDisplay'),
+};
+const intialAppointmentStatusNameState = { status: '' };
+const initialQueueStatusState = {
+  statusUuid: getValueFromSessionStorage('queueStatusUuid'),
+  statusDisplay: getValueFromSessionStorage('queueStatusDisplay'),
+};
 const initialSelectedQueueRoomTimestamp = { providerQueueRoomTimestamp: new Date() };
 const initialPermanentProviderQueueRoomState = {
-  isPermanentProviderQueueRoom: sessionStorage.getItem('isPermanentProviderQueueRoom'),
+  isPermanentProviderQueueRoom: getValueFromSessionStorage('isPermanentProviderQueueRoom'),
 };
 
 export function getSelectedService() {
@@ -35,7 +54,7 @@ export function getSelectedService() {
 }
 
 export function getSelectedAppointmentStatus() {
-  return getGlobalStore<{ status: string }>('appointmentSelectedStatus', intialStatusNameState);
+  return getGlobalStore<{ status: string }>('appointmentSelectedStatus', intialAppointmentStatusNameState);
 }
 
 export function getSelectedQueueLocationName() {
@@ -69,8 +88,8 @@ export function getIsPermanentProviderQueueRoom() {
 
 export const updateSelectedService = (currentServiceUuid: string, currentServiceDisplay: string) => {
   const store = getSelectedService();
-  sessionStorage.setItem('queueServiceDisplay', currentServiceDisplay);
-  sessionStorage.setItem('queueServiceUuid', currentServiceUuid);
+  updateValueInSessionStorage('queueServiceDisplay', currentServiceDisplay);
+  updateValueInSessionStorage('queueServiceUuid', currentServiceUuid);
   store.setState({ serviceUuid: currentServiceUuid, serviceDisplay: currentServiceDisplay });
 };
 
@@ -81,13 +100,13 @@ export const updateSelectedAppointmentStatus = (currentAppointmentStatus: string
 
 export const updateSelectedQueueLocationName = (currentLocationName: string) => {
   const store = getSelectedQueueLocationName();
-  sessionStorage.setItem('queueLocationName', currentLocationName);
+  updateValueInSessionStorage('queueLocationName', currentLocationName);
   store.setState({ queueLocationName: currentLocationName });
 };
 
 export const updateSelectedQueueLocationUuid = (currentLocationUuid: string) => {
   const store = getSelectedQueueLocationUuid();
-  sessionStorage.setItem('queueLocationUuid', currentLocationUuid);
+  updateValueInSessionStorage('queueLocationUuid', currentLocationUuid);
   store.setState({ queueLocationUuid: currentLocationUuid });
 };
 
@@ -98,12 +117,14 @@ export const updatedSelectedQueueRoomTimestamp = (currentProviderRoomTimestamp: 
 
 export const updateIsPermanentProviderQueueRoom = (currentIsPermanentProviderQueueRoom) => {
   const store = getIsPermanentProviderQueueRoom();
-  sessionStorage.setItem('isPermanentProviderQueueRoom', currentIsPermanentProviderQueueRoom);
+  updateValueInSessionStorage('isPermanentProviderQueueRoom', currentIsPermanentProviderQueueRoom);
   store.setState({ isPermanentProviderQueueRoom: currentIsPermanentProviderQueueRoom });
 };
 
 export const updateSelectedQueueStatus = (currentQueueStatusUuid: string, currentQueueStatusDisplay: string) => {
   const store = getSelectedQueueStatus();
+  updateValueInSessionStorage('queueStatusUuid', currentQueueStatusUuid);
+  updateValueInSessionStorage('queueStatusDisplay', currentQueueStatusDisplay);
   store.setState({ statusUuid: currentQueueStatusUuid, statusDisplay: currentQueueStatusDisplay });
 };
 
@@ -117,7 +138,7 @@ export const useSelectedService = () => {
 };
 
 export const useSelectedAppointmentStatus = () => {
-  const [currentAppointmentStatus, setCurrentAppointmentStatus] = useState(intialStatusNameState.status);
+  const [currentAppointmentStatus, setCurrentAppointmentStatus] = useState(intialAppointmentStatusNameState.status);
 
   useEffect(() => {
     getSelectedAppointmentStatus().subscribe(({ status }) => setCurrentAppointmentStatus(status));

--- a/packages/esm-service-queues-app/src/helpers/helpers.ts
+++ b/packages/esm-service-queues-app/src/helpers/helpers.ts
@@ -14,7 +14,17 @@ export const getServiceCountByAppointmentType = (
     .reduce((count, val) => count + val, 0);
 };
 
-function updateValueInSessionStorage(key: string, value: string) {
+/**
+ * This function updates the value in session storage if the value is a valid string.
+ *
+ * In case the value is null or undefined, the key will be removed from session storage.
+ *
+ * This function is mainly useful for not writing null/ undefined in the session storage
+ *
+ * @param key
+ * @param value
+ */
+export function updateValueInSessionStorage(key: string, value: string) {
   if (value === undefined || value === null) {
     sessionStorage.removeItem(key);
   } else {
@@ -22,8 +32,13 @@ function updateValueInSessionStorage(key: string, value: string) {
   }
 }
 
-function getValueFromSessionStorage(key: string) {
-  return sessionStorage.getItem(key) && sessionStorage.getItem(key) !== 'null' ? sessionStorage.getItem(key) : null;
+/**
+ * This function fetches the value for the passed key from session storage
+ * @param key
+ * @returns
+ */
+export function getValueFromSessionStorage(key: string): string | null {
+  return sessionStorage.getItem(key);
 }
 
 const initialQueueLocationNameState = {

--- a/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
+++ b/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
@@ -25,7 +25,7 @@ function getInitialUrl(rep: string, searchCriteria?: QueueEntrySearchCriteria) {
 
   if (searchCriteria) {
     for (let [key, value] of Object.entries(searchCriteria)) {
-      if (value != null) {
+      if (value != null && value !== undefined) {
         searchParam.append(key, value?.toString());
       }
     }

--- a/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
+++ b/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
@@ -25,7 +25,7 @@ function getInitialUrl(rep: string, searchCriteria?: QueueEntrySearchCriteria) {
 
   if (searchCriteria) {
     for (let [key, value] of Object.entries(searchCriteria)) {
-      if (value != null && value !== undefined) {
+      if (value != null) {
         searchParam.append(key, value?.toString());
       }
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR adds a helper function `updateValueInSessionStorage` to prevent writing `null` or `undefined` in the session storage.

Previously, when calling `sessionStorage.setItem(key, value)`, if the value was `null`, it was saved in the session storage and when fetching the data from the storage, it was returning `'null'`, which passed the check `value !== null`, since `value = 'null'`.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-3524

## Other
<!-- Anything not covered above -->
