### PR TITLE
(fix) O3-3996 - Ward App - adjust pagination size of admilocation / t…

### DIFF
--- a/packages/esm-ward-app/src/location-selector/location-selector.component.tsx
+++ b/packages/esm-ward-app/src/location-selector/location-selector.component.tsx
@@ -15,10 +15,11 @@ import useEmrConfiguration from '../hooks/useEmrConfiguration';
 import useLocations from '../hooks/useLocations';
 import styles from './location-selector.scss';
 
-interface LocationSelectorProps extends RadioButtonGroupProps {}
+interface LocationSelectorProps extends RadioButtonGroupProps {
+  paginationSize?: number;
+}
 
-export default function LocationSelector(props: LocationSelectorProps) {
-  const size = 5;
+export default function LocationSelector({ paginationSize = 15, ...props }: LocationSelectorProps) {
   const { t } = useTranslation();
   const { emrConfiguration, isLoadingEmrConfiguration } = useEmrConfiguration();
   const isTablet = !isDesktop(useLayoutType());
@@ -42,7 +43,7 @@ export default function LocationSelector(props: LocationSelectorProps) {
     totalPages,
     goToNext,
     goToPrevious,
-  } = useLocations(filterCriteria, size, !emrConfiguration);
+  } = useLocations(filterCriteria, paginationSize, !emrConfiguration);
 
   const handleSearch = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -81,12 +82,12 @@ export default function LocationSelector(props: LocationSelectorProps) {
           </RadioButtonGroup>
         </ResponsiveWrapper>
       )}
-      {totalCount > size && (
+      {totalCount > paginationSize && (
         <div className={styles.pagination}>
           <span className={styles.bodyShort01}>
             {t('showingLocations', '{{start}}-{{end}} of {{count}} locations', {
-              start: (currentPage - 1) * size + 1,
-              end: Math.min(currentPage * size, totalCount),
+              start: (currentPage - 1) * paginationSize + 1,
+              end: Math.min(currentPage * paginationSize, totalCount),
               count: totalCount,
             })}
           </span>


### PR DESCRIPTION
…ransfer location selector

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Increase the pagination page size of the admission / transfer location picker. I'm using 15 as the page size default because that's also the number UX designers quoted for the max number of beds we display using radio buttons instead of dropdown in the bed selector UI. It's roughly the number of radio button options that can be fit into one screen.

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/user-attachments/assets/101f5c08-e0cb-48a0-964d-316e20287030)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
