### PR TITLE
(fix) O3-4299: Missing Label in Dropdown Menu of Service Queues

### DIFF
--- a/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -67,7 +67,7 @@ function ClinicMetrics() {
             itemToString={(item) =>
               item ? `${item.display} ${item.location?.display ? `- ${item.location.display}` : ''}` : ''
             }
-            label=""
+            label={t('all', 'All')}
             onChange={handleServiceChange}
             size={isDesktop(layout) ? 'sm' : 'lg'}
             titleText=""

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -6,15 +6,15 @@ import { updateSelectedService, useSelectedService, useSelectedQueueLocationUuid
 import { useActiveVisits, useAverageWaitTime } from './clinic-metrics.resource';
 import { useServiceMetricsCount } from './queue-metrics.resource';
 import { useQueueEntries } from '../hooks/useQueueEntries';
+import useQueueServices from '../hooks/useQueueService';
+import { type Concept } from '../types';
 import MetricsCard from './metrics-card.component';
 import MetricsHeader from './metrics-header.component';
-import useQueueServices from '../hooks/useQueueService';
 import styles from './clinic-metrics.scss';
-import { type Concept } from '../types';
 
 export interface Service {
-  uuid: string;
   display: string;
+  uuid?: string;
 }
 
 type ServiceListItem = Service | Concept;
@@ -22,32 +22,34 @@ type ServiceListItem = Service | Concept;
 function ClinicMetrics() {
   const { t } = useTranslation();
   const layout = useLayoutType();
-
   const currentQueueLocation = useSelectedQueueLocationUuid();
-  const { services } = useQueueServices();
   const currentService = useSelectedService();
+
+  const { services } = useQueueServices();
   const { serviceCount } = useServiceMetricsCount(currentService?.serviceUuid, currentQueueLocation);
+
   const [initialSelectedItem, setInitialSelectItem] = useState(() => {
     return !currentService?.serviceDisplay || !currentService?.serviceUuid;
   });
+
   const { totalCount } = useQueueEntries({
     service: currentService?.serviceUuid,
     location: currentQueueLocation,
     isEnded: false,
   });
+
   const { activeVisitsCount, isLoading: loading } = useActiveVisits();
   const { waitTime } = useAverageWaitTime(currentService?.serviceUuid, '');
 
   const defaultServiceItem: Service = {
     display: `${t('all', 'All')}`,
-    uuid: '',
   };
 
   const serviceItems: ServiceListItem[] = [defaultServiceItem, ...(services ?? [])];
 
   const handleServiceChange = ({ selectedItem }) => {
     updateSelectedService(selectedItem.uuid, selectedItem.display);
-    if (selectedItem.uuid == undefined) {
+    if (selectedItem.uuid === undefined) {
       setInitialSelectItem(true);
     } else {
       setInitialSelectItem(false);
@@ -59,18 +61,18 @@ function ClinicMetrics() {
       <MetricsHeader />
       <div className={styles.cardContainer} data-testid="clinic-metrics">
         <MetricsCard
-          label={t('patients', 'Patients')}
-          value={loading ? '--' : activeVisitsCount}
           headerLabel={t('checkedInPatients', 'Checked in patients')}
+          label={t('patients', 'Patients')}
           service="scheduled"
+          value={loading ? '--' : activeVisitsCount}
         />
         <MetricsCard
+          headerLabel=""
           label={t('patients', 'Patients')}
-          value={initialSelectedItem ? totalCount ?? '--' : serviceCount}
-          headerLabel={`${t('waitingFor', 'Waiting for')}:`}
+          locationUuid={currentQueueLocation}
           service={currentService?.serviceDisplay}
           serviceUuid={currentService?.serviceUuid}
-          locationUuid={currentQueueLocation}>
+          value={initialSelectedItem ? totalCount ?? '--' : serviceCount}>
           <Dropdown
             id="inline"
             initialSelectedItem={defaultServiceItem}
@@ -81,15 +83,15 @@ function ClinicMetrics() {
             label=""
             onChange={handleServiceChange}
             size={isDesktop(layout) ? 'sm' : 'lg'}
-            titleText=""
+            titleText={`${t('waitingFor', 'Waiting for')}:`}
             type="inline"
           />
         </MetricsCard>
         <MetricsCard
           label={t('minutes', 'Minutes')}
-          value={waitTime ? waitTime.averageWaitTime : '--'}
           headerLabel={t('averageWaitTime', 'Average wait time today')}
           service="waitTime"
+          value={waitTime ? waitTime.averageWaitTime : '--'}
         />
       </div>
     </>

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -10,11 +10,14 @@ import MetricsCard from './metrics-card.component';
 import MetricsHeader from './metrics-header.component';
 import useQueueServices from '../hooks/useQueueService';
 import styles from './clinic-metrics.scss';
+import { type Concept } from '../types';
 
 export interface Service {
   uuid: string;
   display: string;
 }
+
+type ServiceListItem = Service | Concept;
 
 function ClinicMetrics() {
   const { t } = useTranslation();
@@ -35,12 +38,12 @@ function ClinicMetrics() {
   const { activeVisitsCount, isLoading: loading } = useActiveVisits();
   const { waitTime } = useAverageWaitTime(currentService?.serviceUuid, '');
 
-  const defaultServiceItem = {
+  const defaultServiceItem: Service = {
     display: `${t('all', 'All')}`,
     uuid: '',
   };
 
-  const serviceItems = [defaultServiceItem, ...(services ?? [])];
+  const serviceItems: ServiceListItem[] = [defaultServiceItem, ...(services ?? [])];
 
   const handleServiceChange = ({ selectedItem }) => {
     updateSelectedService(selectedItem.uuid, selectedItem.display);

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/clinic-metrics.component.tsx
@@ -35,6 +35,13 @@ function ClinicMetrics() {
   const { activeVisitsCount, isLoading: loading } = useActiveVisits();
   const { waitTime } = useAverageWaitTime(currentService?.serviceUuid, '');
 
+  const defaultServiceItem = {
+    display: `${t('all', 'All')}`,
+    uuid: '',
+  };
+
+  const serviceItems = [defaultServiceItem, ...(services ?? [])];
+
   const handleServiceChange = ({ selectedItem }) => {
     updateSelectedService(selectedItem.uuid, selectedItem.display);
     if (selectedItem.uuid == undefined) {
@@ -63,11 +70,12 @@ function ClinicMetrics() {
           locationUuid={currentQueueLocation}>
           <Dropdown
             id="inline"
-            items={[{ display: `${t('all', 'All')}` }, ...(services ?? [])]}
+            initialSelectedItem={defaultServiceItem}
+            items={serviceItems}
             itemToString={(item) =>
               item ? `${item.display} ${item.location?.display ? `- ${item.location.display}` : ''}` : ''
             }
-            label={t('all', 'All')}
+            label=""
             onChange={handleServiceChange}
             size={isDesktop(layout) ? 'sm' : 'lg'}
             titleText=""

--- a/packages/esm-service-queues-app/src/patient-queue-metrics/metrics-card.scss
+++ b/packages/esm-service-queues-app/src/patient-queue-metrics/metrics-card.scss
@@ -46,10 +46,16 @@
 .headerLabelContainer {
   display: flex;
   height: layout.$spacing-07;
+  align-items: center;
 
   :global(.cds--dropdown__wrapper--inline) {
     gap: 0;
-    margin-top: -(layout.$spacing-04);
+
+    label {
+      @include type.type-style('heading-compact-01');
+      color: $text-02;
+      margin-right: layout.$spacing-03;
+    }
   }
 
   :global(.cds--list-box__menu-icon) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR addresses an issue where the second clinic metric in Service Queues displayed an empty string instead of the label 'All' when defaulting to show data for all. The label has been updated to display 'All' by default, ensuring clarity and consistency in the UI.

## Screenshots
Before: 
<img width="1470" alt="Screenshot 2025-01-03 at 6 37 10 PM" src="https://github.com/user-attachments/assets/28e00d01-8ccd-4079-af69-1de035ffe51f" />

After:
<img width="1470" alt="Screenshot 2025-01-03 at 6 55 23 PM" src="https://github.com/user-attachments/assets/9f0d2ab2-d3e5-4ac8-a93c-3ccdec77dcd0" />


## Related Issue
[O3-4299](https://openmrs.atlassian.net/browse/O3-4299)


[O3-4299]: https://openmrs.atlassian.net/browse/O3-4299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ