### PR TITLE
(chore) O3-3996 - Ward app - workspace styling changes

### DIFF
--- a/packages/esm-ward-app/src/action-menu-buttons/clinical-forms-workspace-siderail.component.tsx
+++ b/packages/esm-ward-app/src/action-menu-buttons/clinical-forms-workspace-siderail.component.tsx
@@ -29,7 +29,7 @@ const ClinicalFormsWorkspaceSideRailIcon: React.FC = () => {
       label={t('clinicalForms', 'Clinical forms')}
       iconDescription={t('clinicalForms', 'Clinical forms')}
       handler={launchPatientWorkspaceCb}
-      type="ward-patient-clinical-form"
+      type="ward-patient-clinical-forms"
     />
   );
 };

--- a/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail.component.tsx
+++ b/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail.component.tsx
@@ -14,7 +14,7 @@ export default function PatientDischargeSideRailIcon() {
       label={t('discharge', 'Discharge')}
       iconDescription={t('discharge', 'Discharge')}
       handler={handler}
-      type="patient-discharge-workspace"
+      type="ward-patient-discharge"
     />
   );
 }

--- a/packages/esm-ward-app/src/ward-workspace/patient-details/ward-patient.style.scss
+++ b/packages/esm-ward-app/src/ward-workspace/patient-details/ward-patient.style.scss
@@ -5,7 +5,19 @@
   min-height: var(--desktop-workspace-window-height);
 }
 
+.patientWorkspace {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+}
+
 .headerPatientDetail {
   @include type.type-style('body-compact-02');
   margin: 0 layout.$spacing-02;
+}
+
+.patientWorkspaceContentSlot {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
 }

--- a/packages/esm-ward-app/src/ward-workspace/patient-details/ward-patient.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-details/ward-patient.workspace.tsx
@@ -4,6 +4,7 @@ import { type WardPatientWorkspaceProps } from '../../types';
 import WardPatientWorkspaceBanner from '../patient-banner/patient-banner.component';
 import styles from './ward-patient.style.scss';
 import { type WardConfigObject } from '../../config-schema';
+import classNames from 'classnames';
 
 attach('ward-patient-workspace-header-slot', 'patient-vitals-info');
 
@@ -15,14 +16,14 @@ export default function WardPatientWorkspace({ wardPatient }: WardPatientWorkspa
   return (
     <>
       {wardPatient && (
-        <div className={styles.workspaceContainer}>
+        <div className={classNames(styles.workspaceContainer, styles.patientWorkspace)}>
           <WardPatientWorkspaceBanner {...{ wardPatient }} />
-          <div>
-            <ExtensionSlot name="ward-patient-workspace-header-slot" state={extensionSlotState} />
-          </div>
-          <div>
-            <ExtensionSlot name="ward-patient-workspace-content-slot" state={extensionSlotState} />
-          </div>
+          <ExtensionSlot name="ward-patient-workspace-header-slot" state={extensionSlotState} />
+          <ExtensionSlot
+            name="ward-patient-workspace-content-slot"
+            state={extensionSlotState}
+            className={styles.patientWorkspaceContentSlot}
+          />
         </div>
       )}
     </>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Minor CSS changes to enable the content extension in ward patient dashboard to take up the whole workspace height.

Also fixed the "type" of a few workspace action menu icon buttons. (the type string must match the workspace's type string, or else the icon does not get highlighted when the corresponding workspace is opened)

## Screenshots
<!-- Required if you are making UI changes. -->
Pregnancy dash:
![mother-dash](https://github.com/user-attachments/assets/11f8cf15-4ce9-4416-ae64-e69e658a1de9)

Infant dash:
![infant-dash](https://github.com/user-attachments/assets/421d529c-a23e-4037-90e1-ddea162716fe)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
