### PR TITLE
(feat) O3-3250: Display bed number and patient name in In-Patient workspace banner,  Also save provider details with Notes

### DIFF
--- a/packages/esm-ward-app/src/ward-workspace/patient-banner/patient-banner.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-banner/patient-banner.component.tsx
@@ -3,16 +3,23 @@ import type { WardPatient } from '../../types';
 import { WardPatientCardElement } from '../../ward-patient-card/ward-patient-card-element.component';
 import { useCurrentWardCardConfig } from '../../hooks/useCurrentWardCardConfig';
 import styles from './style.scss';
+import WardPatientBedNumber from '../../ward-patient-card/row-elements/ward-patient-bed-number';
+import WardPatientName from '../../ward-patient-card/row-elements/ward-patient-name';
 
 const WardPatientWorkspaceBanner = (props: WardPatient) => {
   const { headerRowElements } = useCurrentWardCardConfig();
   const { patient, bed, visit, firstAdmissionOrTransferEncounter, encounterAssigningToCurrentInpatientLocation } =
     props;
 
-  if (!(patient && bed && visit)) return null;
+  if (!(patient && visit)) {
+    console.warn('Patient details and visit details where not received by the workspace');
+    return null;
+  }
 
   return (
     <div className={styles.patientBanner}>
+      {bed ? <WardPatientBedNumber bed={bed} /> : null}
+      <WardPatientName patient={patient} />
       {headerRowElements.map((elementId, i) => (
         <WardPatientCardElement
           key={`ward-card-${patient.uuid}-header-${i}`}

--- a/packages/esm-ward-app/src/ward-workspace/patient-banner/patient-banner.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-banner/patient-banner.component.tsx
@@ -12,7 +12,7 @@ const WardPatientWorkspaceBanner = (props: WardPatient) => {
     props;
 
   if (!(patient && visit)) {
-    console.warn('Patient details and visit details where not received by the workspace');
+    console.warn('Patient details and visit details were not received by the workspace');
     return null;
   }
 

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/form/notes-form.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/form/notes-form.component.tsx
@@ -70,6 +70,12 @@ const PatientNotesForm: React.FC<PatientNotesFormProps> = ({
         patient: patientUuid,
         location: locationUuid,
         encounterType: emrConfiguration?.visitNoteEncounterType.uuid,
+        encounterProviders: [
+          {
+            encounterRole: emrConfiguration?.clinicianEncounterRole.uuid,
+            provider: providerUuid,
+          },
+        ],
         obs: wardClinicalNote
           ? [
               {

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/form/notes-form.test.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/form/notes-form.test.tsx
@@ -48,6 +48,12 @@ test('renders the visit notes form with all the relevant fields and values', () 
 
 test('renders a success snackbar upon successfully recording a visit note', async () => {
   const successPayload = {
+    encounterProviders: expect.arrayContaining([
+      {
+        encounterRole: emrConfigurationMock.clinicianEncounterRole.uuid,
+        provider: undefined,
+      },
+    ]),
     encounterType: emrConfigurationMock.visitNoteEncounterType.uuid,
     location: undefined,
     obs: expect.arrayContaining([


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Add bed number and patient name on the in-patient workspace patient-banner 
- Add provider details on saving in-patient note

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/user-attachments/assets/89396000-a09d-4838-af00-9325de8cd8fb)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3250

## Other
<!-- Anything not covered above -->
