### PR TITLE
(feat) O3-4338 Ward App - make Ward Patient Banner into an extension

### DIFF
--- a/packages/esm-ward-app/src/index.ts
+++ b/packages/esm-ward-app/src/index.ts
@@ -111,7 +111,7 @@ export const createAdmissionEncounterWorkspaceSideRailIcon = getAsyncLifecycle(
 export const createAdmissionEncounterWorkspace = getAsyncLifecycle(
   () => import('./ward-workspace/create-admission-encounter/create-admission-encounter.workspace'),
   options,
-)
+);
 
 export const defaultWardView = getAsyncLifecycle(
   () => import('./ward-view/default-ward/default-ward-view.component'),
@@ -120,6 +120,11 @@ export const defaultWardView = getAsyncLifecycle(
 
 export const maternalWardView = getAsyncLifecycle(
   () => import('./ward-view/materal-ward/maternal-ward-view.component'),
+  options,
+);
+
+export const wardPatientWorkspaceBanner = getAsyncLifecycle(
+  () => import('./ward-workspace/patient-banner/patient-banner.component'),
   options,
 );
 

--- a/packages/esm-ward-app/src/routes.json
+++ b/packages/esm-ward-app/src/routes.json
@@ -79,6 +79,11 @@
       "component": "maternalWardView",
       "name": "maternal-ward",
       "slot": "maternal-ward"
+    },
+    {
+      "component": "wardPatientWorkspaceBanner",
+      "name": "ward-patient-workspace-banner",
+      "slot": "ward-workspace-patient-banner-slot"
     }
   ],
   "workspaces": [

--- a/packages/esm-ward-app/src/ward-patient-card/row-elements/ward-patient-identifier.tsx
+++ b/packages/esm-ward-app/src/ward-patient-card/row-elements/ward-patient-identifier.tsx
@@ -23,7 +23,12 @@ const WardPatientIdentifier: React.FC<WardPatientIdentifierProps> = ({ id, patie
   }));
 
   return (
-    <PatientBannerPatientIdentifiers identifiers={fhirIdentifiers} showIdentifierLabel={config?.showIdentifierLabel} />
+    <div>
+      <PatientBannerPatientIdentifiers
+        identifiers={fhirIdentifiers}
+        showIdentifierLabel={config?.showIdentifierLabel}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
We need the Ward Patient Banner to be usable in custom workspaces that are not defined within the ward app. Since the Ward Patient Banner has configurable elements. We need a way to pass in the banner into those workspace while preserving React context for configs. This PR does it by making it an extension.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
