### PR TITLE
(fix) O3-3523: Refetch queue entry data when the search criteria changes

### DIFF
--- a/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
+++ b/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
@@ -68,7 +68,7 @@ export function useMutateQueueEntries() {
   };
 }
 
-export function useQueueEntries(searchCriteriaVal?: QueueEntrySearchCriteria, repVal: string = repString) {
+export function useQueueEntries(searchCriteria?: QueueEntrySearchCriteria, rep: string = repString) {
   // This manually implements a kind of pagination using the useSWR hook. It does not use useSWRInfinite
   // because useSWRInfinite does not support with `mutate`. The hook starts by fetching the first page,
   // page zero, waits until data is fetched, then fetches the next page, and so on.
@@ -82,38 +82,36 @@ export function useQueueEntries(searchCriteriaVal?: QueueEntrySearchCriteria, re
   const [data, setData] = useState<Array<Array<QueueEntry>>>([]);
   const [totalCount, setTotalCount] = useState<number>();
   const [currentPage, setCurrentPage] = useState<number>(0);
-  const [searchCriteria, setSearchCriteria] = useState(searchCriteriaVal);
-  const [rep, setRep] = useState(repVal);
-  const [pageUrl, setPageUrl] = useState<string>(getInitialUrl(rep, searchCriteria));
+  const [currentSearchCriteria, setCurrentSearchCriteria] = useState(searchCriteria);
+  const [currentRep, setCurrentRep] = useState(rep);
+  const [pageUrl, setPageUrl] = useState<string>(getInitialUrl(currentRep, currentSearchCriteria));
   const [error, setError] = useState<Error>();
   const { mutateQueueEntries } = useMutateQueueEntries();
   const [waitingForMutate, setWaitingForMutate] = useState(false);
 
   const refetchAllData = useCallback(
-    (newRep: string = rep, newSearchCriteria: QueueEntrySearchCriteria = searchCriteria) => {
+    (newRep: string = currentRep, newSearchCriteria: QueueEntrySearchCriteria = currentSearchCriteria) => {
       setWaitingForMutate(true);
       setCurrentPage(0);
       setPageUrl(getInitialUrl(newRep, newSearchCriteria));
     },
-    [rep, searchCriteria],
+    [currentRep, currentSearchCriteria],
   );
 
-  /**
-   * This hook listens to the searchCriteria and rep values and refetches the data when they change.
-   */
+  // This hook listens to the searchCriteria and rep values and refetches the data when they change.
   useEffect(() => {
-    const isSearchCriteriaUpdated = !isEqual(searchCriteria, searchCriteriaVal);
-    const isRepUpdated = rep !== repVal;
-    if (isSearchCriteriaUpdated || rep !== repVal) {
+    const isSearchCriteriaUpdated = !isEqual(currentSearchCriteria, searchCriteria);
+    const isRepUpdated = currentRep !== rep;
+    if (isSearchCriteriaUpdated || isRepUpdated) {
       if (isSearchCriteriaUpdated) {
-        setSearchCriteria(searchCriteriaVal);
+        setCurrentSearchCriteria(searchCriteria);
       }
       if (isRepUpdated) {
-        setRep(rep);
+        setCurrentRep(rep);
       }
-      refetchAllData(repVal, searchCriteriaVal);
+      refetchAllData(rep, searchCriteria);
     }
-  }, [searchCriteriaVal, searchCriteria, setSearchCriteria, rep, repVal]);
+  }, [searchCriteria, currentSearchCriteria, setCurrentSearchCriteria, currentRep, rep]);
 
   const { data: pageData, isValidating, error: pageError } = useSWR<QueueEntryResponse, Error>(pageUrl, openmrsFetch);
 

--- a/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
@@ -37,12 +37,16 @@ function DefaultQueueTable() {
   const selectedService = useSelectedService();
   const currentLocationUuid = useSelectedQueueLocationUuid();
   const selectedQueueStatus = useSelectedQueueStatus();
-  const { queueEntries, isLoading, error, isValidating } = useQueueEntries({
-    service: selectedService?.serviceUuid,
-    location: currentLocationUuid,
-    isEnded: false,
-    status: selectedQueueStatus?.statusUuid,
-  });
+  const searchCriteria = useMemo(
+    () => ({
+      service: selectedService?.serviceUuid,
+      location: currentLocationUuid,
+      isEnded: false,
+      status: selectedQueueStatus?.statusUuid,
+    }),
+    [selectedService?.serviceUuid, currentLocationUuid, selectedQueueStatus?.statusUuid],
+  );
+  const { queueEntries, isLoading, error, isValidating } = useQueueEntries(searchCriteria);
 
   const { t } = useTranslation();
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
When the search criteria inside the `useQueueEntries` update, the data wasn't being fetched properly.

## Screenshots

### Before


https://github.com/openmrs/openmrs-esm-patient-management/assets/51502471/cf5b73ad-11c2-4067-a94c-47205d10f3c3


### After
https://github.com/openmrs/openmrs-esm-patient-management/assets/51502471/d79f3eb6-13f0-43e7-b407-3ab492ff32ca


## Related Issue
https://issues.openmrs.org/browse/O3-3523

## Other
<!-- Anything not covered above -->
