### PR TITLE
(feat) O3-3200 - service queues - prevent setting of queue entry's st…

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
@@ -23,7 +23,7 @@ export function QueueTableActionCell({ queueEntry }: QueueTableCellComponentProp
         size={isDesktop(layout) ? 'sm' : 'lg'}>
         {t('transition', 'Transition')}
       </Button>
-      <OverflowMenu aria-label="Actions menu" size={isDesktop(layout) ? 'sm' : 'lg'} flipped>
+      <OverflowMenu aria-label="Actions menu" size={isDesktop(layout) ? 'sm' : 'lg'} align="left" flipped>
         <OverflowMenuItem
           className={styles.menuItem}
           aria-label={t('edit', 'Edit')}


### PR DESCRIPTION
…art time to before previous queue entry's

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Further improvement to [https://openmrs.atlassian.net/browse/O3-3200](this ticket) to support editing of queue entry times. We add a front-end check to prevent the edit of the start time to before the previous entry's start time, which gives a better error message than the less-comprehensive server-side error on submit.

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/user-attachments/assets/78c382e4-100c-4d0c-ab57-c3faff9eac2b)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
