### PR TITLE
(fix) service-queues: Fix queue table empty state UI

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
@@ -133,13 +133,18 @@ function QueueTableSection() {
     });
   }, [columns, queueEntries, searchTerm]);
 
-  return !isLoading ? (
+  if (isLoading) {
+    return <DataTableSkeleton role="progressbar" />;
+  }
+
+  return (
     <QueueTable
-      queueEntries={filteredQueueEntries ?? []}
+      ExpandedRow={QueueTableExpandedRow}
+      isLoading={isLoading}
       isValidating={isValidating}
+      queueEntries={filteredQueueEntries ?? []}
       queueUuid={null}
       statusUuid={null}
-      ExpandedRow={QueueTableExpandedRow}
       tableFilters={
         <>
           <QueueDropdownFilter /> <StatusDropdownFilter />
@@ -153,8 +158,6 @@ function QueueTableSection() {
         </>
       }
     />
-  ) : (
-    <DataTableSkeleton role="progressbar" />
   );
 }
 

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.component.tsx
@@ -76,7 +76,7 @@ function QueueTable({
     goTo(1);
   }, [goTo, queueEntries]);
 
-  const rowsData =
+  const rows =
     paginatedQueueEntries?.map((queueEntry) => {
       const row: Record<string, JSX.Element | string> = { id: queueEntry.uuid };
       columns.forEach(({ key, CellComponent }) => {
@@ -97,7 +97,7 @@ function QueueTable({
     <DataTable
       data-floating-menu-container
       overflowMenuOnHover={isDesktop(layout)}
-      rows={rowsData}
+      rows={rows}
       headers={columns}
       size={responsiveSize}
       useZebraStyles>
@@ -106,9 +106,9 @@ function QueueTable({
           <TableContainer className={styles.tableContainer}>
             <div className={styles.toolbarContainer}>
               {isValidating ? (
-                <span>
+                <div className={styles.loaderContainer}>
                   <InlineLoading />
-                </span>
+                </div>
               ) : null}
 
               {tableFilters && (

--- a/packages/esm-service-queues-app/src/queue-table/queue-table.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.scss
@@ -11,19 +11,34 @@
   border: 1px solid colors.$gray-20;
 }
 
+.tableSection {
+  background: colors.$gray-10;
+}
+
 .headerContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: layout.$spacing-05;
-  background-color: $ui-01;
+  background-color: colors.$gray-10;
 }
 
 .headerButtons {
   display: flex;
-  justify-content: space-between;
+
   .filterSearch {
     margin-left: layout.$spacing-05;
+  }
+}
+
+.loaderContainer {
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+
+  :global(.cds--inline-loading) {
+    justify-content: end;
   }
 }
 
@@ -65,7 +80,7 @@
 
 .statusTableContainer {
   padding: layout.$spacing-05;
-  background-color: $ui-01;
+  background-color: colors.$gray-10;
 }
 
 .statusTableHeader {
@@ -77,7 +92,7 @@
 }
 
 .tableContainer {
-  background-color: $ui-01;
+  background-color: colors.$gray-10;
   // margin: 0 layout.$spacing-05;
   padding: 0 1rem;
 
@@ -105,6 +120,7 @@
   }
 
   :global(.cds--table-toolbar) {
+    flex: 3;
     position: static;
     overflow: visible;
   }
@@ -193,11 +209,13 @@ html[dir='rtl'] {
 
 .tileContainer {
   border-top: 1px solid $ui-03;
-  padding: layout.$spacing-07 0;
+  padding: layout.$spacing-07 layout.$spacing-05;
+  background: white;
+  margin: 0 layout.$spacing-05;
 }
 
 .tile {
-  background-color: $ui-01;
+  background-color: colors.$gray-10;
   margin: auto;
   width: fit-content;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR is a follow-up to #1390 which amended the Service Queues dashboard to align more closely with the [designs](https://zpl.io/aN3L75n). This PR fixes an additional issue with the queue table where the empty state wasn't being displayed correctly. More specifically, it:

- Amends the styling of the queue table empty state to match the [designs](https://zpl.io/aN3L75n).
- Fixes the positioning of the loading indicator in the queue table toolbar so it's further offset to the right.

## Screenshots

### Before

#### Empty state UI doesn't have the correct margins and its parent container doesn't have the correct background color

![CleanShot 2025-01-18 at 4  52 20@2x](https://github.com/user-attachments/assets/850a01fa-8581-405b-9797-6d973249ac37)

### After

#### Fixed empty state UI

![CleanShot 2025-01-18 at 3  59 51@2x](https://github.com/user-attachments/assets/5040faee-6476-4d28-ba7b-65527668c5f3)

#### Fixed alignment of inline loader shown when revalidating data 

![CleanShot 2025-01-18 at 4  14 17@2x](https://github.com/user-attachments/assets/5fbba299-be2f-4f01-bb34-6c6801d6c81e)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
