### PR TITLE
(fix) O3-3177: Extra horizontal padding on patient lists page

### DIFF
--- a/packages/esm-patient-list-management-app/src/lists-dashboard/lists-dashboard.scss
+++ b/packages/esm-patient-list-management-app/src/lists-dashboard/lists-dashboard.scss
@@ -25,10 +25,6 @@
   grid-column: span 2;
 }
 
-.tablist {
-  padding: 0 layout.$spacing-05;
-}
-
 .tab {
   min-width: 8.875rem;
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR addresses an issue where extra horizontal padding was present on the Patient Lists page. The unnecessary padding has been removed to improve the page’s layout and ensure consistency with the overall design.

## Screenshots
Before:
<img width="978" alt="Screenshot 2024-12-24 at 10 59 51 PM" src="https://github.com/user-attachments/assets/61b57085-49e0-4bfb-9edb-2e43d5af9666" />

After: 
<img width="975" alt="Screenshot 2024-12-24 at 10 57 54 PM" src="https://github.com/user-attachments/assets/de1b2706-d2c6-4a71-ad87-6c815059ab5d" />

## Related Issue
[O3-3177](https://openmrs.atlassian.net/issues/O3-3177?jql=ORDER%20BY%20created%20DESC)


[O3-3177]: https://openmrs.atlassian.net/browse/O3-3177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ