### PR TITLE
(feat) - O3-4044 - Ward App - add support for vertical tiling of cards

### DIFF
--- a/packages/esm-ward-app/src/index.ts
+++ b/packages/esm-ward-app/src/index.ts
@@ -117,7 +117,13 @@ export function startupApp() {
 
   registerFeatureFlag(
     'bedmanagement-module',
-    'Bed Management Module',
+    'Bed management module',
     'Enables features related to bed management / assignment. Requires the backend bed management module to be installed.',
+  );
+
+  registerFeatureFlag(
+    'ward-view-vertical-tiling',
+    'Ward view vertical tiling',
+    'Enable tiling of bed cards vertically in the ward view.',
   );
 }

--- a/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
@@ -1,9 +1,5 @@
 import { InlineNotification } from '@carbon/react';
-import {
-  useAppContext,
-  useDefineAppContext,
-  WorkspaceContainer
-} from '@openmrs/esm-framework';
+import { useAppContext, useDefineAppContext, useFeatureFlag, WorkspaceContainer } from '@openmrs/esm-framework';
 import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import EmptyBedSkeleton from '../beds/empty-bed-skeleton';
@@ -15,6 +11,7 @@ import WardViewHeader from '../ward-view-header/ward-view-header.component';
 import WardBed from './ward-bed.component';
 import { bedLayoutToBed } from './ward-view.resource';
 import styles from './ward-view.scss';
+import classNames from 'classnames';
 
 const WardView = () => {
   const response = useWardLocation();
@@ -23,6 +20,7 @@ const WardView = () => {
 
   const wardPatientsGroupDetails = useWardPatientGrouping();
   useDefineAppContext<WardPatientGroupDetails>('ward-patients-group', wardPatientsGroupDetails);
+  const isVertical = useFeatureFlag('ward-view-vertical-tiling');
 
   if (isLoadingLocation) {
     return <></>;
@@ -33,27 +31,30 @@ const WardView = () => {
   }
 
   return (
-    <div className={styles.wardView}>
-      <WardViewHeader />
-      <WardViewMain />
+    <>
+      <div className={classNames(styles.wardView, { [styles.verticalTiling]: isVertical })}>
+        <WardViewHeader />
+        <WardViewMain />
+      </div>
       <WorkspaceContainer overlay contextKey="ward" />
-    </div>
+    </>
   );
 };
 
 const WardViewMain = () => {
   const { location } = useWardLocation();
   const { t } = useTranslation();
+  const isVertical = useFeatureFlag('ward-view-vertical-tiling');
 
   const wardPatientsGrouping = useAppContext<WardPatientGroupDetails>('ward-patients-group');
   const { bedLayouts, wardAdmittedPatientsWithBed, wardUnassignedPatientsList } = wardPatientsGrouping ?? {};
   const { isLoading: isLoadingAdmissionLocation, error: errorLoadingAdmissionLocation } =
     wardPatientsGrouping?.admissionLocationResponse ?? {};
   const {
-    isLoading: isLoadingInpatientAdmissions, 
-    error: errorLoadingInpatientAdmissions, 
-    hasMore: hasMoreInpatientAdmissions, 
-    loadMore: loadMoreInpatientAdmissions
+    isLoading: isLoadingInpatientAdmissions,
+    error: errorLoadingInpatientAdmissions,
+    hasMore: hasMoreInpatientAdmissions,
+    loadMore: loadMoreInpatientAdmissions,
   } = wardPatientsGrouping?.inpatientAdmissionResponse ?? {};
 
   const scrollToLoadMoreTrigger = useRef<HTMLDivElement>(null);
@@ -124,7 +125,7 @@ const WardViewMain = () => {
   });
 
   return (
-    <div className={styles.wardViewMain}>
+    <div className={classNames(styles.wardViewMain, { [styles.verticalTiling]: isVertical })}>
       {wardBeds}
       {bedLayouts?.length == 0 && (
         <InlineNotification

--- a/packages/esm-ward-app/src/ward-view/ward-view.scss
+++ b/packages/esm-ward-app/src/ward-view/ward-view.scss
@@ -1,10 +1,15 @@
 @use '@carbon/layout';
+@import '~@openmrs/esm-styleguide/src/vars';
 
 .wardView {
   background-color: #e4e4e4;
   display: flex;
   flex-direction: column;
   padding: 0 layout.$spacing-05;
+
+  &.verticalTiling {
+    height: calc(100vh - var(--omrs-topnav-height));
+  }
 }
 
 .wardViewMain {
@@ -12,4 +17,15 @@
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   display: grid;
   gap: layout.$spacing-05;
+
+  &.verticalTiling {
+    display: block;
+    column-width: 280px;
+    overflow-x: auto;
+
+    > div {
+      break-inside: avoid;
+      margin-bottom: 10px;
+    }
+  }
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
https://openmrs.atlassian.net/browse/O3-4044

Current way of tiling bed cards horizontally in the ward view wastes a lot of space. This PR introduces experimental vertical tiling, which can be enabled with a feature flag.

To enable: `localStorage.setItem("openmrs:feature-flag:ward-view-vertical-tiling", "true")`
To disable: `localStorage.removeItem("openmrs:feature-flag:ward-view-vertical-tiling")`

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![Untitled](https://github.com/user-attachments/assets/74aec495-dab1-4b4b-9f10-bcb5c7edf11b)

After:
![image](https://github.com/user-attachments/assets/a3789914-a375-430f-89c6-7f08acc62548)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
As the elements within the bed cards load, the height of each card can change (sometimes drastically). This can make the vertical tiling look jarring. We can fix that in a separate PR if we decide to go with vertical tiling.

Video:

https://github.com/user-attachments/assets/41136b57-fcb9-43fe-ab40-9aeabf8e961f


