### PR TITLE
(refactor) O3-4199: Bed management should use the modal system

### DIFF
--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
@@ -37,8 +37,7 @@ interface BedAdministrationFormProps {
   headerTitle: string;
   initialData: BedWithLocation;
   occupancyStatuses: string[];
-  onModalChange: (showModal: boolean) => void;
-  showModal: boolean;
+  closeModal: () => void;
 }
 
 interface ErrorType {
@@ -86,8 +85,7 @@ const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
   headerTitle,
   initialData,
   occupancyStatuses,
-  onModalChange,
-  showModal,
+  closeModal,
 }) => {
   const { t } = useTranslation();
   const [occupancyStatus, setOccupancyStatus] = useState(capitalize(initialData.status));
@@ -129,9 +127,8 @@ const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
   };
 
   return (
-    // TODO: Port this over to the modal system or create individual modals for each form
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
-      <ModalHeader title={headerTitle} />
+    <React.Fragment>
+      <ModalHeader title={headerTitle} closeModal={closeModal} />
       <ModalBody hasScrollingContent>
         <Form>
           <Stack gap={3}>
@@ -283,14 +280,14 @@ const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
         </Form>
       </ModalBody>
       <ModalFooter>
-        <Button onClick={() => onModalChange(false)} kind="secondary">
+        <Button onClick={closeModal} kind="secondary">
           {getCoreTranslation('cancel', 'Cancel')}
         </Button>
         <Button disabled={!isDirty} onClick={handleSubmit(onSubmit, onError)}>
           <span>{t('save', 'Save')}</span>
         </Button>
       </ModalFooter>
-    </ComposedModal>
+    </React.Fragment>
   );
 };
 

--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
@@ -6,7 +6,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import {
   Button,
   ComboBox,
-  ComposedModal,
   Form,
   FormGroup,
   InlineNotification,
@@ -196,17 +195,7 @@ const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
                     items={allLocations}
                     itemToString={(location) => location?.display ?? ''}
                     label={t('location', 'Location')}
-                    /*
-                      TODO: onBlur shall be refactored to onBlur={onBlur} if esm-core has @carbon/react version 1.72+
-                      (ComboBox bug does not trigger onChange below mentioned version in production build - see https://github.com/carbon-design-system/carbon/issues/18145#issuecomment-2521936772)
-                    */
-                    onBlur={(event) => {
-                      const selectedLocation = allLocations.find((element) => element.display === event.target.value);
-                      if (selectedLocation)
-                        setValue('location', { display: selectedLocation.display, uuid: selectedLocation.uuid });
-                      else setValue('location', { display: '', uuid: '' });
-                      onBlur();
-                    }}
+                    onBlur={onBlur}
                     onChange={({ selectedItem }) => onChange(selectedItem)}
                     placeholder={t('selectBedLocation', 'Select a bed location')}
                     ref={ref}

--- a/packages/esm-bed-management-app/src/bed-administration/edit-bed-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/edit-bed-form.component.tsx
@@ -64,7 +64,18 @@ const EditBedForm: React.FC<EditBedFormProps> = ({ closeModal, editData, mutate 
         })
         .finally(closeModal);
     },
-    [closeModal, mutate, t],
+    [
+      closeModal,
+      editData.bedNumber,
+      editData.bedType.name,
+      editData.column,
+      editData.location.uuid,
+      editData.row,
+      editData.status,
+      editData.uuid,
+      mutate,
+      t,
+    ],
   );
 
   return (

--- a/packages/esm-bed-management-app/src/bed-administration/edit-bed-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/edit-bed-form.component.tsx
@@ -62,7 +62,7 @@ const EditBedForm: React.FC<EditBedFormProps> = ({ closeModal, editData, mutate 
             subtitle: error?.responseBody?.error?.message ?? error?.message,
           });
         })
-        .finally(() => closeModal());
+        .finally(closeModal);
     },
     [closeModal, mutate, t],
   );

--- a/packages/esm-bed-management-app/src/bed-administration/edit-bed-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/edit-bed-form.component.tsx
@@ -10,11 +10,10 @@ import BedAdministrationForm from './bed-administration-form.component';
 interface EditBedFormProps {
   editData: BedWithLocation;
   mutate: () => void;
-  onModalChange: (showModal: boolean) => void;
-  showModal: boolean;
+  closeModal: () => void;
 }
 
-const EditBedForm: React.FC<EditBedFormProps> = ({ showModal, onModalChange, editData, mutate }) => {
+const EditBedForm: React.FC<EditBedFormProps> = ({ closeModal, editData, mutate }) => {
   const { t } = useTranslation();
   const { admissionLocations } = useLocationsWithAdmissionTag();
   const { bedTypes } = useBedType();
@@ -63,11 +62,9 @@ const EditBedForm: React.FC<EditBedFormProps> = ({ showModal, onModalChange, edi
             subtitle: error?.responseBody?.error?.message ?? error?.message,
           });
         })
-        .finally(() => {
-          onModalChange(false);
-        });
+        .finally(() => closeModal());
     },
-    [editData, mutate, onModalChange, t],
+    [closeModal, mutate, t],
   );
 
   return (
@@ -78,8 +75,7 @@ const EditBedForm: React.FC<EditBedFormProps> = ({ showModal, onModalChange, edi
       headerTitle={headerTitle}
       initialData={editData}
       occupancyStatuses={occupancyStatuses}
-      onModalChange={onModalChange}
-      showModal={showModal}
+      closeModal={closeModal}
     />
   );
 };

--- a/packages/esm-bed-management-app/src/bed-administration/new-bed-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/new-bed-form.component.tsx
@@ -63,7 +63,7 @@ const NewBedForm: React.FC<NewBedFormProps> = ({ closeModal, mutate, defaultLoca
             subtitle: error?.responseBody?.error?.message ?? error?.message,
           });
         })
-        .finally(() => closeModal());
+        .finally(closeModal);
     },
     [t, mutate, closeModal],
   );

--- a/packages/esm-bed-management-app/src/bed-administration/new-bed-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/new-bed-form.component.tsx
@@ -1,20 +1,19 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { showSnackbar } from '@openmrs/esm-framework';
-import { type BedWithLocation } from '../types';
-import { type BedAdministrationData } from './bed-administration-types';
 import { saveBed, useBedType } from './bed-administration.resource';
 import { useLocationsWithAdmissionTag } from '../summary/summary.resource';
 import BedAdministrationForm from './bed-administration-form.component';
+import { type BedWithLocation } from '../types';
+import { type BedAdministrationData } from './bed-administration-types';
 
 interface NewBedFormProps {
   mutate: () => void;
-  onModalChange: (showModal: boolean) => void;
-  showModal: boolean;
+  closeModal: () => void;
   defaultLocation?: { display: string; uuid: string };
 }
 
-const NewBedForm: React.FC<NewBedFormProps> = ({ showModal, onModalChange, mutate, defaultLocation }) => {
+const NewBedForm: React.FC<NewBedFormProps> = ({ closeModal, mutate, defaultLocation }) => {
   const { t } = useTranslation();
   const { admissionLocations } = useLocationsWithAdmissionTag();
   const { bedTypes } = useBedType();
@@ -64,19 +63,16 @@ const NewBedForm: React.FC<NewBedFormProps> = ({ showModal, onModalChange, mutat
             subtitle: error?.responseBody?.error?.message ?? error?.message,
           });
         })
-        .finally(() => {
-          onModalChange(false);
-        });
+        .finally(() => closeModal());
     },
-    [onModalChange, mutate, t],
+    [t, mutate, closeModal],
   );
 
   return (
     <BedAdministrationForm
-      onModalChange={onModalChange}
+      closeModal={closeModal}
       allLocations={admissionLocations}
       availableBedTypes={availableBedTypes}
-      showModal={showModal}
       handleCreateBed={handleCreateBed}
       headerTitle={headerTitle}
       occupancyStatuses={occupancyStatuses}

--- a/packages/esm-bed-management-app/src/bed-tag/bed-tag-administration-table.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-tag/bed-tag-administration-table.component.tsx
@@ -16,12 +16,10 @@ import {
   Tile,
 } from '@carbon/react';
 import { Add, Edit } from '@carbon/react/icons';
-import { ErrorState, isDesktop as desktopLayout, useLayoutType } from '@openmrs/esm-framework';
+import { ErrorState, isDesktop as desktopLayout, showModal, useLayoutType } from '@openmrs/esm-framework';
 import type { BedTagData } from '../types';
 import { useBedTags } from '../summary/summary.resource';
-import BedTagForm from './new-tag-form.component';
 import CardHeader from '../card-header/card-header.component';
-import EditBedTagForm from './edit-tag-form.component';
 import Header from '../header/header.component';
 import styles from '../bed-administration/bed-administration-table.scss';
 
@@ -35,11 +33,23 @@ const BedTagAdministrationTable: React.FC = () => {
   const { bedTags, errorLoadingBedTags, isLoadingBedTags, isValidatingBedTags, mutateBedTags } = useBedTags();
 
   const [isBedDataLoading] = useState(false);
-  const [showBedTagsModal, setAddBedTagsModal] = useState(false);
-  const [showEditBedModal, setShowEditBedModal] = useState(false);
-  const [editData, setEditData] = useState<BedTagData>();
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
+
+  const openNewBedTagModal = () => {
+    const dispose = showModal('new-bed-tag-modal', {
+      closeModal: () => dispose(),
+      mutate: mutateBedTags,
+    });
+  };
+
+  const openEditBedTagModal = (editData: BedTagData) => {
+    const dispose = showModal('edit-bed-tag-modal', {
+      closeModal: () => dispose(),
+      mutate: mutateBedTags,
+      editData: editData,
+    });
+  };
 
   const tableHeaders = [
     {
@@ -67,9 +77,7 @@ const BedTagAdministrationTable: React.FC = () => {
             renderIcon={Edit}
             onClick={(e) => {
               e.preventDefault();
-              setEditData(entry);
-              setShowEditBedModal(true);
-              setAddBedTagsModal(false);
+              openEditBedTagModal(entry);
             }}
             kind={'ghost'}
             iconDescription={t('editBedTag', 'Edit Bed Tag')}
@@ -109,26 +117,12 @@ const BedTagAdministrationTable: React.FC = () => {
       <Header title={t('bedTags', 'Bed tags')} />
 
       <div className={styles.widgetCard}>
-        {showBedTagsModal ? (
-          <BedTagForm onModalChange={setAddBedTagsModal} showModal={showBedTagsModal} mutate={mutateBedTags} />
-        ) : null}
-        {showEditBedModal ? (
-          <EditBedTagForm
-            onModalChange={setShowEditBedModal}
-            showModal={showEditBedModal}
-            editData={editData}
-            mutate={mutateBedTags}
-          />
-        ) : null}
         <CardHeader title={headerTitle}>
           <span className={styles.backgroundDataFetchingIndicator}>
             <span>{isValidatingBedTags ? <InlineLoading /> : null}</span>
           </span>
           {bedTags?.length ? (
-            <Button
-              kind="ghost"
-              renderIcon={(props) => <Add size={16} {...props} />}
-              onClick={() => setAddBedTagsModal(true)}>
+            <Button kind="ghost" renderIcon={(props) => <Add size={16} {...props} />} onClick={openNewBedTagModal}>
               {t('addBedTag', 'Add bed tag')}
             </Button>
           ) : null}
@@ -166,7 +160,7 @@ const BedTagAdministrationTable: React.FC = () => {
                       kind="ghost"
                       size="sm"
                       renderIcon={(props) => <Add size={16} {...props} />}
-                      onClick={() => setAddBedTagsModal(true)}>
+                      onClick={openNewBedTagModal}>
                       {t('addBedTag', 'Add bed tag')}
                     </Button>
                   </Tile>

--- a/packages/esm-bed-management-app/src/bed-tag/bed-tag-administration-table.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-tag/bed-tag-administration-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -43,13 +43,16 @@ const BedTagAdministrationTable: React.FC = () => {
     });
   };
 
-  const openEditBedTagModal = (editData: BedTagData) => {
-    const dispose = showModal('edit-bed-tag-modal', {
-      closeModal: () => dispose(),
-      mutate: mutateBedTags,
-      editData: editData,
-    });
-  };
+  const openEditBedTagModal = useCallback(
+    (editData: BedTagData) => {
+      const dispose = showModal('edit-bed-tag-modal', {
+        closeModal: () => dispose(),
+        mutate: mutateBedTags,
+        editData: editData,
+      });
+    },
+    [mutateBedTags],
+  );
 
   const tableHeaders = [
     {
@@ -88,7 +91,7 @@ const BedTagAdministrationTable: React.FC = () => {
         </>
       ),
     }));
-  }, [responsiveSize, bedTags, t]);
+  }, [bedTags, t, responsiveSize, openEditBedTagModal]);
 
   if (isBedDataLoading || isLoadingBedTags) {
     return (

--- a/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
@@ -75,8 +75,8 @@ const BedTagsAdministrationForm: React.FC<BedTagAdministrationFormProps> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
-      <ModalHeader title={headerTitle} />
+    <React.Fragment>
+      <ModalHeader title={headerTitle} closeModal={() => onModalChange(false)} />
       <ModalBody hasScrollingContent>
         <Form>
           <Stack gap={3}>
@@ -120,7 +120,7 @@ const BedTagsAdministrationForm: React.FC<BedTagAdministrationFormProps> = ({
           <span>{t('save', 'Save')}</span>
         </Button>
       </ModalFooter>
-    </ComposedModal>
+    </React.Fragment>
   );
 };
 

--- a/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
@@ -29,8 +29,7 @@ interface BedTagAdministrationFormProps {
   handleDeleteBedTag?: () => void;
   headerTitle: string;
   initialData: BedTagData;
-  onModalChange: (showModal: boolean) => void;
-  showModal: boolean;
+  closeModal: () => void;
 }
 
 interface ErrorType {
@@ -41,8 +40,7 @@ const BedTagsAdministrationForm: React.FC<BedTagAdministrationFormProps> = ({
   handleCreateBedTag,
   headerTitle,
   initialData,
-  onModalChange,
-  showModal,
+  closeModal,
 }) => {
   const { t } = useTranslation();
 
@@ -76,7 +74,7 @@ const BedTagsAdministrationForm: React.FC<BedTagAdministrationFormProps> = ({
 
   return (
     <React.Fragment>
-      <ModalHeader title={headerTitle} closeModal={() => onModalChange(false)} />
+      <ModalHeader title={headerTitle} closeModal={closeModal} />
       <ModalBody hasScrollingContent>
         <Form>
           <Stack gap={3}>
@@ -113,7 +111,7 @@ const BedTagsAdministrationForm: React.FC<BedTagAdministrationFormProps> = ({
         </Form>
       </ModalBody>
       <ModalFooter>
-        <Button onClick={() => onModalChange(false)} kind="secondary">
+        <Button onClick={closeModal} kind="secondary">
           {getCoreTranslation('cancel', 'Cancel')}
         </Button>
         <Button disabled={!isDirty} onClick={handleSubmit(onSubmit, onError)}>

--- a/packages/esm-bed-management-app/src/bed-tag/edit-tag-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-tag/edit-tag-form.component.tsx
@@ -9,11 +9,10 @@ import BedTagsAdministrationForm from './bed-tags-admin-form.component';
 interface EditBedTagFormProps {
   editData: BedTagData;
   mutate: Mutator<BedTagData>;
-  onModalChange: (showModal: boolean) => void;
-  showModal: boolean;
+  closeModal: () => void;
 }
 
-const EditBedTagForm: React.FC<EditBedTagFormProps> = ({ editData, mutate, onModalChange, showModal }) => {
+const EditBedTagForm: React.FC<EditBedTagFormProps> = ({ editData, mutate, closeModal }) => {
   const { t } = useTranslation();
   const { bedTags } = useBedTags();
   const headerTitle = t('editTag', 'Edit Tag');
@@ -45,11 +44,9 @@ const EditBedTagForm: React.FC<EditBedTagFormProps> = ({ editData, mutate, onMod
             subtitle: error?.message,
           });
         })
-        .finally(() => {
-          onModalChange(false);
-        });
+        .finally(closeModal);
     },
-    [onModalChange, mutate, editData, t],
+    [editData.uuid, closeModal, t, mutate],
   );
 
   return (
@@ -60,8 +57,7 @@ const EditBedTagForm: React.FC<EditBedTagFormProps> = ({ editData, mutate, onMod
         handleCreateBedTag={handleUpdateBedTag}
         headerTitle={headerTitle}
         initialData={editData}
-        onModalChange={onModalChange}
-        showModal={showModal}
+        closeModal={closeModal}
       />
     </>
   );

--- a/packages/esm-bed-management-app/src/bed-tag/new-tag-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-tag/new-tag-form.component.tsx
@@ -7,11 +7,10 @@ import BedTagsAdministrationForm from './bed-tags-admin-form.component';
 
 interface BedTagFormProps {
   mutate: () => void;
-  onModalChange: (showModal: boolean) => void;
-  showModal: boolean;
+  closeModal: () => void;
 }
 
-const NewTagForm: React.FC<BedTagFormProps> = ({ showModal, onModalChange, mutate }) => {
+const NewTagForm: React.FC<BedTagFormProps> = ({ closeModal, mutate }) => {
   const { t } = useTranslation();
   const { admissionLocations } = useLocationsWithAdmissionTag();
   const { bedTags } = useBedTags();
@@ -48,11 +47,9 @@ const NewTagForm: React.FC<BedTagFormProps> = ({ showModal, onModalChange, mutat
             subtitle: error?.message,
           });
         })
-        .finally(() => {
-          onModalChange(false);
-        });
+        .finally(closeModal);
     },
-    [onModalChange, mutate, t],
+    [closeModal, t, mutate],
   );
 
   return (
@@ -62,8 +59,7 @@ const NewTagForm: React.FC<BedTagFormProps> = ({ showModal, onModalChange, mutat
       handleCreateBedTag={handleCreateBedTag}
       headerTitle={headerTitle}
       initialData={initialData}
-      onModalChange={onModalChange}
-      showModal={showModal}
+      closeModal={closeModal}
     />
   );
 };

--- a/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
@@ -79,8 +79,8 @@ const BedTypeAdministrationForm: React.FC<BedAdministrationFormProps> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
-      <ModalHeader title={headerTitle} />
+    <React.Fragment>
+      <ModalHeader title={headerTitle} closeModal={() => onModalChange(false)} />
       <ModalBody hasScrollingContent>
         <Form>
           <Stack gap={3}>
@@ -155,7 +155,7 @@ const BedTypeAdministrationForm: React.FC<BedAdministrationFormProps> = ({
           <span>{t('save', 'Save')}</span>
         </Button>
       </ModalFooter>
-    </ComposedModal>
+    </React.Fragment>
   );
 };
 

--- a/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
@@ -31,8 +31,7 @@ interface BedAdministrationFormProps {
   handleSubmission?: (formData: BedTypeData) => void;
   headerTitle: string;
   initialData: BedTypeData;
-  onModalChange: (showModal: boolean) => void;
-  showModal: boolean;
+  closeModal: () => void;
 }
 
 interface ErrorType {
@@ -43,8 +42,7 @@ const BedTypeAdministrationForm: React.FC<BedAdministrationFormProps> = ({
   handleSubmission,
   headerTitle,
   initialData,
-  onModalChange,
-  showModal,
+  closeModal,
 }) => {
   const { t } = useTranslation();
 
@@ -80,7 +78,7 @@ const BedTypeAdministrationForm: React.FC<BedAdministrationFormProps> = ({
 
   return (
     <React.Fragment>
-      <ModalHeader title={headerTitle} closeModal={() => onModalChange(false)} />
+      <ModalHeader title={headerTitle} closeModal={closeModal} />
       <ModalBody hasScrollingContent>
         <Form>
           <Stack gap={3}>
@@ -148,7 +146,7 @@ const BedTypeAdministrationForm: React.FC<BedAdministrationFormProps> = ({
         </Form>
       </ModalBody>
       <ModalFooter>
-        <Button onClick={() => onModalChange(false)} kind="secondary">
+        <Button onClick={closeModal} kind="secondary">
           {getCoreTranslation('cancel', 'Cancel')}
         </Button>
         <Button disabled={!isDirty} onClick={handleSubmit(onSubmit, onError)}>

--- a/packages/esm-bed-management-app/src/bed-type/bed-type-administration-table.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-type/bed-type-administration-table.component.tsx
@@ -17,7 +17,7 @@ import {
   Tile,
 } from '@carbon/react';
 import { Add, Edit } from '@carbon/react/icons';
-import { ErrorState, isDesktop as desktopLayout, useLayoutType } from '@openmrs/esm-framework';
+import { ErrorState, isDesktop as desktopLayout, showModal, useLayoutType } from '@openmrs/esm-framework';
 import type { BedTypeData } from '../types';
 import { useBedTypes } from '../summary/summary.resource';
 import CardHeader from '../card-header/card-header.component';
@@ -37,10 +37,22 @@ const BedTypeAdministrationTable: React.FC = () => {
 
   const [currentPage, setCurrentPage] = useState(1);
   const [currentPageSize, setPageSize] = useState(10);
-  const [editData, setEditData] = useState<BedTypeData>();
   const [pageSize] = useState(10);
-  const [showBedTypeModal, setAddBedTypeModal] = useState(false);
-  const [showEditBedModal, setShowEditBedModal] = useState(false);
+
+  const openNewBedTypeModal = () => {
+    const dispose = showModal('new-bed-type-modal', {
+      closeModal: () => dispose(),
+      mutate: mutateBedTypes,
+    });
+  };
+
+  const openEditBedTypeModal = (editData: BedTypeData) => {
+    const dispose = showModal('edit-bed-type-modal', {
+      closeModal: () => dispose(),
+      mutate: mutateBedTypes,
+      editData,
+    });
+  };
 
   const tableHeaders = [
     {
@@ -76,9 +88,7 @@ const BedTypeAdministrationTable: React.FC = () => {
             label={t('editBedType', 'Edit bed type')}
             onClick={(e) => {
               e.preventDefault();
-              setEditData(entry);
-              setShowEditBedModal(true);
-              setAddBedTypeModal(false);
+              openEditBedTypeModal(entry);
             }}
             size={responsiveSize}>
             <Edit />
@@ -113,28 +123,13 @@ const BedTypeAdministrationTable: React.FC = () => {
   return (
     <>
       <Header title={t('bedTypes', 'Bed types')} />
-
       <div className={styles.widgetCard}>
-        {showBedTypeModal ? (
-          <BedTypeForm onModalChange={setAddBedTypeModal} showModal={showBedTypeModal} mutate={mutateBedTypes} />
-        ) : null}
-        {showEditBedModal ? (
-          <EditBedTypeForm
-            editData={editData}
-            mutate={mutateBedTypes}
-            onModalChange={setShowEditBedModal}
-            showModal={showEditBedModal}
-          />
-        ) : null}
         <CardHeader title={headerTitle}>
           <span className={styles.backgroundDataFetchingIndicator}>
             <span>{isValidatingBedTypes ? <InlineLoading /> : null}</span>
           </span>
           {bedTypes?.length ? (
-            <Button
-              kind="ghost"
-              renderIcon={(props) => <Add size={16} {...props} />}
-              onClick={() => setAddBedTypeModal(true)}>
+            <Button kind="ghost" renderIcon={(props) => <Add size={16} {...props} />} onClick={openNewBedTypeModal}>
               {t('addBedType', 'Add bed type')}
             </Button>
           ) : null}
@@ -172,7 +167,7 @@ const BedTypeAdministrationTable: React.FC = () => {
                       kind="ghost"
                       size="sm"
                       renderIcon={(props) => <Add size={16} {...props} />}
-                      onClick={() => setAddBedTypeModal(true)}>
+                      onClick={openNewBedTypeModal}>
                       {t('addBedType', 'Add bed type')}
                     </Button>
                   </Tile>

--- a/packages/esm-bed-management-app/src/bed-type/bed-type-administration-table.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-type/bed-type-administration-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
@@ -21,8 +21,6 @@ import { ErrorState, isDesktop as desktopLayout, showModal, useLayoutType } from
 import type { BedTypeData } from '../types';
 import { useBedTypes } from '../summary/summary.resource';
 import CardHeader from '../card-header/card-header.component';
-import BedTypeForm from './new-bed-type-form.component';
-import EditBedTypeForm from './edit-bed-type.component';
 import Header from '../header/header.component';
 import styles from '../bed-administration/bed-administration-table.scss';
 
@@ -46,13 +44,16 @@ const BedTypeAdministrationTable: React.FC = () => {
     });
   };
 
-  const openEditBedTypeModal = (editData: BedTypeData) => {
-    const dispose = showModal('edit-bed-type-modal', {
-      closeModal: () => dispose(),
-      mutate: mutateBedTypes,
-      editData,
-    });
-  };
+  const openEditBedTypeModal = useCallback(
+    (editData: BedTypeData) => {
+      const dispose = showModal('edit-bed-type-modal', {
+        closeModal: () => dispose(),
+        mutate: mutateBedTypes,
+        editData,
+      });
+    },
+    [mutateBedTypes],
+  );
 
   const tableHeaders = [
     {
@@ -95,7 +96,7 @@ const BedTypeAdministrationTable: React.FC = () => {
           </IconButton>
         ),
       })),
-    [responsiveSize, bedTypes, t],
+    [openEditBedTypeModal, responsiveSize, bedTypes, t],
   );
 
   if (isLoadingBedTypes) {

--- a/packages/esm-bed-management-app/src/bed-type/edit-bed-type.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-type/edit-bed-type.component.tsx
@@ -9,11 +9,10 @@ import BedTypeAdministrationForm from './bed-type-admin-form.component';
 interface EditBedTypeFormProps {
   editData: BedTypeData;
   mutate: Mutator<BedType>;
-  onModalChange: (showModal: boolean) => void;
-  showModal: boolean;
+  closeModal: () => void;
 }
 
-const EditBedTypeForm: React.FC<EditBedTypeFormProps> = ({ editData, mutate, onModalChange, showModal }) => {
+const EditBedTypeForm: React.FC<EditBedTypeFormProps> = ({ editData, mutate, closeModal }) => {
   const { t } = useTranslation();
   const { bedTypes } = useBedTypes();
   const headerTitle = t('editBedType', 'Edit bed type');
@@ -48,25 +47,20 @@ const EditBedTypeForm: React.FC<EditBedTypeFormProps> = ({ editData, mutate, onM
             kind: 'error',
           });
         })
-        .finally(() => {
-          onModalChange(false);
-        });
+        .finally(closeModal);
     },
-    [onModalChange, mutate, editData, t],
+    [editData.uuid, t, mutate, closeModal],
   );
 
   return (
-    <>
-      <BedTypeAdministrationForm
-        onModalChange={onModalChange}
-        availableBedTypes={bedTypes}
-        showModal={showModal}
-        handleSubmission={handleUpdateBedType}
-        headerTitle={headerTitle}
-        initialData={editData}
-        allLocations={[]}
-      />
-    </>
+    <BedTypeAdministrationForm
+      availableBedTypes={bedTypes}
+      handleSubmission={handleUpdateBedType}
+      headerTitle={headerTitle}
+      initialData={editData}
+      allLocations={[]}
+      closeModal={closeModal}
+    />
   );
 };
 

--- a/packages/esm-bed-management-app/src/bed-type/new-bed-type-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-type/new-bed-type-form.component.tsx
@@ -7,11 +7,10 @@ import BedTypeAdministrationForm from './bed-type-admin-form.component';
 
 interface BedTypeFormProps {
   mutate: Mutator<BedType>;
-  onModalChange: (showModal: boolean) => void;
-  showModal: boolean;
+  closeModal: () => void;
 }
 
-const NewBedTypeForm: React.FC<BedTypeFormProps> = ({ mutate, onModalChange, showModal }) => {
+const NewBedTypeForm: React.FC<BedTypeFormProps> = ({ mutate, closeModal }) => {
   const { t } = useTranslation();
   const { admissionLocations } = useLocationsWithAdmissionTag();
   const headerTitle = t('createBedType', 'Create bed type');
@@ -52,11 +51,9 @@ const NewBedTypeForm: React.FC<BedTypeFormProps> = ({ mutate, onModalChange, sho
             subtitle: error?.message,
           });
         })
-        .finally(() => {
-          onModalChange(false);
-        });
+        .finally(closeModal);
     },
-    [onModalChange, mutate, t],
+    [closeModal, t, mutate],
   );
 
   return (
@@ -66,8 +63,7 @@ const NewBedTypeForm: React.FC<BedTypeFormProps> = ({ mutate, onModalChange, sho
       handleSubmission={handleCreateBedType}
       headerTitle={headerTitle}
       initialData={initialData}
-      onModalChange={onModalChange}
-      showModal={showModal}
+      closeModal={closeModal}
     />
   );
 };

--- a/packages/esm-bed-management-app/src/index.ts
+++ b/packages/esm-bed-management-app/src/index.ts
@@ -59,3 +59,5 @@ export const newBedModal = getAsyncLifecycle(() => import('./bed-administration/
 export const editBedModal = getAsyncLifecycle(() => import('./bed-administration/edit-bed-form.component'), options);
 export const newBedTypeModal = getAsyncLifecycle(() => import('./bed-type/new-bed-type-form.component'), options);
 export const editBedTypeModal = getAsyncLifecycle(() => import('./bed-type/edit-bed-type.component'), options);
+export const newBedTagModal = getAsyncLifecycle(() => import('./bed-tag/new-tag-form.component'), options);
+export const editBedTagModal = getAsyncLifecycle(() => import('./bed-tag/edit-tag-form.component'), options);

--- a/packages/esm-bed-management-app/src/index.ts
+++ b/packages/esm-bed-management-app/src/index.ts
@@ -57,3 +57,5 @@ export const bedTagLeftPanelLink = getSyncLifecycle(
 
 export const newBedModal = getAsyncLifecycle(() => import('./bed-administration/new-bed-form.component'), options);
 export const editBedModal = getAsyncLifecycle(() => import('./bed-administration/edit-bed-form.component'), options);
+export const newBedTypeModal = getAsyncLifecycle(() => import('./bed-type/new-bed-type-form.component'), options);
+export const editBedTypeModal = getAsyncLifecycle(() => import('./bed-type/edit-bed-type.component'), options);

--- a/packages/esm-bed-management-app/src/index.ts
+++ b/packages/esm-bed-management-app/src/index.ts
@@ -56,3 +56,4 @@ export const bedTagLeftPanelLink = getSyncLifecycle(
 );
 
 export const newBedModal = getAsyncLifecycle(() => import('./bed-administration/new-bed-form.component'), options);
+export const editBedModal = getAsyncLifecycle(() => import('./bed-administration/edit-bed-form.component'), options);

--- a/packages/esm-bed-management-app/src/index.ts
+++ b/packages/esm-bed-management-app/src/index.ts
@@ -54,3 +54,5 @@ export const bedTagLeftPanelLink = getSyncLifecycle(
   }),
   options,
 );
+
+export const newBedModal = getAsyncLifecycle(() => import('./bed-administration/new-bed-form.component'), options);

--- a/packages/esm-bed-management-app/src/routes.json
+++ b/packages/esm-bed-management-app/src/routes.json
@@ -46,6 +46,14 @@
     {
       "name": "edit-bed-modal",
       "component": "editBedModal"
+    },
+    {
+      "name": "new-bed-type-modal",
+      "component": "newBedTypeModal"
+    },
+    {
+      "name": "edit-bed-type-modal",
+      "component": "editBedTypeModal"
     }
   ]
 }

--- a/packages/esm-bed-management-app/src/routes.json
+++ b/packages/esm-bed-management-app/src/routes.json
@@ -54,6 +54,14 @@
     {
       "name": "edit-bed-type-modal",
       "component": "editBedTypeModal"
+    },
+    {
+      "name": "new-bed-tag-modal",
+      "component": "newBedTagModal"
+    },
+    {
+      "name": "edit-bed-tag-modal",
+      "component": "editBedTagModal"
     }
   ]
 }

--- a/packages/esm-bed-management-app/src/routes.json
+++ b/packages/esm-bed-management-app/src/routes.json
@@ -37,5 +37,11 @@
       "slot": "bed-management-left-panel-slot",
       "order": 0
     }
+  ],
+  "modals": [
+    {
+      "name": "new-bed-modal",
+      "component": "newBedModal"
+    }
   ]
 }

--- a/packages/esm-bed-management-app/src/routes.json
+++ b/packages/esm-bed-management-app/src/routes.json
@@ -42,6 +42,10 @@
     {
       "name": "new-bed-modal",
       "component": "newBedModal"
+    },
+    {
+      "name": "edit-bed-modal",
+      "component": "editBedModal"
     }
   ]
 }

--- a/packages/esm-bed-management-app/src/ward-with-beds/ward-with-beds.component.tsx
+++ b/packages/esm-bed-management-app/src/ward-with-beds/ward-with-beds.component.tsx
@@ -17,9 +17,8 @@ import {
   InlineLoading,
 } from '@carbon/react';
 import { ArrowLeft, Add } from '@carbon/react/icons';
-import { navigate, usePagination } from '@openmrs/esm-framework';
+import { navigate, showModal, usePagination } from '@openmrs/esm-framework';
 import { useBedsForLocation, useLocationName } from '../summary/summary.resource';
-import NewBedForm from '../bed-administration/new-bed-form.component';
 import Header from '../header/header.component';
 import styles from './ward-with-beds.scss';
 
@@ -32,7 +31,6 @@ const WardWithBeds: React.FC = () => {
   const { name } = useLocationName(location);
 
   const [pageSize, setPageSize] = useState(10);
-  const [showAddBedModal, setShowAddBedModal] = useState(false);
   const { results: paginatedData, goTo, currentPage } = usePagination(bedsData, pageSize);
 
   if (isLoadingBeds) {
@@ -89,6 +87,14 @@ const WardWithBeds: React.FC = () => {
     }));
   }, [paginatedData]);
 
+  const openNewBedModal = () => {
+    const dispose = showModal('new-bed-modal', {
+      closeModal: () => dispose(),
+      mutate: mutate,
+      defaultLocation: { display: name, uuid: location },
+    });
+  };
+
   return (
     <>
       <Header title={name ? name : '--'} />
@@ -113,22 +119,9 @@ const WardWithBeds: React.FC = () => {
               <span>{t('returnToSummary', 'Return to summary')}</span>
             </Button>
             <span>{isValidating ? <InlineLoading /> : null}</span>
-            <Button
-              kind="ghost"
-              renderIcon={(props) => <Add size={16} {...props} />}
-              onClick={() => setShowAddBedModal(true)}>
+            <Button kind="ghost" renderIcon={(props) => <Add size={16} {...props} />} onClick={openNewBedModal}>
               <span>{t('addBed', 'Add bed')}</span>
             </Button>
-          </div>
-          <div>
-            {showAddBedModal ? (
-              <NewBedForm
-                mutate={mutate}
-                onModalChange={setShowAddBedModal}
-                showModal={showAddBedModal}
-                defaultLocation={{ display: name, uuid: location }}
-              />
-            ) : null}
           </div>
           <div className={styles.container}>
             <DataTable rows={tableRows} headers={tableHeaders} useZebraStyles>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR refactors the current modal functionality in the bed management app to use the openmrs modal system as described [here](https://o3-docs.openmrs.org/docs/modal-system). When I was working on this PR I was careful only to refactor the modals, separate edit-add functionalities _(beds, bed tags bed types)_, and not change any underlying implementation. Any change made can be considered absolutely necessary.

I also improved the UX when submitting the modals by adding loading states on the button and showing a spinner. Nothing major.

## Screenshots
<!-- Required if you are making UI changes. -->
### Short video verifying that nothing breaks after this change
https://github.com/user-attachments/assets/5e25e243-f2d7-4f17-915d-0b786401b138


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4199
## Other
<!-- Anything not covered above -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209837472253519