### PR TITLE
(fix) O3-3787 : Refresh workspace title when clicked on new patient

### DIFF
--- a/packages/esm-ward-app/src/ward-workspace/patient-details/ward-patient.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-details/ward-patient.workspace.tsx
@@ -9,8 +9,8 @@ attach('ward-patient-workspace-header-slot', 'patient-vitals-info');
 
 export default function WardPatientWorkspace({ setTitle, wardPatient: { patient } }: WardPatientWorkspaceProps) {
   useEffect(() => {
-    setTitle(patient.person.display, <PatientWorkspaceTitle patient={patient} />);
-  }, []);
+    setTitle(patient.person.display, <PatientWorkspaceTitle key={patient.uuid} patient={patient} />);
+  }, [patient.uuid]);
 
   return (
     <div className={styles.workspaceContainer}>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
I have mentioned detailed solution in this [PR](https://github.com/openmrs/openmrs-esm-core/pull/1177). For now this might be like a temporary solution.
The workspace title which was set dynamically does not updated when clicked on other patients.Putting the props which are passed to the title node as a dependency in useEffect works.
[OpenMRS - Personal - Microsoft_ Edge 2024-10-10 21-26-09.webm](https://github.com/user-attachments/assets/109330d6-b3c3-46e7-b7d0-5725a3505eda)




## Related Issue
https://openmrs.atlassian.net/browse/O3-3787


