### PR TITLE
(fix) O3-4275: Alignment issue for Time and Duration fields on invalid input

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.scss
+++ b/packages/esm-appointments-app/src/form/appointments-form.scss
@@ -36,7 +36,7 @@ $openmrs-background-grey: #ededed;
   display: flex;
   flex-flow: row wrap;
   gap: layout.$spacing-05;
-  align-items: center;
+  align-items: start;
 }
 
 .dateTimeFields {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This Pull Request fixes a UI bug in the Appointments Form of the esm-appointments-app module within the esm-patient-management-app monorepo. The issue was causing misalignment between the Time and Duration (minutes) fields when invalid input was entered in the Duration (minutes) field.


## Screenshots
Before:
![image](https://github.com/user-attachments/assets/fd073bb0-43c9-4671-a85a-79e80766353c)

After:
<img width="1470" alt="Screenshot 2024-12-14 at 12 44 53 PM" src="https://github.com/user-attachments/assets/d1b143a7-6e60-41c8-8f27-5ffa90d44ad2" />


## Related Issue
[O3-4275](https://openmrs.atlassian.net/browse/O3-4275)



[O3-4275]: https://openmrs.atlassian.net/browse/O3-4275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ