### PR TITLE
(feat) O3-3244 & O3-3250: Add hook for fetching EMR Configuration

### DIFF
--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -275,6 +275,7 @@
   "ticketNumber": "Ticket Number",
   "time": "Time",
   "timeCannotBeInFuture": "Time cannot be in the future",
+  "timeCannotBePriorToPreviousQueueEntry": "Time cannot be before start of previous queue entry: {{time}}",
   "timeOfTransition": "Time of transition",
   "tirageNotYetCompleted": "Triage has not yet been completed",
   "today": "Today",

--- a/packages/esm-ward-app/src/hooks/useEmrConfiguration.ts
+++ b/packages/esm-ward-app/src/hooks/useEmrConfiguration.ts
@@ -13,7 +13,7 @@ interface EmrApiConfigurationResponse {
 
 export default function useEmrConfiguration() {
   const swrData = useSWRImmutable<FetchResponse<EmrApiConfigurationResponse>>(
-    `${restBaseUrl}/emrapi/onfiguration`,
+    `${restBaseUrl}/emrapi/configuration`,
     openmrsFetch,
   );
 

--- a/packages/esm-ward-app/src/hooks/useEmrConfiguration.ts
+++ b/packages/esm-ward-app/src/hooks/useEmrConfiguration.ts
@@ -1,0 +1,30 @@
+import { type FetchResponse, openmrsFetch, type OpenmrsResource, restBaseUrl } from '@openmrs/esm-framework';
+import { useMemo } from 'react';
+import useSWRImmutable from 'swr/immutable';
+
+interface EmrApiConfigurationResponse {
+  admissionEncounterType: OpenmrsResource;
+  clinicianEncounterRole: OpenmrsResource;
+  consultFreeTextCommentsConcept: OpenmrsResource;
+  visitNoteEncounterType: OpenmrsResource;
+  // There are many more keys to this object, but we only need these for now
+  // Add more keys as needed
+}
+
+export default function useEmrConfiguration() {
+  const swrData = useSWRImmutable<FetchResponse<EmrApiConfigurationResponse>>(
+    `${restBaseUrl}/emrapi/onfiguration`,
+    openmrsFetch,
+  );
+
+  const results = useMemo(
+    () => ({
+      emrConfiguration: swrData.data?.data,
+      isLoadingEmrConfiguration: swrData.isLoading,
+      mutateEmrConfiguration: swrData.mutate,
+      errorFetchingEmrConfiguration: swrData.error,
+    }),
+    [swrData],
+  );
+  return results;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR adds a new hook `useEmrConfiguration` to fetch the EMR Configuration.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-3244
https://issues.openmrs.org/browse/O3-3250

## Other
<!-- Anything not covered above -->
