### PR TITLE
(fix) Add a css fix to make the close button visible in the cancel edit confimation modal

### DIFF
--- a/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.modal.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.modal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+import styles from './cancel-patient-edit.scss';
 
 interface CancelPatientEditPropsModal {
   close(): void;
@@ -14,6 +15,7 @@ const CancelPatientEditModal: React.FC<CancelPatientEditPropsModal> = ({ close, 
       <ModalHeader
         closeModal={close}
         title={t('confirmDiscardChangesTitle', 'Are you sure you want to discard these changes?')}
+        className={styles.modalHeader}
       />
       <ModalBody>
         <p>{t('confirmDiscardChangesBody', 'Your unsaved changes will be lost if you proceed to discard the form')}.</p>

--- a/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.scss
+++ b/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.scss
@@ -1,0 +1,29 @@
+@use '@carbon/layout';
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
+  }
+}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds a css fix to make the close button visible again in the cancel edit confirmation modal in patient registration.

## Screenshots
<!-- Required if you are making UI changes. -->
Before fix:
<img width="1710" alt="Screenshot 2024-12-18 at 1 48 52 PM" src="https://github.com/user-attachments/assets/27f70f08-6326-480d-9f00-11f95e2d3501" />
After fix:
<img width="1710" alt="Screenshot 2024-12-18 at 12 21 22 PM" src="https://github.com/user-attachments/assets/9feb9570-3a76-405a-8b9f-35da434354cc" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

