### PR TITLE
(feat) O3-3404: Validate `date appointment issued` in the appointments form

### DIFF
--- a/e2e/core/test.ts
+++ b/e2e/core/test.ts
@@ -1,4 +1,4 @@
-import { APIRequestContext, Page, test as base } from '@playwright/test';
+import { type APIRequestContext, type Page, test as base } from '@playwright/test';
 import { api } from '../fixtures';
 
 // This file sets up our custom test harness using the custom fixtures.

--- a/e2e/specs/appointments.spec.ts
+++ b/e2e/specs/appointments.spec.ts
@@ -86,6 +86,9 @@ test('Add, edit and cancel an appointment', async ({ page, api }) => {
     await page.getByLabel('Duration (minutes)').fill('80');
   });
 
+  await test.step('I set the Date appointment issued', async () => {
+    await page.getByLabel('Date appointment issued').fill('20/08/2024');
+  });
   await test.step('And I change the note', async () => {
     await page
       .getByPlaceholder('Write any additional points here')

--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -192,6 +192,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
         message: 'Date appointment issued cannot be after the appointment date',
       },
     );
+
   type AppointmentFormData = z.infer<typeof appointmentsFormSchema>;
 
   const defaultDateAppointmentScheduled = appointment?.dateAppointmentScheduled
@@ -817,30 +818,28 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
               name="dateAppointmentScheduled"
               control={control}
               render={({ field: { onChange, value, ref }, fieldState }) => (
-                <DatePicker
-                  datePickerType="single"
-                  dateFormat={datePickerFormat}
-                  value={value}
-                  maxDate={new Date()}
-                  onChange={([date]) => onChange(date)}
-                  invalid={!!fieldState?.error?.message}
-                  invalidText={fieldState?.error?.message}>
-                  <DatePickerInput
-                    id="dateAppointmentScheduledPickerInput"
-                    labelText={t('dateScheduledDetail', 'Date appointment issued')}
-                    style={{ width: '100%' }}
-                    placeholder={datePickerPlaceHolder}
-                    ref={ref}
-                  />
-                </DatePicker>
+                <div style={{ width: '100%' }}>
+                  <DatePicker
+                    datePickerType="single"
+                    dateFormat={datePickerFormat}
+                    value={value}
+                    maxDate={new Date()}
+                    onChange={([date]) => onChange(date)}
+                    invalid={!!fieldState?.error?.message}
+                    invalidText={fieldState?.error?.message}>
+                    <DatePickerInput
+                      id="dateAppointmentScheduledPickerInput"
+                      labelText={t('dateScheduledDetail', 'Date appointment issued')}
+                      style={{ width: '100%' }}
+                      placeholder={datePickerPlaceHolder}
+                      ref={ref}
+                    />
+                  </DatePicker>
+                  {fieldState?.error?.message && <div className={styles.errorMessage}>{fieldState.error.message}</div>}
+                </div>
               )}
             />
           </ResponsiveWrapper>
-          {errors.dateAppointmentScheduled && (
-            <div style={{ color: 'red', fontSize: '0.75rem', marginTop: '0.25rem' }}>
-              {errors.dateAppointmentScheduled.message}
-            </div>
-          )}
         </section>
 
         <section className={styles.formGroup}>

--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -176,7 +176,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
       },
       {
         path: ['appointmentDateTime.recurringPatternEndDate'],
-        message: 'A recurring appointment should have an end date',
+        message: t('A recurring appointment should have an end date'),
       },
     )
     .refine(
@@ -189,10 +189,9 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
       },
       {
         path: ['dateAppointmentScheduled'],
-        message: 'Date appointment issued cannot be after the appointment date',
+        message: t('Date appointment issued cannot be after the appointment date'),
       },
     );
-
   type AppointmentFormData = z.infer<typeof appointmentsFormSchema>;
 
   const defaultDateAppointmentScheduled = appointment?.dateAppointmentScheduled

--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -176,7 +176,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
       },
       {
         path: ['appointmentDateTime.recurringPatternEndDate'],
-        message: t('A recurring appointment should have an end date'),
+        message: t('recurringAppointmentShouldHaveEndDate', 'A recurring appointment should have an end date'),
       },
     )
     .refine(
@@ -189,7 +189,10 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
       },
       {
         path: ['dateAppointmentScheduled'],
-        message: t('Date appointment issued cannot be after the appointment date'),
+        message: t(
+          'dateAppointmentIssuedCannotBeAfterAppointmentDate',
+          'Date appointment issued cannot be after the appointment date',
+        ),
       },
     );
   type AppointmentFormData = z.infer<typeof appointmentsFormSchema>;

--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -178,8 +178,20 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
         path: ['appointmentDateTime.recurringPatternEndDate'],
         message: 'A recurring appointment should have an end date',
       },
-    );
+    )
+    .refine(
+      (formValues) => {
+        const appointmentDate = formValues.appointmentDateTime?.startDate;
+        const dateAppointmentScheduled = formValues.dateAppointmentScheduled;
 
+        if (!appointmentDate || !dateAppointmentScheduled) return true;
+        return dateAppointmentScheduled < appointmentDate;
+      },
+      {
+        path: ['dateAppointmentScheduled'],
+        message: 'Date appointment issued cannot be after the appointment date',
+      },
+    );
   type AppointmentFormData = z.infer<typeof appointmentsFormSchema>;
 
   const defaultDateAppointmentScheduled = appointment?.dateAppointmentScheduled
@@ -469,33 +481,6 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
           </ResponsiveWrapper>
         </section>
         <section className={styles.formGroup}>
-          <span className={styles.heading}>{t('dateScheduled', 'Date appointment issued')}</span>
-          <ResponsiveWrapper>
-            <Controller
-              name="dateAppointmentScheduled"
-              control={control}
-              render={({ field: { onChange, value, ref }, fieldState }) => (
-                <DatePicker
-                  datePickerType="single"
-                  dateFormat={datePickerFormat}
-                  value={value}
-                  maxDate={new Date()}
-                  onChange={([date]) => onChange(date)}
-                  invalid={!!fieldState?.error?.message}
-                  invalidText={fieldState?.error?.message}>
-                  <DatePickerInput
-                    id="dateAppointmentScheduledPickerInput"
-                    labelText={t('dateScheduledDetail', 'Date appointment issued')}
-                    style={{ width: '100%' }}
-                    placeholder={datePickerPlaceHolder}
-                    ref={ref}
-                  />
-                </DatePicker>
-              )}
-            />
-          </ResponsiveWrapper>
-        </section>
-        <section className={styles.formGroup}>
           <span className={styles.heading}>{t('service', 'Service')}</span>
           <ResponsiveWrapper>
             <Controller
@@ -540,7 +525,6 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
             />
           </ResponsiveWrapper>
         </section>
-
         <section className={styles.formGroup}>
           <span className={styles.heading}>{t('appointmentType_title', 'Appointment Type')}</span>
           <ResponsiveWrapper>
@@ -825,6 +809,38 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
               )}
             />
           </ResponsiveWrapper>
+        </section>
+        <section className={styles.formGroup}>
+          <span className={styles.heading}>{t('dateScheduled', 'Date appointment issued')}</span>
+          <ResponsiveWrapper>
+            <Controller
+              name="dateAppointmentScheduled"
+              control={control}
+              render={({ field: { onChange, value, ref }, fieldState }) => (
+                <DatePicker
+                  datePickerType="single"
+                  dateFormat={datePickerFormat}
+                  value={value}
+                  maxDate={new Date()}
+                  onChange={([date]) => onChange(date)}
+                  invalid={!!fieldState?.error?.message}
+                  invalidText={fieldState?.error?.message}>
+                  <DatePickerInput
+                    id="dateAppointmentScheduledPickerInput"
+                    labelText={t('dateScheduledDetail', 'Date appointment issued')}
+                    style={{ width: '100%' }}
+                    placeholder={datePickerPlaceHolder}
+                    ref={ref}
+                  />
+                </DatePicker>
+              )}
+            />
+          </ResponsiveWrapper>
+          {errors.dateAppointmentScheduled && (
+            <div style={{ color: 'red', fontSize: '0.75rem', marginTop: '0.25rem' }}>
+              {errors.dateAppointmentScheduled.message}
+            </div>
+          )}
         </section>
 
         <section className={styles.formGroup}>

--- a/packages/esm-appointments-app/src/form/appointments-form.component.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.component.tsx
@@ -717,7 +717,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps> = ({
                       <DatePicker
                         datePickerType="single"
                         dateFormat={datePickerFormat}
-                        value={value.startDate}
+                        value={value?.startDate}
                         onChange={([date]) => {
                           if (date) {
                             onChange({ ...value, startDate: date });

--- a/packages/esm-appointments-app/src/form/appointments-form.scss
+++ b/packages/esm-appointments-app/src/form/appointments-form.scss
@@ -76,3 +76,12 @@ $openmrs-background-grey: #ededed;
   max-inline-size: fit-content;
   padding-top: layout.$spacing-03;
 }
+
+.errorMessage {
+  color: red;
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  text-align: left;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
https://openmrs.atlassian.net/browse/O3-3404
This PR does the following:

1. Moves the `Date appointment issued` at the bottom of the Appointment form,
2.  Ensure that the `Date appointment issued ` should never be after the appointment date. 

## Screenshots
<!-- Required if you are making UI changes. -->
[appointments.webm](https://github.com/user-attachments/assets/b1851cf4-cc44-43ab-b28d-dae890ff8956)

![image](https://github.com/user-attachments/assets/bb48e1bc-b493-4aca-93ce-115c2c614005)





## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
