### PR TITLE
(fix) O3-3915: The buttons in the refine-search overlay for the patient search button are partially hidden in a desktop layout

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search.component.tsx
@@ -292,7 +292,7 @@ const RefineSearch: React.FC<RefineSearchProps> = ({ setFilters, inTabletOrOverl
   }
 
   return (
-    <form onSubmit={handleSubmit} className={styles.refineSeachContainer} data-openmrs-role="Refine Search">
+    <form onSubmit={handleSubmit} className={styles.refineSearchContainer} data-openmrs-role="Refine Search">
       <h2 className={styles.productiveHeading02}>{t('refineSearch', 'Refine search')}</h2>
       <div className={styles.field}>
         <div className={styles.labelText}>

--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search.scss
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search.scss
@@ -2,7 +2,7 @@
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
-.refineSeachContainer {
+.refineSearchContainer {
   h2 {
     margin: layout.$spacing-03 0;
   }

--- a/packages/esm-patient-search-app/src/ui-components/overlay/overlay.scss
+++ b/packages/esm-patient-search-app/src/ui-components/overlay/overlay.scss
@@ -5,8 +5,8 @@
 .desktopOverlay {
   position: fixed;
   top: layout.$spacing-09;
+  bottom: 0;
   right: 0;
-  height: 100vh;
   width: 26.25rem;
   background-color: $ui-01;
   border-left: 1px solid $text-03;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR addresses an issue in the refine search overlay component under the patient search. On desktop the buttons for submitting or discarding the refined search are partially hidden.
This seems to be caused by the fact that the `Overlay` component [here](https://github.com/mccarthyaaron/openmrs-esm-patient-management/blob/main/packages/esm-patient-search-app/src/ui-components/overlay/index.tsx) has a height of 100vh as well as a position from the top of 3rem. This causes it to immediately go below the viewport. The actual issue then seems to arise down the component hierarchy [here](https://github.com/mccarthyaaron/openmrs-esm-patient-management/blob/main/packages/esm-patient-search-app/src/patient-search-page/refine-search.scss#L70) with the refine seach dialog container. It is positioned `bottom: 0` (which bottom is below the screen). Couple that with the `justify-content: flex-end` and you then end up with the the containers content partially hidden below the viewport.

the suggested solution here is to remove the height property from the Overlay component and give it  `bottom: 0`. Such that it sticks to the bottom of the viewport.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/919003ba-10ee-468a-9535-51fc454b3046


## Related Issue
https://openmrs.atlassian.net/browse/O3-3915
