### PR TITLE
(fix) ward app - remove duplicate WorkspaceContainer

### DIFF
--- a/packages/esm-ward-app/src/root.component.tsx
+++ b/packages/esm-ward-app/src/root.component.tsx
@@ -15,8 +15,6 @@ const Root: React.FC = () => {
           <Route path="/:locationUuid" element={<WardView />} />
         </Routes>
       </BrowserRouter>
-      
-      <WorkspaceContainer overlay contextKey="ward" />
     </main>
   );
 };


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
From the `<WorkspaceContainer>` documentation:

> If there are multiple apps on a page, only one of those apps should use this component—it "hosts" the workspaces.

At some point, the `<WorkspaceContainer>` got added to `esm-home-app`, resulting in duplicate instances of that component. Having duplicate instances doesn't break functionality, but the workspace is loaded twice. This results in performance issues, especially when we have a custom workspace to load an iframe of the O2 patient chart. The PR just removes the `<WorkspaceContainer>` from the ward app. 

(This issue wouldn't have existed if if the Ward app isn't loaded as part of the home app. We plan to move towards decoupling them, after which we should add the `<WorkspaceContainer>` back into the ward app)

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
