### PR TITLE
(fix) O3-4104 Ward App - prevent cancelling of pending ADT request wh…

### DIFF
--- a/packages/esm-ward-app/src/hooks/useEmrConfiguration.ts
+++ b/packages/esm-ward-app/src/hooks/useEmrConfiguration.ts
@@ -39,6 +39,8 @@ interface EmrApiConfigurationResponse {
     excludedEncounterTypes: Array<string>;
     uuid: string;
   }>;
+  bedAssignmentEncounterType: OpenmrsResource;
+  cancelADTRequestEncounterType: OpenmrsResource;
   // There are many more keys to this object, but we only need these for now
   // Add more keys as needed
 }
@@ -94,6 +96,8 @@ const customRepProps = [
   ['unknownPatientPersonAttributeType', 'ref'],
   ['supportsVisitsLocationTag', '(uuid,display,name,links)'],
   ['transferForm', 'ref'],
+  ['bedAssignmentEncounterType', 'ref'],
+  ['cancelADTRequestEncounterType', 'ref'],
 ];
 
 const customRep = `custom:${customRepProps.map((prop) => prop.join(':')).join(',')}`;

--- a/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-bed-swap-form.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-bed-swap-form.component.tsx
@@ -69,7 +69,7 @@ export default function PatientBedSwapForm({
       setShowErrorNotifications(false);
       createEncounter({
         patient: patient.uuid,
-        encounterType: emrConfiguration.transferWithinHospitalEncounterType.uuid,
+        encounterType: emrConfiguration.bedAssignmentEncounterType.uuid,
         location: location?.uuid,
         encounterProviders: [
           {


### PR DESCRIPTION
…en patient swaps bed

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR changes the encounter type used when swapping bed for a patient. This prevents the backend from thinking that any pending transfer request of the patient is cancelled.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4104

## Other
<!-- Anything not covered above -->
