### PR TITLE
(feat) O3-3848 Enable Admission request bar to always be displayed. 

### DIFF
--- a/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
+++ b/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
@@ -16,7 +16,7 @@ const AdmissionRequestsBar: React.FC<AdmissionRequestsBarProps> = ({ wardPending
   const { t } = useTranslation();
   const layout = useLayoutType();
 
-  if (isLoading || !inpatientRequests?.length) {
+  if (isLoading || !inpatientRequests) {
     return null;
   }
 
@@ -31,11 +31,13 @@ const AdmissionRequestsBar: React.FC<AdmissionRequestsBarProps> = ({ wardPending
   }
 
   return (
-    <div className={styles.admissionRequestsContainer}>
+    <div className={`${styles.admissionRequestsContainer} ${
+      inpatientRequests?.length ? styles.blackBackground : styles.lightBlueBackground
+    }`}>
       <Movement className={styles.movementIcon} size="24" />
       <span className={styles.content}>
         {t('admissionRequestsCount', '{{count}} admission request', {
-          count: inpatientRequests.length,
+          count: inpatientRequests?.length,
         })}
       </span>
       <Button

--- a/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
+++ b/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
@@ -37,7 +37,7 @@ const AdmissionRequestsBar: React.FC<AdmissionRequestsBarProps> = ({ wardPending
       <Movement className={styles.movementIcon} size="24" />
       <span className={styles.content}>
         {t('admissionRequestsCount', '{{count}} admission request', {
-          count: inpatientRequests?.length,
+          count: inpatientRequests.length,
         })}
       </span>
       <Button

--- a/packages/esm-ward-app/src/ward-view-header/admission-requests.scss
+++ b/packages/esm-ward-app/src/ward-view-header/admission-requests.scss
@@ -30,8 +30,18 @@
   margin-right: layout.$spacing-03;
 }
 
+.blackBackground {
+  background-color: black;
+  color: white;
+}
+
+.lightBlueBackground {
+  background-color: white;
+  border-left:4px solid $color-blue-60-2;
+  color: black;
+}
+
 .content {
   @include type.type-style('heading-compact-01');
-  color: $ui-02;
   margin-right: layout.$spacing-03;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Previously the bar has been rendering only if their inpatient requests. I have removed that check and made it render even when there no requests.
Also did some conditional styling where the bar is white when no requests are present and black when patient requests exist.

## Screenshots
![Screenshot from 2024-11-08 12-41-21](https://github.com/user-attachments/assets/01dcf186-f861-4450-b5a4-7ee344a136f7)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3848

## Other
<!-- Anything not covered above -->
