### PR TITLE
(fix) O3-4207 : prevent double clicking on bed swap submittion

### DIFF
--- a/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-bed-swap-form.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-bed-swap-form.component.tsx
@@ -54,6 +54,7 @@ export default function PatientBedSwapForm({
   const onSubmit = useCallback(
     (values: FormValues) => {
       const bedSelected = beds.find((bed) => bed.bedId === values.bedId);
+      setIsSubmitting(true);
       setShowErrorNotifications(false);
       createEncounter(patient, emrConfiguration.bedAssignmentEncounterType)
         .then(async (response) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds a simple fix to set the `isSubmitting` state to true before making the API calls. This in consequence disables the save button to properly protect from double clicking and other probable debounce issues.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-4207

## Other
<!-- Anything not covered above -->
