### PR TITLE
(fix) O3-3902 - make age() function (and its usage) handle null birth…

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -86,8 +86,13 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
               />
             </div>
             <div className={styles.demographics}>
-              <span>{getGender(patient.person.gender)}</span> &middot; <span>{age(patient.person.birthdate)}</span>{' '}
-              &middot; <span>{formatDate(parseDate(patient.person.birthdate), { mode: 'wide', time: false })}</span>
+              <span>{getGender(patient.person.gender)}</span>
+              {patient.person.birthdate && (
+                <>
+                  &middot; <span>{age(patient.person.birthdate)}</span> &middot;{' '}
+                  <span>{formatDate(parseDate(patient.person.birthdate), { mode: 'wide', time: false })}</span>
+                </>
+              )}
             </div>
             <div>
               <div className={styles.identifiers}>

--- a/packages/esm-ward-app/src/ward-patient-card/row-elements/ward-patient-age.tsx
+++ b/packages/esm-ward-app/src/ward-patient-card/row-elements/ward-patient-age.tsx
@@ -6,7 +6,7 @@ export interface WardPatientAgeProps {
 }
 
 const WardPatientAge: React.FC<WardPatientAgeProps> = ({ patient }) => {
-  return <div>{age(patient.person?.birthdate)}</div>;
+  return patient.person?.birthdate ? <div>{age(patient.person.birthdate)}</div> : null;
 };
 
 export default WardPatientAge;

--- a/packages/esm-ward-app/src/ward-workspace/patient-details/ward-patient.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-details/ward-patient.workspace.tsx
@@ -45,7 +45,9 @@ const PatientWorkspaceTitle: React.FC<WardPatientWorkspaceViewProps> = ({ patien
     <>
       <div>{patient.person.display} &nbsp;</div>
       <div className={styles.headerPatientDetail}>&middot; &nbsp; {getGender(t, patient.person?.gender)}</div>
-      <div className={styles.headerPatientDetail}>&middot; &nbsp; {age(patient.person?.birthdate)}</div>
+      {patient.person?.birthdate && (
+        <div className={styles.headerPatientDetail}>&middot; &nbsp; {age(patient.person?.birthdate)}</div>
+      )}
     </>
   );
 };


### PR DESCRIPTION
…days

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
See [corresponding PR](https://github.com/openmrs/openmrs-esm-core/pull/1136) in core

Add a null check to prevent NPE in the age() function when a patient's birthdate is null. There are also places, in core and patient-management, where this is insufficient, when UI elements should just not render in that case. This PR adds null check in those places too.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3902

## Other
<!-- Anything not covered above -->
