### PR TITLE
(fix) O3-4008 - Ward App - swap the position of patient card footer a…

### DIFF
--- a/packages/esm-ward-app/src/ward-patient-card/ward-patient-card.component.tsx
+++ b/packages/esm-ward-app/src/ward-patient-card/ward-patient-card.component.tsx
@@ -36,6 +36,16 @@ const WardPatientCard: WardPatientCard = (wardPatient) => {
         ))}
         <ExtensionSlot name={headerExtensionSlotName} state={wardPatient} />
       </div>
+      <div className={styles.wardPatientCardRow}>
+        {footerRowElements.map((elementId, i) => (
+          <WardPatientCardElement
+            key={`ward-card-${patient.uuid}-footer-${i}`}
+            elementId={elementId}
+            {...wardPatient}
+          />
+        ))}
+        <ExtensionSlot name={footerExtensionSlotName} state={wardPatient} />
+      </div>
       {wardPatient?.inpatientRequest || showPendingOrders ? (
         <div className={styles.wardPatientCardPendingItemsRow}>
           <Hourglass className={styles.hourGlassIcon} size="16" />:
@@ -52,16 +62,6 @@ const WardPatientCard: WardPatientCard = (wardPatient) => {
         state={wardPatient}
         className={classNames(styles.wardPatientCardExtensionSlot)}
       />
-      <div className={styles.wardPatientCardRow}>
-        {footerRowElements.map((elementId, i) => (
-          <WardPatientCardElement
-            key={`ward-card-${patient.uuid}-footer-${i}`}
-            elementId={elementId}
-            {...wardPatient}
-          />
-        ))}
-        <ExtensionSlot name={footerExtensionSlotName} state={wardPatient} />
-      </div>
       <button
         className={styles.wardPatientCardButton}
         onClick={() => {


### PR DESCRIPTION
…nd extension rows

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
When the patient card contains mother child rows, the placement of the footer looks confusing. Below, it's unclear that the "Gravida" and "Time on Ward" value is for the mother patient, not the baby:

![Untitled](https://github.com/user-attachments/assets/165e458a-c191-4cb6-a023-f6706996d52a)

This PR attempts to fix it by swapping the order of the footer and the extension rows in the patient card. We'll see how that looks and maybe make more subsequent changes.

## Screenshots
<!-- Required if you are making UI changes. -->
With new change:
![image](https://github.com/user-attachments/assets/bbd7bdbf-5013-4ff1-a26c-e47224a21bca)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4008

## Other
<!-- Anything not covered above -->
