### PR TITLE
(refactor) Port modal registrations to use the modal system

### DIFF
--- a/packages/esm-appointments-app/src/routes.json
+++ b/packages/esm-appointments-app/src/routes.json
@@ -3,12 +3,6 @@
   "backendDependencies": {
     "webservices.rest": "^2.2.0"
   },
-  "modals": [
-    {
-      "name": "end-appointment-modal",
-      "component": "endAppointmentModal"
-    }
-  ],
   "extensions": [
     {
       "name": "home-appointments",
@@ -36,11 +30,7 @@
       "slot": "calendar-dashboard-slot",
       "component": "appointmentsCalendarDashboardLink"
     },
-    {
-      "name": "check-in-appointment-modal",
-      "slot": "todays-appointment-slot",
-      "component": "checkInModal"
-    },
+
     {
       "name": "todays-appointments-dashboard",
       "slot": "todays-appointment-slot",
@@ -112,10 +102,6 @@
       "slot": "upcoming-appointment-slot"
     },
     {
-      "name": "patient-appointment-cancel-confirmation-dialog",
-      "component": "patientAppointmentsCancelConfirmationDialog"
-    },
-    {
       "name": "edit-appointments-form",
       "component": "appointmentsForm",
       "meta": {
@@ -153,6 +139,16 @@
       "name": "home-appointments-tile",
       "slot": "home-metrics-tiles-slot",
       "component": "homeAppointmentsTile"
+    }
+  ],
+  "modals": [
+    {
+      "name": "end-appointment-modal",
+      "component": "endAppointmentModal"
+    },
+    {
+      "name": "patient-appointment-cancel-confirmation-dialog",
+      "component": "patientAppointmentsCancelConfirmationDialog"
     }
   ]
 }

--- a/packages/esm-service-queues-app/src/routes.json
+++ b/packages/esm-service-queues-app/src/routes.json
@@ -41,10 +41,6 @@
       "slot": "service-queues-dashboard-slot"
     },
     {
-      "name": "edit-queue-entry-status-modal",
-      "component": "editQueueEntryStatusModal"
-    },
-    {
       "name": "patient-info-banner-slot",
       "component": "patientInfoBannerSlot"
     },
@@ -57,46 +53,11 @@
       "component": "clearAllQueueEntries"
     },
     {
-      "name": "add-visit-to-queue-modal",
-      "component": "addVisitToQueueModal"
-    },
-    {
-      "name": "transition-queue-entry-status-modal",
-      "component": "transitionQueueEntryStatusModal"
-    },
-    {
       "name": "previous-visit-summary-widget",
       "component": "pastVisitSummary",
       "slot": "previous-visit-summary-slot"
     },
-    {
-      "name": "add-provider-to-room-modal",
-      "component": "addProviderToRoomModal"
-    },
-    {
-      "name": "transition-queue-entry-modal",
-      "component": "transitionQueueEntryModal"
-    },
-    {
-      "name": "transition-patient-to-latest-queue-modal",
-      "component": "transitionPatientToLatestQueue"
-    },
-    {
-      "name": "edit-queue-entry-modal",
-      "component": "editQueueEntryModal"
-    },
-    {
-      "name": "undo-transition-queue-entry-modal",
-      "component": "undoTransitionQueueEntryModal"
-    },
-    {
-      "name": "void-queue-entry-modal",
-      "component": "voidQueueEntryModal"
-    },
-    {
-      "name": "end-queue-entry-modal",
-      "component": "endQueueEntryModal"
-    },
+
     {
       "name": "active-visits-row-actions",
       "component": "activeVisitsRowActions",
@@ -106,6 +67,48 @@
       "name": "visit-form-queue-fields",
       "component": "visitFormQueueFields",
       "slot":"visit-form-queue-slot"
+    }
+  ],
+  "modals": [
+    {
+      "name": "add-visit-to-queue-modal",
+      "component": "addVisitToQueueModal"
+    },
+    {
+      "name": "add-provider-to-room-modal",
+      "component": "addProviderToRoomModal"
+    },
+    {
+      "name": "edit-queue-entry-modal",
+      "component": "editQueueEntryModal"
+    },
+    {
+      "name": "edit-queue-entry-status-modal",
+      "component": "editQueueEntryStatusModal"
+    },
+    {
+      "name": "end-queue-entry-modal",
+      "component": "endQueueEntryModal"
+    },
+    {
+      "name": "transition-patient-to-latest-queue-modal",
+      "component": "transitionPatientToLatestQueue"
+    },
+    {
+      "name": "transition-queue-entry-modal",
+      "component": "transitionQueueEntryModal"
+    },
+    {
+      "name": "transition-queue-entry-status-modal",
+      "component": "transitionQueueEntryStatusModal"
+    },
+    {
+      "name": "undo-transition-queue-entry-modal",
+      "component": "undoTransitionQueueEntryModal"
+    },
+    {
+      "name": "void-queue-entry-modal",
+      "component": "voidQueueEntryModal"
     }
   ],
   "workspaces": [


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR ports over some left over modal registrations to use the modal system instead of the legacy extension modal registry. It also removes an [unused](https://github.com/search?q=org:openmrs+check-in-appointment-modal&type=code) modal registration from the Appointments app routes registry.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
