### PR TITLE
(fix) O3-3244: Fix can not read from `undefiend` `uuid` on  inpatient Transfers

### DIFF
--- a/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-transfer-request-form.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-transfer-request-form.component.tsx
@@ -12,7 +12,7 @@ import { createEncounter } from '../../ward.resource';
 import useWardLocation from '../../hooks/useWardLocation';
 import type { ObsPayload, WardPatientWorkspaceProps } from '../../types';
 import { useInpatientRequest } from '../../hooks/useInpatientRequest';
-import { Form, ButtonSet, Button, TextArea, InlineNotification, RadioButtonGroup, RadioButton } from '@carbon/react';
+import { Button, ButtonSet, Form, InlineNotification, RadioButton, RadioButtonGroup, TextArea } from '@carbon/react';
 
 export default function PatientTransferForm({
   closeWorkspaceWithSavedChanges,
@@ -102,7 +102,7 @@ export default function PatientTransferForm({
       }
 
       createEncounter({
-        patient: patient.uuid,
+        patient: patient?.uuid,
         encounterType: emrConfiguration.visitNoteEncounterType.uuid,
         location: location.uuid,
         encounterProviders: [
@@ -141,7 +141,7 @@ export default function PatientTransferForm({
       currentProvider,
       location,
       emrConfiguration,
-      patient.uuid,
+      patient?.uuid,
       dispositionsWithTypeTransfer,
       mutateAdmissionLocation,
       mutateInpatientRequest,
@@ -229,7 +229,7 @@ export default function PatientTransferForm({
         <Button
           type="submit"
           size="xl"
-          disabled={isLoadingEmrConfiguration || isSubmitting || errorFetchingEmrConfiguration}>
+          disabled={isLoadingEmrConfiguration || isSubmitting || errorFetchingEmrConfiguration || !patient}>
           {t('save', 'Save')}
         </Button>
       </ButtonSet>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
PR fixes can not read from `undefiend` `uuid` on inpatient Transfers

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
