### PR TITLE
(fix): flatten beds array before filtering by occupancy status

### DIFF
--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration-table.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration-table.component.tsx
@@ -72,7 +72,7 @@ const BedAdministrationTable: React.FC = () => {
   const { results, currentPage, totalPages, goTo } = usePagination(
     filterOption === 'ALL'
       ? bedsGroupedByLocation
-      : bedsGroupedByLocation.filter((bed) => bed.status === filterOption) ?? [],
+      : bedsGroupedByLocation.flat().filter((bed) => bed.status === filterOption) ?? [],
     pageSize,
   );
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds a simple fix to flatten the bed's array before filtering the elements inside it. The issue was because previously we were running a filter on an array of arrays which made the callback item an array of beds not a bed.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/df6f01de-a940-426c-90ea-a24cc935ee8e



## Related Issue
https://openmrs.atlassian.net/browse/O3-3723

## Other
<!-- Anything not covered above -->
