### PR TITLE
(fix) Remove unused bed management extensions

### DIFF
--- a/packages/esm-bed-management-app/src/routes.json
+++ b/packages/esm-bed-management-app/src/routes.json
@@ -36,21 +36,6 @@
       "name": "bed-management-home-dashboard-link",
       "slot": "bed-management-left-panel-slot",
       "order": 0
-    },
-    {
-      "component": "bedAdmission",
-      "name": "bed-admission-dashboard",
-      "slot": "bed-admission-dashboard-slot"
-    },
-    {
-      "name": "bed-admission-dashboard-link",
-      "component": "bedAdmissionDashboardLink",
-      "slot": "homepage-dashboard-slot",
-      "meta": {
-        "name": "bed-admission",
-        "slot": "bed-admission-dashboard-slot",
-        "title": "Bed-admission"
-      }
     }
   ]
 }


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes some unused extension definitions from the Bed management app's `routes.json` file. This was likely cruft from the original repo that was copied over when we created the repository.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
