### PR TITLE
(feat) O3-4023 Ward App - force patient to be admitted before being a…

### DIFF
--- a/packages/esm-ward-app/src/ward-view-header/admission-requests.scss
+++ b/packages/esm-ward-app/src/ward-view-header/admission-requests.scss
@@ -36,8 +36,8 @@
 }
 
 .lightBlueBackground {
-  background-color: white;
-  border-left:4px solid $color-blue-60-2;
+  background-color: $color-blue-10;
+  border-left: 4px solid $color-blue-60-2;
   color: #393939;
 }
 

--- a/packages/esm-ward-app/src/ward-workspace/admission-request-card/admission-request-card-actions.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/admission-request-card/admission-request-card-actions.component.tsx
@@ -1,31 +1,17 @@
 import { Button } from '@carbon/react';
-import {
-  ArrowRightIcon,
-  launchWorkspace,
-  showSnackbar,
-  useAppContext,
-  useFeatureFlag,
-  useLayoutType,
-} from '@openmrs/esm-framework';
+import { launchWorkspace, useAppContext, useLayoutType } from '@openmrs/esm-framework';
 import React, { useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import useWardLocation from '../../hooks/useWardLocation';
 import type { WardPatientCardType, WardPatientWorkspaceProps, WardViewContext } from '../../types';
 import { useAdmitPatient } from '../../ward.resource';
 import { AdmissionRequestsWorkspaceContext } from '../admission-request-workspace/admission-requests.workspace';
+import AdmissionPatientButton from '../admit-patient-button.component';
 import styles from './admission-request-card.scss';
 
 const AdmissionRequestCardActions: WardPatientCardType = ({ wardPatient }) => {
-  const { patient, inpatientRequest } = wardPatient;
-  const { dispositionType } = inpatientRequest;
   const { t } = useTranslation();
-  const { location } = useWardLocation();
   const responsiveSize = useLayoutType() === 'tablet' ? 'lg' : 'md';
-  const { WardPatientHeader, wardPatientGroupDetails } = useAppContext<WardViewContext>('ward-view-context') ?? {};
-  const { admitPatient, isLoadingEmrConfiguration, errorFetchingEmrConfiguration } = useAdmitPatient();
-
-  const launchPatientAdmissionForm = () =>
-    launchWorkspace<WardPatientWorkspaceProps>('admit-patient-form-workspace', { wardPatient, WardPatientHeader });
+  const { WardPatientHeader } = useAppContext<WardViewContext>('ward-view-context') ?? {};
 
   const launchPatientTransferForm = useCallback(() => {
     launchWorkspace<WardPatientWorkspaceProps>('patient-transfer-request-workspace', {
@@ -41,42 +27,7 @@ const AdmissionRequestCardActions: WardPatientCardType = ({ wardPatient }) => {
     });
   };
 
-  const isBedManagementModuleInstalled = useFeatureFlag('bedmanagement-module');
   const { closeWorkspaceWithSavedChanges } = useContext(AdmissionRequestsWorkspaceContext);
-
-  // If bed management module is installed, open the next form
-  // for bed selection. If not, admit patient directly
-  const onAdmit = () => {
-    if (isBedManagementModuleInstalled) {
-      launchPatientAdmissionForm();
-    } else {
-      admitPatient(patient, dispositionType)
-        .then(
-          (response) => {
-            if (response && response?.ok) {
-              showSnackbar({
-                kind: 'success',
-                title: t('patientAdmittedSuccessfully', 'Patient admitted successfully'),
-                subtitle: t('patientAdmittedWoBed', 'Patient admitted successfully to {{location}}', {
-                  location: location?.display,
-                }),
-              });
-            }
-          },
-          (err: Error) => {
-            showSnackbar({
-              kind: 'error',
-              title: t('errorCreatingEncounter', 'Failed to admit patient'),
-              subtitle: err.message,
-            });
-          },
-        )
-        .finally(() => {
-          wardPatientGroupDetails?.mutate?.();
-          closeWorkspaceWithSavedChanges();
-        });
-    }
-  };
 
   return (
     <div className={styles.admissionRequestActionBar}>
@@ -86,14 +37,10 @@ const AdmissionRequestCardActions: WardPatientCardType = ({ wardPatient }) => {
       <Button kind="ghost" size={responsiveSize} onClick={launchCancelAdmissionForm}>
         {t('cancel', 'Cancel')}
       </Button>
-      <Button
-        kind="ghost"
-        renderIcon={ArrowRightIcon}
-        size={responsiveSize}
-        disabled={isLoadingEmrConfiguration || errorFetchingEmrConfiguration}
-        onClick={onAdmit}>
-        {t('admitPatient', 'Admit patient')}
-      </Button>
+      <AdmissionPatientButton
+        wardPatient={wardPatient}
+        onAdmitPatientSuccess={() => closeWorkspaceWithSavedChanges()}
+      />
     </div>
   );
 };

--- a/packages/esm-ward-app/src/ward-workspace/admit-patient-button.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/admit-patient-button.component.tsx
@@ -1,0 +1,82 @@
+import { Button } from '@carbon/react';
+import {
+  ArrowRightIcon,
+  launchWorkspace,
+  showSnackbar,
+  useAppContext,
+  useFeatureFlag,
+  useLayoutType,
+} from '@openmrs/esm-framework';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import useWardLocation from '../hooks/useWardLocation';
+import type { WardPatient, WardPatientWorkspaceProps, WardViewContext } from '../types';
+import { useAdmitPatient } from '../ward.resource';
+
+interface AdmissionPatientButtonProps {
+  wardPatient: WardPatient;
+  onAdmitPatientSuccess();
+}
+
+const AdmissionPatientButton: React.FC<AdmissionPatientButtonProps> = ({ wardPatient, onAdmitPatientSuccess }) => {
+  const { patient, inpatientRequest, bed } = wardPatient ?? {};
+  const dispositionType = inpatientRequest?.dispositionType ?? 'ADMIT';
+  const { t } = useTranslation();
+  const { location } = useWardLocation();
+  const responsiveSize = useLayoutType() === 'tablet' ? 'lg' : 'md';
+  const { WardPatientHeader, wardPatientGroupDetails } = useAppContext<WardViewContext>('ward-view-context') ?? {};
+  const { admitPatient, isLoadingEmrConfiguration, errorFetchingEmrConfiguration } = useAdmitPatient();
+
+  const launchPatientAdmissionForm = () =>
+    launchWorkspace<WardPatientWorkspaceProps>('admit-patient-form-workspace', { wardPatient, WardPatientHeader });
+
+  const isBedManagementModuleInstalled = useFeatureFlag('bedmanagement-module');
+
+  // If bed management module is installed and the patient does not currently assigned a bed,
+  // open the next form for bed selection. If not, admit patient directly
+  // (Note that it is possible, albeit an edge case, for a patient to have a bed assigned while not admitted)
+  const onAdmit = () => {
+    if (isBedManagementModuleInstalled && !bed) {
+      launchPatientAdmissionForm();
+    } else {
+      admitPatient(patient, dispositionType)
+        .then(
+          (response) => {
+            if (response && response?.ok) {
+              showSnackbar({
+                kind: 'success',
+                title: t('patientAdmittedSuccessfully', 'Patient admitted successfully'),
+                subtitle: t('patientAdmittedWoBed', 'Patient admitted successfully to {{location}}', {
+                  location: location?.display,
+                }),
+              });
+            }
+          },
+          (err: Error) => {
+            showSnackbar({
+              kind: 'error',
+              title: t('errorCreatingEncounter', 'Failed to admit patient'),
+              subtitle: err.message,
+            });
+          },
+        )
+        .finally(() => {
+          wardPatientGroupDetails?.mutate?.();
+          onAdmitPatientSuccess();
+        });
+    }
+  };
+
+  return (
+    <Button
+      kind="ghost"
+      renderIcon={ArrowRightIcon}
+      size={responsiveSize}
+      disabled={isLoadingEmrConfiguration || errorFetchingEmrConfiguration}
+      onClick={onAdmit}>
+      {t('admitPatient', 'Admit patient')}
+    </Button>
+  );
+};
+
+export default AdmissionPatientButton;

--- a/packages/esm-ward-app/src/ward-workspace/admit-patient-form-workspace/admit-patient-form.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/admit-patient-form-workspace/admit-patient-form.workspace.tsx
@@ -25,8 +25,8 @@ const AdmitPatientFormWorkspace: React.FC<WardPatientWorkspaceProps> = ({
   closeWorkspaceWithSavedChanges,
   promptBeforeClosing,
 }) => {
-  const { patient, inpatientRequest } = wardPatient;
-  const { dispositionType } = inpatientRequest;
+  const { patient, inpatientRequest } = wardPatient ?? {};
+  const dispositionType = inpatientRequest?.dispositionType ?? 'ADMIT';
 
   const { t } = useTranslation();
   const { location } = useWardLocation();

--- a/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-transfer-swap.scss
+++ b/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-transfer-swap.scss
@@ -9,6 +9,10 @@
   color: #393939;
 }
 
+.formError {
+  margin-bottom: layout.$spacing-05;
+}
+
 .workspaceContent {
   padding: layout.$spacing-05;
   height: 100%;

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -93,6 +93,8 @@
   "transfers": "Transfers",
   "transferType": "Transfer type",
   "typeOfTransfer": "Type of transfer",
+  "unableToTransferPatient": "Unable to transfer patient",
+  "unableToTransferPatientNotYetAdmitted": "This patient is not admitted to this ward. Admit this patient before transferring them to a different location.",
   "unknown": "Unknown",
   "visitNoteSaved": "Patient note saved",
   "wardClinicalNotePlaceholder": "Write any notes here",


### PR DESCRIPTION
…ble to transfer

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
It is technically possible, albeit an edge case, to have a patient assigned a bed without being admitted to a ward location. Currently, it's also possible to create a transfer request for the patient, but the pending transfer request fails to show up within the patient card.

This PR changes the UI to force the user to admit a patient first (if they haven't already), before being able to transfer them.

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/user-attachments/assets/793abe1d-83e6-4a44-a0c2-ad0dc5ec3ac6)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4023

## Other
<!-- Anything not covered above -->
