### PR TITLE
(fix) O3-3240: Fix appearance of card rows in admission request cards

### DIFF
--- a/packages/esm-ward-app/src/ward-workspace/admission-request-card.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/admission-request-card.component.tsx
@@ -10,11 +10,11 @@ interface AdmissionRequestCardProps {
 
 const AdmissionRequestCard: React.FC<AdmissionRequestCardProps> = ({ patient }) => {
   const { locationUuid } = useParams();
-  const admissionPatientCardSlots = usePatientCardRows(locationUuid);
+  const rows = usePatientCardRows(locationUuid);
   return (
-    <div className={styles.admissionRequestCardHeader}>
-      {admissionPatientCardSlots.map((AdmissionPatientCard, i) => (
-        <AdmissionPatientCard key={i} patient={patient} bed={null} visit={null} />
+    <div className={styles.admissionRequestCard}>
+      {rows.map((CardRow, i) => (
+        <CardRow key={i} patient={patient} bed={null} visit={null} />
       ))}
     </div>
   );

--- a/packages/esm-ward-app/src/ward-workspace/admission-request-card.scss
+++ b/packages/esm-ward-app/src/ward-workspace/admission-request-card.scss
@@ -5,13 +5,10 @@
 
 .admissionRequestCard {
   background-color: $ui-01;
-  padding: spacing.$spacing-03;
   border: 1px solid $ui-03;
-  height: fit-content;
   color: $color-gray-70;
   display: flex;
-  align-items: center;
-  flex-wrap: wrap;
+  flex-direction: column;
   > :not(:first-child) {
     border-top: 1px colors.$gray-20 solid;
   }

--- a/packages/esm-ward-app/src/ward-workspace/admission-request-card.scss
+++ b/packages/esm-ward-app/src/ward-workspace/admission-request-card.scss
@@ -1,19 +1,19 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing';
+@use '@carbon/colors';
 @import '~@openmrs/esm-styleguide/src/vars';
 
-.admissionRequestCardHeader {
-  background-color: $ui-03;
+.admissionRequestCard {
+  background-color: $ui-01;
   padding: spacing.$spacing-03;
-  border: 1px solid $color-gray-30;
+  border: 1px solid $ui-03;
   height: fit-content;
   color: $color-gray-70;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  > div:not(:first-of-type)::before {
-    content: '·';
-    padding: spacing.$spacing-02;
+  > :not(:first-child) {
+    border-top: 1px colors.$gray-20 solid;
   }
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

The admission request cards are displaying the patient rows as specified in the card configuration. So the right information is already visible; it just wasn't showing up correctly. Also there was a lot of misleading naming in the code.

## Screenshots

![image](https://github.com/user-attachments/assets/797b3648-451d-4826-afba-1912046e46eb)


## Related Issue

https://openmrs.atlassian.net/issues/O3-3240

## Other

I think that further work on the admission request card will be very difficult under the current configuration paradigm. The designs call for admission request visit information to be displayed in the header row. It also calls for gravida not to be displayed in the admission request card.