### PR TITLE
(fix) O3-3617: In the appointments calender cliking the popover button takes user back to appointments page.

### DIFF
--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view-expanded.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view-expanded.component.tsx
@@ -29,7 +29,12 @@ const MonthlyWorkloadViewExpanded: React.FC<MonthlyWorkloadViewExpandedProps> = 
 
   return (
     <Popover open={isOpen} align="top" ref={popoverRef}>
-      <button className={styles.showMoreItems} onClick={() => setIsOpen((prev) => !prev)}>
+      <button
+        className={styles.showMoreItems}
+        onClick={(e) => {
+          e.stopPropagation();
+          setIsOpen((prev) => !prev);
+        }}>
         {t('countMore', '{{count}} more', { count })}
       </button>
       <PopoverContent>


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR tackles an issue in the appointments calender where clicking the button which is supposed to display the popover when some appointment services are truncated, causes the popover to appear briefly then navigates the user to the appointments page. The cause of this bug is that the event propagates up to the [this div](https://github.com/openmrs/openmrs-esm-patient-management/blob/83ff7c42076ad08669370fa7bf61ff0fb03b5e4b/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view.component.tsx#L52) which has an onclick event handler which navigates the user to the appointments page. The suggested solution is to call e.stopPropagation() in the button onClick handler

## Screenshots

https://github.com/user-attachments/assets/b92d83f9-5c23-4f55-9404-a270b54f4b6c



## Related Issue
https://openmrs.atlassian.net/browse/O3-3617
