### PR TITLE
(fix) O3-3906:  ComposedModal usage missing scroll bar

### DIFF
--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
@@ -21,7 +21,7 @@ import {
   InlineNotification,
 } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { type Location } from '@openmrs/esm-framework';
+import { getCoreTranslation, type Location } from '@openmrs/esm-framework';
 import type { BedType, BedFormData } from '../types';
 import { type BedAdministrationData } from './bed-administration-types';
 
@@ -119,7 +119,7 @@ const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
     <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
       <ModalHeader title={headerTitle} />
       <ModalBody hasScrollingContent>
-        <Form onSubmit={handleSubmit(onSubmit, onError)}>
+        <Form>
           <Stack gap={3}>
             <FormGroup legendText={''}>
               <Controller
@@ -279,7 +279,7 @@ const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
       </ModalBody>
       <ModalFooter>
         <Button onClick={() => onModalChange(false)} kind="secondary">
-          {t('cancel', 'Cancel')}
+          {getCoreTranslation('cancel', 'Cancel')}
         </Button>
         <Button disabled={!isDirty} onClick={handleSubmit(onSubmit, onError)}>
           <span>{t('save', 'Save')}</span>

--- a/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
@@ -15,7 +15,7 @@ import {
   InlineNotification,
 } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { type Location } from '@openmrs/esm-framework';
+import { getCoreTranslation, type Location } from '@openmrs/esm-framework';
 import type { BedTagData } from '../types';
 
 const BedTagAdministrationSchema = z.object({
@@ -77,8 +77,8 @@ const BedTagsAdministrationForm: React.FC<BedTagAdministrationFormProps> = ({
   return (
     <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
       <ModalHeader title={headerTitle} />
-      <Form onSubmit={handleSubmit(onSubmit, onError)}>
-        <ModalBody hasScrollingContent>
+      <ModalBody hasScrollingContent>
+        <Form onSubmit={handleSubmit(onSubmit, onError)}>
           <Stack gap={3}>
             <FormGroup legendText={''}>
               <Controller
@@ -110,16 +110,16 @@ const BedTagsAdministrationForm: React.FC<BedTagAdministrationFormProps> = ({
               />
             )}
           </Stack>
-        </ModalBody>
-        <ModalFooter>
-          <Button onClick={() => onModalChange(false)} kind="secondary">
-            {t('cancel', 'Cancel')}
-          </Button>
-          <Button disabled={!isDirty} type="submit">
-            <span>{t('save', 'Save')}</span>
-          </Button>
-        </ModalFooter>
-      </Form>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button onClick={() => onModalChange(false)} kind="secondary">
+          {getCoreTranslation('cancel', 'Cancel')}
+        </Button>
+        <Button disabled={!isDirty} onClick={handleSubmit(onSubmit, onError)}>
+          <span>{t('save', 'Save')}</span>
+        </Button>
+      </ModalFooter>
     </ComposedModal>
   );
 };

--- a/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
@@ -78,7 +78,7 @@ const BedTagsAdministrationForm: React.FC<BedTagAdministrationFormProps> = ({
     <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
       <ModalHeader title={headerTitle} />
       <ModalBody hasScrollingContent>
-        <Form onSubmit={handleSubmit(onSubmit, onError)}>
+        <Form>
           <Stack gap={3}>
             <FormGroup legendText={''}>
               <Controller

--- a/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
@@ -82,7 +82,7 @@ const BedTypeAdministrationForm: React.FC<BedAdministrationFormProps> = ({
     <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
       <ModalHeader title={headerTitle} />
       <ModalBody hasScrollingContent>
-        <Form onSubmit={handleSubmit(onSubmit, onError)}>
+        <Form>
           <Stack gap={3}>
             <FormGroup legendText={''}>
               <Controller

--- a/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
@@ -16,7 +16,7 @@ import {
   InlineNotification,
 } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { type Location } from '@openmrs/esm-framework';
+import { getCoreTranslation, type Location } from '@openmrs/esm-framework';
 import type { BedType, BedTypeData } from '../types';
 
 const BedTypeAdministrationSchema = z.object({
@@ -81,8 +81,8 @@ const BedTypeAdministrationForm: React.FC<BedAdministrationFormProps> = ({
   return (
     <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
       <ModalHeader title={headerTitle} />
-      <Form onSubmit={handleSubmit(onSubmit, onError)}>
-        <ModalBody hasScrollingContent>
+      <ModalBody hasScrollingContent>
+        <Form onSubmit={handleSubmit(onSubmit, onError)}>
           <Stack gap={3}>
             <FormGroup legendText={''}>
               <Controller
@@ -149,16 +149,16 @@ const BedTypeAdministrationForm: React.FC<BedAdministrationFormProps> = ({
               />
             )}
           </Stack>
-        </ModalBody>
-        <ModalFooter>
-          <Button onClick={() => onModalChange(false)} kind="secondary">
-            {t('cancel', 'Cancel')}
-          </Button>
-          <Button disabled={!isDirty} type="submit">
-            <span>{t('save', 'Save')}</span>
-          </Button>
-        </ModalFooter>
-      </Form>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button onClick={() => onModalChange(false)} kind="secondary">
+          {getCoreTranslation('cancel', 'Cancel')}
+        </Button>
+        <Button disabled={!isDirty} onClick={handleSubmit(onSubmit, onError)}>
+          <span>{t('save', 'Save')}</span>
+        </Button>
+      </ModalFooter>
     </ComposedModal>
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Currently, using of ComposedModal in the Bed management module is missing a scroll bar, this PR adds a Scrollbar to the dialog to make it easy for different screen sizes.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3906
