### PR TITLE
(test) Assert presence of patient details in patient banner

### DIFF
--- a/e2e/specs/register-new-patient.spec.ts
+++ b/e2e/specs/register-new-patient.spec.ts
@@ -45,6 +45,7 @@ test('Register a new patient', async ({ page }) => {
   });
 
   await test.step("And I should the newly registered patient's details displayed in the patient banner", async () => {
+    await page.getByRole('banner', { name: /patient banner/i }).waitFor({ timeout: 10000 });
     await expect(page.getByRole('banner', { name: /patient banner/i })).toBeVisible();
     await expect(page.getByText(/johnny donny ronny/i)).toBeVisible();
     await expect(page.getByText(/male/i)).toBeVisible();

--- a/e2e/specs/register-new-patient.spec.ts
+++ b/e2e/specs/register-new-patient.spec.ts
@@ -32,6 +32,7 @@ test('Register a new patient', async ({ page }) => {
 
   await test.step('And then I fill the registration form and then click the `Submit` button', async () => {
     await patientRegistrationPage.fillPatientRegistrationForm(formValues);
+    await expect(page.getByText(/new patient created/i)).toBeVisible();
   });
 
   await test.step("Then I should be redirected to the new patient's chart page", async () => {
@@ -40,27 +41,27 @@ test('Register a new patient', async ({ page }) => {
     await expect(page).toHaveURL(patientChartUrlRegex);
   });
 
-  await test.step('And I should see a success toast notification', async () => {
-    await expect(page.getByText(/new patient created/i)).toBeVisible();
-  });
-
   await test.step("And I should the newly registered patient's details displayed in the patient banner", async () => {
-    await page.getByRole('banner', { name: /patient banner/i }).waitFor({ timeout: 10000 });
-    await expect(page.getByRole('banner', { name: /patient banner/i })).toBeVisible();
-    await expect(page.getByText(/johnny donny ronny/i)).toBeVisible();
-    await expect(page.getByText(/male/i)).toBeVisible();
-    await expect(page.getByText(/4 yrs, 6 mths/i)).toBeVisible();
-    await expect(page.getByText(/01 — Feb — 2020/i)).toBeVisible();
-    await expect(page.getByText(/OpenMRS ID/i)).toBeVisible();
-    await page.getByRole('button', { name: /show details/i }).click();
-    await expect(page.getByRole('button', { name: /hide details/i })).toBeVisible();
-    await expect(page.getByText(/^address$/i)).toBeVisible();
-    await expect(page.getByText(/address line 1: bom jesus street/i)).toBeVisible();
-    await expect(page.getByText(/city: recife/i)).toBeVisible();
-    await expect(page.getByText(/state: pernambuco/i)).toBeVisible();
-    await expect(page.getByText(/country: brazil/i)).toBeVisible();
-    await expect(page.getByText(/contact details/i)).toBeVisible();
-    await expect(page.getByText(/telephone number: 5555551234/i)).toBeVisible();
+    const patientBanner = page.locator('header[aria-label="patient banner"]');
+    await patientBanner.waitFor({ state: 'visible' });
+
+    await expect(page.getByLabel('patient banner').getByText(/johnny donny ronny/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/male/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/4 yrs, 6 mths/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/01 — Feb — 2020/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/OpenMRS ID/i)).toBeVisible();
+    await page
+      .getByLabel('patient banner')
+      .getByRole('button', { name: /show details/i })
+      .click();
+    await expect(page.getByLabel('patient banner').getByRole('button', { name: /hide details/i })).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/^address$/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/address line 1: bom jesus street/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/city: recife/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/state: pernambuco/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/country: brazil/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/contact details/i)).toBeVisible();
+    await expect(page.getByLabel('patient banner').getByText(/telephone number: 5555551234/i)).toBeVisible();
   });
 });
 

--- a/e2e/specs/register-new-patient.spec.ts
+++ b/e2e/specs/register-new-patient.spec.ts
@@ -34,15 +34,19 @@ test('Register a new patient', async ({ page }) => {
     await patientRegistrationPage.fillPatientRegistrationForm(formValues);
   });
 
-  await test.step("Then I should be redirected to the new patient's chart page and a new patient record should be created from the information captured in the form", async () => {
+  await test.step("Then I should be redirected to the new patient's chart page", async () => {
     const patientChartUrlRegex = new RegExp('^[\\w\\d:\\/.-]+\\/patient\\/[\\w\\d-]+\\/chart\\/.*$');
     await page.waitForURL(patientChartUrlRegex);
     await expect(page).toHaveURL(patientChartUrlRegex);
-    await page.locator('header[data-openmrs-role="patient banner"]').waitFor();
-    await expect(page.locator('header[data-openmrs-role="patient banner"]')).toBeVisible();
   });
 
-  await test.step("And I should the newly registered patient's details in the patient banner", async () => {
+  await test.step('And I should see a success toast notification', async () => {
+    await expect(page.getByText(/new patient created/i)).toBeVisible();
+  });
+
+  await test.step("And I should the newly registered patient's details displayed in the patient banner", async () => {
+    await page.locator('[data-openmrs-role="patient banner"]').waitFor();
+    await expect(page.locator('[data-openmrs-role="patient banner"]')).toBeVisible();
     await expect(page.getByText(/johnny donny ronny/i)).toBeVisible();
     await expect(page.getByText(/male/i)).toBeVisible();
     await expect(page.getByText(/4 yrs, 6 mths/i)).toBeVisible();

--- a/e2e/specs/register-new-patient.spec.ts
+++ b/e2e/specs/register-new-patient.spec.ts
@@ -5,7 +5,7 @@ import { deletePatient, getPatient } from '../commands';
 
 let patientUuid: string;
 
-test('Register a new patient', async ({ page, api }) => {
+test('Register a new patient', async ({ page }) => {
   test.setTimeout(5 * 60 * 1000);
   const patientRegistrationPage = new RegistrationAndEditPage(page);
 
@@ -38,7 +38,12 @@ test('Register a new patient', async ({ page, api }) => {
     const patientChartUrlRegex = new RegExp('^[\\w\\d:\\/.-]+\\/patient\\/[\\w\\d-]+\\/chart\\/.*$');
     await page.waitForURL(patientChartUrlRegex);
     await expect(page).toHaveURL(patientChartUrlRegex);
-    await expect(page.getByText(/Johnny Donny Ronny/i)).toBeVisible();
+    await page.locator('header[data-openmrs-role="patient banner"]').waitFor();
+    await expect(page.locator('header[data-openmrs-role="patient banner"]')).toBeVisible();
+  });
+
+  await test.step("And I should the newly registered patient's details in the patient banner", async () => {
+    await expect(page.getByText(/johnny donny ronny/i)).toBeVisible();
     await expect(page.getByText(/male/i)).toBeVisible();
     await expect(page.getByText(/4 yrs, 6 mths/i)).toBeVisible();
     await expect(page.getByText(/01 — Feb — 2020/i)).toBeVisible();

--- a/e2e/specs/register-new-patient.spec.ts
+++ b/e2e/specs/register-new-patient.spec.ts
@@ -45,8 +45,7 @@ test('Register a new patient', async ({ page }) => {
   });
 
   await test.step("And I should the newly registered patient's details displayed in the patient banner", async () => {
-    await page.locator('[data-openmrs-role="patient banner"]').waitFor();
-    await expect(page.locator('[data-openmrs-role="patient banner"]')).toBeVisible();
+    await expect(page.getByRole('banner', { name: /patient banner/i })).toBeVisible();
     await expect(page.getByText(/johnny donny ronny/i)).toBeVisible();
     await expect(page.getByText(/male/i)).toBeVisible();
     await expect(page.getByText(/4 yrs, 6 mths/i)).toBeVisible();

--- a/e2e/specs/register-new-patient.spec.ts
+++ b/e2e/specs/register-new-patient.spec.ts
@@ -30,38 +30,49 @@ test('Register a new patient', async ({ page }) => {
     await patientRegistrationPage.waitUntilTheFormIsLoaded();
   });
 
-  await test.step('And then I fill the registration form and then click the `Submit` button', async () => {
+  await test.step('And then I fill the registration form with the data in `formValues` and then click the `Submit` button', async () => {
     await patientRegistrationPage.fillPatientRegistrationForm(formValues);
+  });
+
+  await test.step('Then I should see a success notification', async () => {
     await expect(page.getByText(/new patient created/i)).toBeVisible();
   });
 
-  await test.step("Then I should be redirected to the new patient's chart page", async () => {
+  await test.step("And I should be redirected to the new patient's chart page", async () => {
     const patientChartUrlRegex = new RegExp('^[\\w\\d:\\/.-]+\\/patient\\/[\\w\\d-]+\\/chart\\/.*$');
     await page.waitForURL(patientChartUrlRegex);
     await expect(page).toHaveURL(patientChartUrlRegex);
   });
 
-  await test.step("And I should the newly registered patient's details displayed in the patient banner", async () => {
+  await test.step("And I should see the newly registered patient's details displayed in the patient banner", async () => {
     const patientBanner = page.locator('header[aria-label="patient banner"]');
-    await patientBanner.waitFor({ state: 'visible' });
 
-    await expect(page.getByLabel('patient banner').getByText(/johnny donny ronny/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/male/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/4 yrs, 6 mths/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/01 — Feb — 2020/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/OpenMRS ID/i)).toBeVisible();
+    await expect(patientBanner).toBeVisible();
+    await expect(patientBanner.getByText('Johnny Donny Ronny')).toBeVisible();
+    await expect(patientBanner.getByText(/male/i)).toBeVisible();
+    await expect(patientBanner.getByText(/4 yrs, 6 mths/i)).toBeVisible();
+    await expect(patientBanner.getByText(/01 — Feb — 2020/i)).toBeVisible();
+    await expect(patientBanner.getByText(/OpenMRS ID/i)).toBeVisible();
+  });
+
+  await test.step('And when I click the `Show details` button in the patient banner', async () => {
     await page
       .getByLabel('patient banner')
       .getByRole('button', { name: /show details/i })
       .click();
-    await expect(page.getByLabel('patient banner').getByRole('button', { name: /hide details/i })).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/^address$/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/address line 1: bom jesus street/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/city: recife/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/state: pernambuco/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/country: brazil/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/contact details/i)).toBeVisible();
-    await expect(page.getByLabel('patient banner').getByText(/telephone number: 5555551234/i)).toBeVisible();
+  });
+
+  await test.step("Then I should see the patient's address and contact details displayed in the patient banner", async () => {
+    const patientBanner = page.locator('header[aria-label="patient banner"]');
+
+    await expect(patientBanner.getByRole('button', { name: /hide details/i })).toBeVisible();
+    await expect(patientBanner.getByText(/^address$/i)).toBeVisible();
+    await expect(patientBanner.getByText(/address line 1: Bom Jesus Street/i)).toBeVisible();
+    await expect(patientBanner.getByText(/city: Recife/i)).toBeVisible();
+    await expect(patientBanner.getByText(/state: Pernambuco/i)).toBeVisible();
+    await expect(patientBanner.getByText(/country: Brazil/i)).toBeVisible();
+    await expect(patientBanner.getByText(/contact details/i)).toBeVisible();
+    await expect(patientBanner.getByText(/telephone number: 5555551234/i)).toBeVisible();
   });
 });
 
@@ -73,11 +84,11 @@ test('Register an unknown patient', async ({ api, page }) => {
     await patientRegistrationPage.waitUntilTheFormIsLoaded();
   });
 
-  await test.step(`And I click on the unknown 'patient's name' tab`, async () => {
+  await test.step("And I click the `No` tab in the `Patient's Name is Known?` field", async () => {
     await page.getByRole('tab', { name: /no/i }).first().click();
   });
 
-  await test.step('And I select `female` as the patient gender', async () => {
+  await test.step('And then I set the gender to `Female`', async () => {
     await page
       .locator('label')
       .filter({ hasText: /female/i })
@@ -86,11 +97,11 @@ test('Register an unknown patient', async ({ api, page }) => {
       .click();
   });
 
-  await test.step('And I click on the unknown `Date of Birth` tab', async () => {
+  await test.step('And then I click on the `No` tab in the "Date of Birth Known" field', async () => {
     await page.getByRole('tab', { name: /no/i }).nth(1).click();
   });
 
-  await test.step('And I fill the field for estimated age in years', async () => {
+  await test.step('And then I fill in 25 as the estimated age in years', async () => {
     const estimatedAgeField = await page.getByLabel(/estimated age in years/i);
     await estimatedAgeField.clear();
     await estimatedAgeField.fill('25');
@@ -100,13 +111,25 @@ test('Register an unknown patient', async ({ api, page }) => {
     await page.getByRole('button', { name: /register patient/i }).click();
   });
 
-  await test.step('Then I should see a success toast notification', async () => {
+  await test.step('Then I should see a success notification', async () => {
     await expect(page.getByText(/new patient created/i)).toBeVisible();
   });
 
-  await test.step('And I should see the newly recorded unknown patient dispalyed on the dashboard', async () => {
-    const patient = await getPatient(api, /patient\/(.+)\/chart/.exec(page.url())?.[1]);
-    expect(patient?.person?.display).toBe('UNKNOWN UNKNOWN');
+  await test.step("And I should be redirected to the new patient's chart page", async () => {
+    const patientChartUrlRegex = new RegExp('^[\\w\\d:\\/.-]+\\/patient\\/[\\w\\d-]+\\/chart\\/.*$');
+    await page.waitForURL(patientChartUrlRegex);
+    await expect(page).toHaveURL(patientChartUrlRegex);
+  });
+
+  await test.step("And I should see the newly registered patient's details displayed in the patient banner", async () => {
+    const patientBanner = page.locator('header[aria-label="patient banner"]');
+
+    expect(patientBanner).toBeVisible();
+    await expect(patientBanner.getByText('Unknown Unknown')).toBeVisible();
+    await expect(patientBanner.getByText(/female/i)).toBeVisible();
+    await expect(patientBanner.getByText(/25 yrs/i)).toBeVisible();
+    await expect(patientBanner.getByText(/01 — Jan — 1999/i)).toBeVisible();
+    await expect(patientBanner.getByText(/OpenMRS ID/i)).toBeVisible();
   });
 });
 

--- a/e2e/support/github/run-e2e-docker-env.sh
+++ b/e2e/support/github/run-e2e-docker-env.sh
@@ -20,7 +20,7 @@ do
   # run yarn pack for our app and add it to the working directory
   yarn workspace "$app" pack -o "$working_dir/$app_name.tgz" >/dev/null;
 done;
-echo "Created packed app archives" 
+echo "Created packed app archives"
 
 echo "Creating dynamic spa-assemble-config.json..."
 # dynamically assemble our list of frontend modules, prepending the login app and
@@ -29,7 +29,12 @@ echo "Creating dynamic spa-assemble-config.json..."
 jq -n \
   --arg apps "$apps" \
   --arg app_names "$(echo ${app_names[@]})" \
-  '{"@openmrs/esm-primary-navigation-app": "next", "@openmrs/esm-home-app": "next", "@openmrs/esm-patient-chart-app": "next"} + (
+  '{
+    "@openmrs/esm-primary-navigation-app": "next",
+    "@openmrs/esm-home-app": "next",
+    "@openmrs/esm-patient-chart-app": "next",
+    "@openmrs/esm-patient-banner-app": "next"
+  } + (
     ($apps | split("\n")) as $apps | ($app_names | split(" ") | map("/app/" + .)) as $app_files
     | [$apps, $app_files]
     | transpose


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Extends the "Register a new patient" spec to assert the presence of the newly entered registration data in the patient banner.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
