### PR TITLE
(chore) O3-3069 - service queues - Tweak the queue table UI

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
@@ -13,7 +13,7 @@ export function QueueTableActionCell({ queueEntry }: QueueTableCellComponentProp
     <div className={styles.actionsCell}>
       <Button
         kind="ghost"
-        aria-label={t('actions', 'Actions')}
+        aria-label={t('transition', 'Transition')}
         onClick={() => {
           const dispose = showModal('transition-queue-entry-modal', {
             closeModal: () => dispose(),

--- a/packages/esm-service-queues-app/src/queue-table/cells/queue-table-coming-from-cell.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/cells/queue-table-coming-from-cell.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { type QueueTableColumnFunction, type QueueTableCellComponentProps } from '../../types';
 
 export const QueueTableComingFromCell = ({ queueEntry }: QueueTableCellComponentProps) => {
-  return <>{queueEntry.queueComingFrom?.display}</>;
+  return <>{queueEntry.queueComingFrom?.display ?? '--'}</>;
 };
 
 export const queueTableComingFromColumn: QueueTableColumnFunction = (key, header) => ({

--- a/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { DataTableSkeleton, Dropdown, TableToolbarSearch } from '@carbon/react';
+import { DataTableSkeleton, Dropdown, Layer, TableToolbarSearch } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
 import {
   closeWorkspace,
@@ -91,63 +91,65 @@ function DefaultQueueTable() {
   }, [queueEntries, searchTerm]);
 
   return (
-    <div className={styles.container}>
-      <div className={styles.headerContainer}>
-        <div className={!isDesktop(layout) ? styles.tabletHeading : styles.desktopHeading}>
-          <h4>{t('patientsCurrentlyInQueue', 'Patients currently in queue')}</h4>
+    <div className={styles.defaultQueueTable}>
+      <Layer className={styles.container}>
+        <div className={styles.headerContainer}>
+          <div className={!isDesktop(layout) ? styles.tabletHeading : styles.desktopHeading}>
+            <h4>{t('patientsCurrentlyInQueue', 'Patients currently in queue')}</h4>
+          </div>
+          <div className={styles.headerButtons}>
+            <ExtensionSlot
+              name="patient-search-button-slot"
+              state={{
+                isOpen: isPatientSearchOpen,
+                searchQuery: patientSearchQuery,
+                buttonText: t('addPatientToQueue', 'Add patient to queue'),
+                overlayHeader: t('addPatientToQueue', 'Add patient to queue'),
+                buttonProps: {
+                  kind: 'secondary',
+                  renderIcon: (props) => <Add size={16} {...props} />,
+                  size: 'sm',
+                },
+                searchQueryUpdatedAction: (searchQuery: string) => {
+                  setPatientSearchQuery(searchQuery);
+                },
+                selectPatientAction: (selectedPatientUuid: string) => {
+                  setIsPatientSearchOpen(false);
+                  launchWorkspace(serviceQueuesPatientSearchWorkspace, {
+                    selectedPatientUuid,
+                    currentServiceQueueUuid: selectedService?.serviceUuid,
+                    handleBackToSearchList,
+                  });
+                },
+              }}
+            />
+          </div>
         </div>
-        <div className={styles.headerButtons}>
-          <ExtensionSlot
-            name="patient-search-button-slot"
-            state={{
-              isOpen: isPatientSearchOpen,
-              searchQuery: patientSearchQuery,
-              buttonText: t('addPatientToQueue', 'Add patient to queue'),
-              overlayHeader: t('addPatientToQueue', 'Add patient to queue'),
-              buttonProps: {
-                kind: 'secondary',
-                renderIcon: (props) => <Add size={16} {...props} />,
-                size: 'sm',
-              },
-              searchQueryUpdatedAction: (searchQuery: string) => {
-                setPatientSearchQuery(searchQuery);
-              },
-              selectPatientAction: (selectedPatientUuid: string) => {
-                setIsPatientSearchOpen(false);
-                launchWorkspace(serviceQueuesPatientSearchWorkspace, {
-                  selectedPatientUuid,
-                  currentServiceQueueUuid: selectedService?.serviceUuid,
-                  handleBackToSearchList,
-                });
-              },
-            }}
-          />
-        </div>
-      </div>
-      {!isLoading ? (
-        <div className={styles.paddedQueueTable}>
-          <QueueTable
-            queueEntries={filteredQueueEntries ?? []}
-            isValidating={isValidating}
-            queueUuid={null}
-            statusUuid={null}
-            ExpandedRow={QueueTableExpandedRow}
-            tableFilter={[
-              <QueueDropdownFilter />,
-              <StatusDropdownFilter />,
-              <TableToolbarSearch
-                className={styles.search}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder={t('searchThisList', 'Search this list')}
-                size={isDesktop(layout) ? 'sm' : 'lg'}
-              />,
-              <ClearQueueEntries queueEntries={filteredQueueEntries} />,
-            ]}
-          />
-        </div>
-      ) : (
-        <DataTableSkeleton role="progressbar" />
-      )}
+        {!isLoading ? (
+          <div>
+            <QueueTable
+              queueEntries={filteredQueueEntries ?? []}
+              isValidating={isValidating}
+              queueUuid={null}
+              statusUuid={null}
+              ExpandedRow={QueueTableExpandedRow}
+              tableFilter={[
+                <QueueDropdownFilter />,
+                <StatusDropdownFilter />,
+                <TableToolbarSearch
+                  className={styles.search}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  placeholder={t('searchThisList', 'Search this list')}
+                  size={isDesktop(layout) ? 'sm' : 'lg'}
+                />,
+                <ClearQueueEntries queueEntries={filteredQueueEntries} />,
+              ]}
+            />
+          </div>
+        ) : (
+          <DataTableSkeleton role="progressbar" />
+        )}
+      </Layer>
     </div>
   );
 }

--- a/packages/esm-service-queues-app/src/queue-table/queue-table-by-status-skeleton.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table-by-status-skeleton.component.tsx
@@ -1,12 +1,8 @@
-import { DataTableSkeleton, SkeletonText, Tab, TabList, TabPanel, TabPanels, Tabs } from '@carbon/react';
-import { isDesktop, useLayoutType } from '@openmrs/esm-framework';
+import { DataTableSkeleton, SkeletonText } from '@carbon/react';
 import React from 'react';
 import styles from './queue-table.scss';
-import classNames from 'classnames';
 
 export const QueueTableByStatusSkeleton = () => {
-  const layout = useLayoutType();
-
   return (
     <div className={styles.container}>
       <div className={styles.statusTableContainer}>

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
@@ -48,9 +48,6 @@ interface QueueTableProps {
   // if provided, adds addition table toolbar elements
   tableFilter?: React.ReactNode[];
 
-  // if provided, adds title to the top-left
-  header?: string;
-
   isLoading?: boolean;
 }
 
@@ -62,7 +59,6 @@ function QueueTable({
   queueTableColumnsOverride,
   ExpandedRow,
   tableFilter,
-  header,
   isLoading,
 }: QueueTableProps) {
   const { t } = useTranslation();
@@ -109,7 +105,6 @@ function QueueTable({
         <>
           <TableContainer className={styles.tableContainer}>
             <div className={styles.toolbarContainer}>
-              <h5 className={styles.tableHeader}>{header}</h5>
               {isValidating ? (
                 <span>
                   <InlineLoading />

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
-@use '@carbon/styles/scss/type';
-@use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@use '@carbon/layout';
+@use '@carbon/type';
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .defaultQueueTable {
   margin: 1rem;
@@ -60,12 +60,12 @@
 }
 
 .statusTableContainer {
-  padding: spacing.$spacing-05;
+  padding: layout.$spacing-05;
   background-color: $ui-01;
 }
 
 .statusTableHeader {
-  padding: spacing.$spacing-03 0;
+  padding: layout.$spacing-03 0;
 }
 
 .tableHeader {

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.scss
@@ -23,7 +23,7 @@
   display: flex;
   justify-content: space-between;
   .filterSearch {
-    margin-left: spacing.$spacing-05;
+    margin-left: layout.$spacing-05;
   }
 }
 
@@ -74,7 +74,7 @@
 
 .tableContainer {
   background-color: $ui-01;
-  // margin: 0 spacing.$spacing-05;
+  // margin: 0 layout.$spacing-05;
   padding: 0;
 
   a {
@@ -123,7 +123,7 @@
 .tabletHeading {
   text-align: left;
   text-transform: capitalize;
-  margin-bottom: spacing.$spacing-05;
+  margin-bottom: layout.$spacing-05;
 
   h4:after {
     content: '';
@@ -158,7 +158,7 @@ html[dir='rtl'] {
   .headerContainer {
     svg {
       margin-left: 0;
-      margin-right: spacing.$spacing-03;
+      margin-right: layout.$spacing-03;
     }
     h4 {
       text-align: right;
@@ -172,10 +172,10 @@ html[dir='rtl'] {
       text-align: right;
       .serviceColor {
         margin-right: 0;
-        margin-left: spacing.$spacing-03;
+        margin-left: layout.$spacing-03;
       }
       button {
-        padding: spacing.$spacing-03 0 spacing.$spacing-03 spacing.$spacing-05;
+        padding: layout.$spacing-03 0 layout.$spacing-03 layout.$spacing-05;
         text-align: right;
       }
     }
@@ -183,14 +183,14 @@ html[dir='rtl'] {
 }
 
 .tabList {
-  padding-left: spacing.$spacing-05;
+  padding-left: layout.$spacing-05;
 }
 
 .tileContainer {
   background-color: $ui-02;
   border-top: 1px solid $ui-03;
   padding: 2rem 0;
-  // margin: 0 spacing.$spacing-05;
+  // margin: 0 layout.$spacing-05;
 }
 
 .tile {

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.scss
@@ -1,9 +1,14 @@
+@use '@carbon/colors';
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing';
 @import '~@openmrs/esm-styleguide/src/vars';
 
+.defaultQueueTable {
+  margin: 1rem;
+}
+
 .container {
-  background-color: $ui-01;
+  border: 1px solid colors.$gray-20;
 }
 
 .headerContainer {
@@ -56,6 +61,11 @@
 
 .statusTableContainer {
   padding: spacing.$spacing-05;
+  background-color: $ui-01;
+}
+
+.statusTableHeader {
+  padding: spacing.$spacing-03 0;
 }
 
 .tableHeader {
@@ -193,8 +203,4 @@ html[dir='rtl'] {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-}
-
-.paddedQueueTable {
-  padding: 0 spacing.$spacing-05;
 }

--- a/packages/esm-service-queues-app/src/views/queue-tables-for-all-statuses.component.tsx
+++ b/packages/esm-service-queues-app/src/views/queue-tables-for-all-statuses.component.tsx
@@ -171,14 +171,16 @@ function QueueTableForQueueAndStatus({
   const filteredQueueEntries = filterQueueEntries(queueEntries, searchTerm, statusUuid);
   return (
     <div className={styles.statusTableContainer}>
-      <QueueTable
-        key={statusUuid}
-        queueEntries={filteredQueueEntries}
-        header={status.display}
-        isValidating={isValidating}
-        queueUuid={queue.uuid}
-        statusUuid={statusUuid}
-      />
+      <h5 className={styles.statusTableHeader}>{status.display}</h5>
+      <div className={styles.container}>
+        <QueueTable
+          key={statusUuid}
+          queueEntries={filteredQueueEntries}
+          isValidating={isValidating}
+          queueUuid={queue.uuid}
+          statusUuid={statusUuid}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Cosmetic changes to the queue table. 
- The queue table in the service queue home now has similar appearance to the table in appointments home.
- The queue table in `/queue-table-by-status/<queueuuid>` retains its current styling in this  [mock up](https://app.zeplin.io/project/65f454477b16814668c38d02/screen/65fda7c21963a07e10c8ccd5).
## Screenshots
<!-- Required if you are making UI changes. -->
Queue table in home:
![image](https://github.com/user-attachments/assets/291687a2-ab1e-43cb-9fe3-da32ff74c424)

Appointments table for comparison:
![image](https://github.com/user-attachments/assets/d2e6666d-5eb9-4c64-9b7f-b22680b371ae)

===================

Queue Table by status:
![image](https://github.com/user-attachments/assets/243d1fdf-53b9-4d0c-adc9-ff626164654e)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
