### PR TITLE
(fix) O3-4015 - Ward App - unassign bed from patient when they are tr…

### DIFF
--- a/packages/esm-ward-app/src/hooks/useAssignedBedByPatient.ts
+++ b/packages/esm-ward-app/src/hooks/useAssignedBedByPatient.ts
@@ -1,0 +1,9 @@
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { type BedDetail } from '../types';
+import useSWR from 'swr';
+
+export function useAssignedBedByPatient(patientUuid: string) {
+  const url = `${restBaseUrl}/beds?patientUuid=${patientUuid}`;
+
+  return useSWR<{ data: { results: Array<BedDetail> } }, Error>(url, openmrsFetch);
+}

--- a/packages/esm-ward-app/src/types/index.ts
+++ b/packages/esm-ward-app/src/types/index.ts
@@ -67,6 +67,14 @@ export interface Bed {
   status: BedStatus;
 }
 
+export interface BedDetail {
+  bedId: number;
+  bedNumber: number;
+  bedType: BedType;
+  physicalLocation: Location;
+  patients: Array<Patient>;
+}
+
 export interface BedLayout {
   rowNumber: number;
   columnNumber: number;


### PR DESCRIPTION
…ansferred

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
When a patient with a bed in location A is transferred to a new location B, their current bed should be unassigned. Previous [PR](https://github.com/openmrs/openmrs-esm-patient-management/pull/1326/files) did not correctly fix this issue. It was trying to look for the assigned bed in location B instead of A. This PR fixes it by adding and using a new hook to get the bed assigned to the patient.

Adjusted the unit tests to reflect this change.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
