### PR TITLE
(feat) O3-4044 Ward App - use vertical tiling for ward patient cards

### DIFF
--- a/packages/esm-ward-app/src/index.ts
+++ b/packages/esm-ward-app/src/index.ts
@@ -117,10 +117,4 @@ export function startupApp() {
     'Bed management module',
     'Enables features related to bed management / assignment. Requires the backend bed management module to be installed.',
   );
-
-  registerFeatureFlag(
-    'ward-view-vertical-tiling',
-    'Ward view vertical tiling',
-    'Enable tiling of bed cards vertically in the ward view.',
-  );
 }

--- a/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
@@ -13,7 +13,6 @@ const WardView: React.FC<{}> = () => {
   const { t } = useTranslation();
 
   const locationUuid = location?.uuid;
-  const isVertical = useFeatureFlag('ward-view-vertical-tiling');
   const wardConfig = useWardConfig(locationUuid);
 
   if (isLoadingLocation) {
@@ -27,7 +26,7 @@ const WardView: React.FC<{}> = () => {
   const wardId = wardConfig.id;
 
   return (
-    <div className={classNames(styles.wardView, { [styles.verticalTiling]: isVertical })}>
+    <div className={classNames(styles.wardView, styles.verticalTiling)}>
       <ExtensionSlot name={wardId} />
     </div>
   );

--- a/packages/esm-ward-app/src/ward-view/ward.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/ward.component.tsx
@@ -11,12 +11,11 @@ import styles from './ward-view.scss';
 const Ward = ({ wardBeds, wardUnassignedPatients }: { wardBeds: ReactNode; wardUnassignedPatients: ReactNode }) => {
   const { location } = useWardLocation();
   const { t } = useTranslation();
-  const isVertical = useFeatureFlag('ward-view-vertical-tiling');
 
-  const {wardPatientGroupDetails} = useAppContext<WardViewContext>('ward-view-context') ?? {};
+  const { wardPatientGroupDetails } = useAppContext<WardViewContext>('ward-view-context') ?? {};
   const { bedLayouts } = wardPatientGroupDetails ?? {};
   const { isLoading: isLoadingAdmissionLocation, error: errorLoadingAdmissionLocation } =
-  wardPatientGroupDetails?.admissionLocationResponse ?? {};
+    wardPatientGroupDetails?.admissionLocationResponse ?? {};
   const {
     isLoading: isLoadingInpatientAdmissions,
     error: errorLoadingInpatientAdmissions,
@@ -56,7 +55,7 @@ const Ward = ({ wardBeds, wardUnassignedPatients }: { wardBeds: ReactNode; wardU
   if (!wardPatientGroupDetails) return <></>;
 
   return (
-    <div className={classNames(styles.wardViewMain, { [styles.verticalTiling]: isVertical })}>
+    <div className={classNames(styles.wardViewMain, styles.verticalTiling)}>
       {wardBeds}
       {bedLayouts?.length == 0 && isBedManagementModuleInstalled && (
         <InlineNotification


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Previously, vertical tiling mode for ward patient cards was behind a feature flag. The ward view scrolls vertically when there is not enough screen space to display the cards. Feedback from both PIH team and UX designers seems positive on it, so I'm just going to enable it. 

## Screenshots
<!-- Required if you are making UI changes. -->
Ward with many beds + patients. The ward view uses vertical scrolling.
![image](https://github.com/user-attachments/assets/19394f7b-1a19-4f18-b2a3-13a00a88443a)

Ward with few beds + patients. Note that the tiling mode prefers roughly even height for each column, so in this case, the tiling actually appears horizontal.
![image](https://github.com/user-attachments/assets/41d04b44-c161-4b79-8cc0-20a8bad8f836)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4044

## Other
<!-- Anything not covered above -->
