### PR TITLE
(fix) Standardize modal header close button styles

### DIFF
--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-cancel.modal.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-cancel.modal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import { changeAppointmentStatus, usePatientAppointments } from './patient-appointments.resource';
+import styles from './patient-appointments-cancel.scss';
 
 interface PatientCancelAppointmentModalProps {
   closeCancelModal: () => void;
@@ -47,7 +48,11 @@ const PatientCancelAppointmentModal: React.FC<PatientCancelAppointmentModalProps
 
   return (
     <div>
-      <ModalHeader closeModal={closeCancelModal} title={t('cancelAppointment', 'Cancel appointment')} />
+      <ModalHeader
+        className={styles.modalHeader}
+        closeModal={closeCancelModal}
+        title={t('cancelAppointment', 'Cancel appointment')}
+      />
       <ModalBody>
         <p>{t('cancelAppointmentModalConfirmationText', 'Are you sure you want to cancel this appointment?')}</p>
       </ModalBody>

--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-cancel.scss
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-cancel.scss
@@ -1,10 +1,4 @@
 @use '@carbon/layout';
-@use '@carbon/type';
-
-.modalBody {
-  padding-bottom: layout.$spacing-03;
-  margin-bottom: 0;
-}
 
 .modalHeader {
   :global {
@@ -32,9 +26,4 @@
       transform: translate(-3.75rem, 1.25rem);
     }
   }
-}
-
-.p {
-  margin-bottom: layout.$spacing-02;
-  @include type.type-style('body-01');
 }

--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import capitalize from 'lodash-es/capitalize';
 import { z } from 'zod';
 import { useForm, Controller } from 'react-hook-form';
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { getCoreTranslation, type Location } from '@openmrs/esm-framework';
 import { type BedAdministrationData } from './bed-administration-types';
 import { type BedType, type BedFormData } from '../types';
+import styles from '../modals.scss';
 
 interface BedAdministrationFormProps {
   allLocations: Location[];
@@ -115,7 +116,7 @@ const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
   return (
     // TODO: Port this over to the modal system or create individual modals for each form
     <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
-      <ModalHeader title={headerTitle} />
+      <ModalHeader className={styles.modalHeader} title={headerTitle} />
       <ModalBody hasScrollingContent>
         <Form>
           <Stack gap={3}>

--- a/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-tag/bed-tags-admin-form.component.tsx
@@ -17,6 +17,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { getCoreTranslation, type Location } from '@openmrs/esm-framework';
 import type { BedTagData } from '../types';
+import styles from '../modals.scss';
 
 const BedTagAdministrationSchema = z.object({
   name: z.string().max(255),
@@ -76,7 +77,7 @@ const BedTagsAdministrationForm: React.FC<BedTagAdministrationFormProps> = ({
 
   return (
     <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
-      <ModalHeader title={headerTitle} />
+      <ModalHeader className={styles.modalHeader} title={headerTitle} />
       <ModalBody hasScrollingContent>
         <Form>
           <Stack gap={3}>

--- a/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-type/bed-type-admin-form.component.tsx
@@ -18,6 +18,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { getCoreTranslation, type Location } from '@openmrs/esm-framework';
 import type { BedType, BedTypeData } from '../types';
+import styles from '../modals.scss';
 
 const BedTypeAdministrationSchema = z.object({
   name: z.string().max(255),
@@ -80,7 +81,7 @@ const BedTypeAdministrationForm: React.FC<BedAdministrationFormProps> = ({
 
   return (
     <ComposedModal open={showModal} onClose={() => onModalChange(false)} preventCloseOnClickOutside>
-      <ModalHeader title={headerTitle} />
+      <ModalHeader className={styles.modalHeader} title={headerTitle} />
       <ModalBody hasScrollingContent>
         <Form>
           <Stack gap={3}>

--- a/packages/esm-bed-management-app/src/modals.scss
+++ b/packages/esm-bed-management-app/src/modals.scss
@@ -1,10 +1,4 @@
 @use '@carbon/layout';
-@use '@carbon/type';
-
-.modalBody {
-  padding-bottom: layout.$spacing-03;
-  margin-bottom: 0;
-}
 
 .modalHeader {
   :global {
@@ -32,9 +26,4 @@
       transform: translate(-3.75rem, 1.25rem);
     }
   }
-}
-
-.p {
-  margin-bottom: layout.$spacing-02;
-  @include type.type-style('body-01');
 }

--- a/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.modal.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.modal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+import styles from './cancel-patient-edit.scss';
 
 interface CancelPatientEditPropsModal {
   close(): void;
@@ -12,6 +13,7 @@ const CancelPatientEditModal: React.FC<CancelPatientEditPropsModal> = ({ close, 
   return (
     <>
       <ModalHeader
+        className={styles.modalHeader}
         closeModal={close}
         title={t('confirmDiscardChangesTitle', 'Are you sure you want to discard these changes?')}
       />

--- a/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.scss
+++ b/packages/esm-patient-registration-app/src/widgets/cancel-patient-edit.scss
@@ -1,10 +1,4 @@
 @use '@carbon/layout';
-@use '@carbon/type';
-
-.modalBody {
-  padding-bottom: layout.$spacing-03;
-  margin-bottom: 0;
-}
 
 .modalHeader {
   :global {
@@ -32,9 +26,4 @@
       transform: translate(-3.75rem, 1.25rem);
     }
   }
-}
-
-.p {
-  margin-bottom: layout.$spacing-02;
-  @include type.type-style('body-01');
 }

--- a/packages/esm-patient-registration-app/src/widgets/delete-identifier-confirmation.modal.tsx
+++ b/packages/esm-patient-registration-app/src/widgets/delete-identifier-confirmation.modal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalHeader, ModalFooter } from '@carbon/react';
+import styles from './delete-identifier-confirmation.scss';
 
 interface DeleteIdentifierConfirmationModalProps {
   closeModal: () => void;
@@ -20,6 +21,7 @@ const DeleteIdentifierConfirmationModal: React.FC<DeleteIdentifierConfirmationMo
   return (
     <>
       <ModalHeader
+        className={styles.modalHeader}
         closeModal={closeModal}
         title={t('deleteIdentifierModalHeading', 'Delete identifier?')}></ModalHeader>
       <ModalBody>

--- a/packages/esm-patient-registration-app/src/widgets/delete-identifier-confirmation.scss
+++ b/packages/esm-patient-registration-app/src/widgets/delete-identifier-confirmation.scss
@@ -1,10 +1,4 @@
 @use '@carbon/layout';
-@use '@carbon/type';
-
-.modalBody {
-  padding-bottom: layout.$spacing-03;
-  margin-bottom: 0;
-}
 
 .modalHeader {
   :global {
@@ -32,9 +26,4 @@
       transform: translate(-3.75rem, 1.25rem);
     }
   }
-}
-
-.p {
-  margin-bottom: layout.$spacing-02;
-  @include type.type-style('body-01');
 }

--- a/packages/esm-service-queues-app/src/active-visits/change-status-dialog.component.tsx
+++ b/packages/esm-service-queues-app/src/active-visits/change-status-dialog.component.tsx
@@ -106,7 +106,13 @@ const ChangeStatus: React.FC<ChangeStatusDialogProps> = ({ queueEntry, closeModa
   const onError = (errors) => console.error(errors);
 
   if (Object.keys(queueEntry)?.length === 0) {
-    return <ModalHeader closeModal={closeModal} title={t('patientNotInQueue', 'The patient is not in the queue')} />;
+    return (
+      <ModalHeader
+        className={styles.modalHeader}
+        closeModal={closeModal}
+        title={t('patientNotInQueue', 'The patient is not in the queue')}
+      />
+    );
   }
 
   if (Object.keys(queueEntry)?.length > 0) {
@@ -114,6 +120,7 @@ const ChangeStatus: React.FC<ChangeStatusDialogProps> = ({ queueEntry, closeModa
       <div>
         <Form onSubmit={handleSubmit(onSubmit, onError)}>
           <ModalHeader
+            className={styles.modalHeader}
             closeModal={closeModal}
             title={t('movePatientToNextService', 'Move patient to the next service?')}
           />

--- a/packages/esm-service-queues-app/src/active-visits/change-status-dialog.scss
+++ b/packages/esm-service-queues-app/src/active-visits/change-status-dialog.scss
@@ -1,6 +1,6 @@
+@use '@carbon/colors';
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '@carbon/colors';
 
 .radioButtonGroup {
   display: flex;
@@ -44,4 +44,32 @@ section {
   margin-top: layout.$spacing-03;
   color: colors.$red-60;
   @include type.type-style('label-01');
+}
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
+  }
 }

--- a/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.component.tsx
+++ b/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.component.tsx
@@ -140,7 +140,11 @@ const AddProviderQueueRoom: React.FC<AddProviderQueueRoomProps> = ({ closeModal,
 
   return (
     <div>
-      <ModalHeader closeModal={closeModal} title={t('addAProviderQueueRoom', 'Add a provider queue room?')} />
+      <ModalHeader
+        className={styles.modalHeader}
+        closeModal={closeModal}
+        title={t('addAProviderQueueRoom', 'Add a provider queue room?')}
+      />
       <ModalBody>
         <Form onSubmit={onSubmit}>
           <section className={styles.section}>

--- a/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.scss
+++ b/packages/esm-service-queues-app/src/add-provider-queue-room/add-provider-queue-room.scss
@@ -2,6 +2,34 @@
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
+  }
+}
+
 .section {
   margin: layout.$spacing-03;
 }

--- a/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.component.tsx
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.component.tsx
@@ -45,6 +45,7 @@ const ClearQueueEntriesDialog: React.FC<ClearQueueEntriesDialogProps> = ({ queue
   return (
     <div>
       <ModalHeader
+        className={styles.modalHeader}
         closeModal={closeModal}
         label={t('serviceQueue', 'Service queue')}
         title={t('clearAllQueueEntries', 'Clear all queue entries?')}

--- a/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.scss
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-dialog/clear-queue-entries-dialog.scss
@@ -1,7 +1,36 @@
+@use '@carbon/layout';
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
 #subHeading {
   @include type.type-style('heading-compact-01');
   color: $ui-05;
+}
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
+  }
 }

--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions-modal.scss
@@ -34,3 +34,31 @@ section {
 .dateTimeFields {
   display: flex;
 }
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
+  }
+}

--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions.modal.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions.modal.tsx
@@ -210,7 +210,7 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({
 
   return (
     <>
-      <ModalHeader closeModal={closeModal} title={modalTitle} />
+      <ModalHeader className={styles.modalHeader} closeModal={closeModal} title={modalTitle} />
       <ModalBody>
         <div className={styles.queueEntryActionModalBody}>
           <Stack gap={4}>

--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-confirm-action.modal.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-confirm-action.modal.tsx
@@ -4,6 +4,7 @@ import { type QueueEntry } from '../../types';
 import { Button, ModalHeader, ModalBody, ModalFooter, Stack } from '@carbon/react';
 import { type FetchResponse, showSnackbar } from '@openmrs/esm-framework';
 import { useMutateQueueEntries } from '../../hooks/useQueueEntries';
+import styles from './queue-entry-confirm-action.scss';
 
 interface QueueEntryUndoActionsModalProps {
   queueEntry: QueueEntry;
@@ -75,7 +76,7 @@ export const QueueEntryConfirmActionModal: React.FC<QueueEntryUndoActionsModalPr
 
   return (
     <>
-      <ModalHeader closeModal={closeModal} title={modalTitle} />
+      <ModalHeader className={styles.modalHeader} closeModal={closeModal} title={modalTitle} />
       <ModalBody>
         <Stack gap={4}>
           <h5>{queueEntry.display}</h5>

--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-confirm-action.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-confirm-action.scss
@@ -1,10 +1,4 @@
 @use '@carbon/layout';
-@use '@carbon/type';
-
-.modalBody {
-  padding-bottom: layout.$spacing-03;
-  margin-bottom: 0;
-}
 
 .modalHeader {
   :global {
@@ -32,9 +26,4 @@
       transform: translate(-3.75rem, 1.25rem);
     }
   }
-}
-
-.p {
-  margin-bottom: layout.$spacing-02;
-  @include type.type-style('body-01');
 }

--- a/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.component.tsx
+++ b/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.component.tsx
@@ -5,8 +5,8 @@ import { parseDate, showSnackbar, useVisit } from '@openmrs/esm-framework';
 import { type MappedQueueEntry } from '../types';
 import { startOfDay } from '../constants';
 import { useCheckedInAppointments, endQueueEntry } from './remove-queue-entry.resource';
-import styles from './remove-queue-entry.scss';
 import { useMutateQueueEntries } from '../hooks/useQueueEntries';
+import styles from './remove-queue-entry.scss';
 
 interface RemoveQueueEntryDialogProps {
   queueEntry: MappedQueueEntry;
@@ -70,8 +70,9 @@ const RemoveQueueEntryDialog: React.FC<RemoveQueueEntryDialogProps> = ({ queueEn
   ]);
 
   return (
-    <div>
+    <>
       <ModalHeader
+        className={styles.modalHeader}
         closeModal={closeModal}
         label={t('serviceQueue', 'Service queue')}
         title={t('removeFromQueueAndEndVisit', 'Remove patient from queue and end active visit?')}
@@ -92,7 +93,7 @@ const RemoveQueueEntryDialog: React.FC<RemoveQueueEntryDialogProps> = ({ queueEn
           {t('endVisit', 'End visit')}
         </Button>
       </ModalFooter>
-    </div>
+    </>
   );
 };
 

--- a/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.scss
+++ b/packages/esm-service-queues-app/src/remove-queue-entry-dialog/remove-queue-entry.scss
@@ -1,5 +1,34 @@
+@use '@carbon/layout';
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
+  }
+}
 
 #subHeading {
   @include type.type-style('heading-compact-01');

--- a/packages/esm-service-queues-app/src/transition-queue-entry/transition-queue-entry-dialog.component.tsx
+++ b/packages/esm-service-queues-app/src/transition-queue-entry/transition-queue-entry-dialog.component.tsx
@@ -107,7 +107,7 @@ const TransitionQueueEntryModal: React.FC<TransitionQueueEntryModalProps> = ({ c
 
   return (
     <div>
-      <ModalHeader closeModal={closeModal} title={t('servePatient', 'Serve patient')} />
+      <ModalHeader className={styles.modalHeader} closeModal={closeModal} title={t('servePatient', 'Serve patient')} />
       <ModalBody className={styles.modalBody}>
         <div>
           <section className={styles.modalBody}>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Standardizes the positioning and styling of modal close buttons across the application by:

- Adding consistent modal header styles across all modals
- Positioning close buttons absolutely in the top-right corner
- Adding hover state styling for close buttons
- Fixing popover positioning for left-aligned modals

This change affects modals in:

- Appointments app
- Bed management app
- Patient registration app
- Service queues app

This resolves an issue that we think is caused by Carbon version mismatches. The hope is that this [pull request](https://github.com/openmrs/openmrs-esm-core/pull/1215) in Core will fix the issue more permanently.

## Screenshots

### Before

![CleanShot 2024-12-18 at 3  45 53@2x](https://github.com/user-attachments/assets/90f8a574-a609-4664-8fbe-5940dc22ad1e)

![CleanShot 2024-12-18 at 3  45 41@2x](https://github.com/user-attachments/assets/bff4f49c-57bb-4c30-98ba-d3c5688a449e)

### After

![CleanShot 2024-12-18 at 3  34 18@2x](https://github.com/user-attachments/assets/166ce4e3-be8b-449a-879b-6e9fabbab8cd)

There's still one issue with the modals in the bed management app - launching the modals immediately applies focus to the close button. I've not looked at this in depth, but my current suspicion is that that's happening because those modals haven't fully been ported over to reusing the modal container that Core ships. This [open PR](https://github.com/openmrs/openmrs-esm-patient-management/pull/1381) will effect that migration, and hopefully fix this issue.

![CleanShot 2024-12-18 at 3  35 49@2x](https://github.com/user-attachments/assets/f485b180-44db-442f-9e7b-1ae628d40a78)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

We've seen this happen before [in the Form Builder](https://github.com/openmrs/openmrs-esm-form-builder/pull/317), where we applied a similar workaround.
