### PR TITLE
(fix) O3-4337 Service queues - make QueueTableByStatus show tables in…

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions.resource.ts
+++ b/packages/esm-service-queues-app/src/queue-table/queue-entry-actions/queue-entry-actions.resource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch, restBaseUrl, type Location } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, restBaseUrl, type Location } from '@openmrs/esm-framework';
 import { type Concept, type QueueEntry } from '../../types';
 
 // see QueueEntryTransition.java in openmrs-module-queue
@@ -20,7 +20,10 @@ interface TransitionQueueEntryParams {
  * @param abortController
  * @returns
  */
-export function transitionQueueEntry(params: TransitionQueueEntryParams, abortController?: AbortController) {
+export function transitionQueueEntry(
+  params: TransitionQueueEntryParams,
+  abortController?: AbortController,
+): Promise<FetchResponse<QueueEntry>> {
   return openmrsFetch(`${restBaseUrl}/queue-entry/transition`, {
     method: 'POST',
     headers: {

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
@@ -135,11 +135,11 @@ function QueueTable({
                   return (
                     <React.Fragment key={row.id}>
                       <Row {...getRowProps({ row })}>
-                        {row.cells.map((cell) => (
+                        {row.cells.map((cell, i) => (
                           <TableCell
                             key={cell.id}
                             className={classNames({
-                              'cds--table-column-menu': cell?.id?.split(':')?.[1] === 'actions',
+                              'cds--table-column-menu': columns[i].key.includes('actions'),
                             })}>
                             {cell.value}
                           </TableCell>

--- a/packages/esm-service-queues-app/src/views/queue-tables-for-all-statuses.component.tsx
+++ b/packages/esm-service-queues-app/src/views/queue-tables-for-all-statuses.component.tsx
@@ -95,7 +95,7 @@ interface QueueTablesByStatusProps {
 function QueueTablesByStatus({ selectedQueue, searchTerm }: QueueTablesByStatusProps) {
   const { t } = useTranslation();
   const { queueEntries, isLoading, isValidating } = useQueueEntries({ queue: selectedQueue.uuid, isEnded: false });
-  const allowedStatuses = selectedQueue.allowedStatuses.reverse();
+  const allowedStatuses = [...selectedQueue.allowedStatuses].reverse();
   const noStatuses = !allowedStatuses?.length;
   if (isLoading) {
     return <QueueTableByStatusSkeleton />;


### PR DESCRIPTION
… predicable order

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The queues by status page did not render the queue tables in a predictable order because it uses `.reverse()` to reverse the statuses array, which mutates the array and violates React's rule. This fixes it by creating a new array instance before calling `reverse()`.

Also sneaking in some very minor typings and css.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
