### PR TITLE
(fix) O3-3563: set maxDate to correct todays date

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/dob/dob.component.tsx
@@ -2,7 +2,7 @@ import React, { type ChangeEvent, useCallback, useContext } from 'react';
 import { ContentSwitcher, Layer, Switch, TextInput } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { useField } from 'formik';
-import { type CalendarDate, getLocalTimeZone } from '@internationalized/date';
+import { type CalendarDate, getLocalTimeZone, today } from '@internationalized/date';
 import { PatientRegistrationContext } from '../../patient-registration-context';
 import { OpenmrsDatePicker, useConfig } from '@openmrs/esm-framework';
 import { type RegistrationConfig } from '../../../config-schema';
@@ -32,7 +32,7 @@ export const DobField: React.FC = () => {
   const [yearsEstimated, yearsEstimateMeta] = useField('yearsEstimated');
   const [monthsEstimated, monthsEstimateMeta] = useField('monthsEstimated');
   const { setFieldValue } = useContext(PatientRegistrationContext);
-  const today = new Date();
+  const todayDate = today(getLocalTimeZone()).toDate(getLocalTimeZone());
 
   const onToggle = useCallback(
     (e: { name?: string | number }) => {
@@ -104,7 +104,7 @@ export const DobField: React.FC = () => {
               id="birthdate"
               {...birthdate}
               onChange={onDateChange}
-              maxDate={today}
+              maxDate={todayDate}
               labelText={t('dateOfBirthLabelText', 'Date of Birth')}
               isInvalid={!!(birthdateMeta.touched && birthdateMeta.error)}
               value={birthdate.value}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Updates the `today` date to be set based on the locale.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1440" alt="Screenshot 2024-07-10 at 11 45 37 AM" src="https://github.com/openmrs/openmrs-esm-patient-management/assets/34070216/216085af-3698-4ab7-8824-a22410ae4f07">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3563

## Other
<!-- Anything not covered above -->
