### PR TITLE
Revert "fix: extra horizontal padding on patient lists page"

### DIFF
--- a/packages/esm-patient-list-management-app/src/lists-dashboard/lists-dashboard.scss
+++ b/packages/esm-patient-list-management-app/src/lists-dashboard/lists-dashboard.scss
@@ -25,6 +25,10 @@
   grid-column: span 2;
 }
 
+.tablist {
+  padding: 0 layout.$spacing-05;
+}
+
 .tab {
   min-width: 8.875rem;
 


### PR DESCRIPTION
This reverts commit d96a06285b6180b7514dd1692d3922da3476a277.

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
Added the horizontal padding back to the patient lists page.
