### PR TITLE
(fix) O3-3996 - Ward App - minor CSS fixes

### DIFF
--- a/packages/esm-ward-app/src/ward-view/ward-view.scss
+++ b/packages/esm-ward-app/src/ward-view/ward-view.scss
@@ -2,11 +2,6 @@
 
 .wardView {
   background-color: #e4e4e4;
-  position: absolute;
-  top: var(--omrs-topnav-height);
-  bottom: 0;
-  left: 0;
-  right: 0;
   display: flex;
   flex-direction: column;
   padding: 0 layout.$spacing-05;
@@ -17,5 +12,4 @@
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   display: grid;
   gap: layout.$spacing-05;
-  padding: layout.$spacing-05;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

In the ward view: 

- the margins at the top above the location and metrics should go away
- The first column of bed cards should align with the Location text at the top.

 See: https://app.zeplin.io/project/65f454477b16814668c38d02/screen/65fda236f0ad0df6e5d786ec

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://github.com/user-attachments/assets/4bdfd619-56de-4ac9-b196-8ca6251a1e17)

After:
![image](https://github.com/user-attachments/assets/9eb2f5e2-5bce-498f-a52e-04b31ec8b1dc)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
