### PR TITLE
(fix) O3-4365 Ward app - fix styling of patient identifier in patient…

### DIFF
--- a/packages/esm-ward-app/src/ward-patient-card/row-elements/ward-patient-identifier.scss
+++ b/packages/esm-ward-app/src/ward-patient-card/row-elements/ward-patient-identifier.scss
@@ -1,0 +1,3 @@
+.wardPatientIdentifierWrapper {
+  display: contents;
+}

--- a/packages/esm-ward-app/src/ward-patient-card/row-elements/ward-patient-identifier.tsx
+++ b/packages/esm-ward-app/src/ward-patient-card/row-elements/ward-patient-identifier.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type Patient, type PatientIdentifier, PatientBannerPatientIdentifiers } from '@openmrs/esm-framework';
 import { useElementConfig } from '../../ward-view/ward-view.resource';
+import styles from './ward-patient-identifier.scss';
 
 export interface WardPatientIdentifierProps {
   patient: Patient;
@@ -23,7 +24,7 @@ const WardPatientIdentifier: React.FC<WardPatientIdentifierProps> = ({ id, patie
   }));
 
   return (
-    <div>
+    <div className={styles.wardPatientIdentifierWrapper}>
       <PatientBannerPatientIdentifiers
         identifiers={fhirIdentifiers}
         showIdentifierLabel={config?.showIdentifierLabel}


### PR DESCRIPTION
… card

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This fixes the wrapping issue with patient identifiers, introduced when attempting to fix the stray dots that appear with multiple identifiers.

## Screenshots
<!-- Required if you are making UI changes. -->
before:
![image](https://github.com/user-attachments/assets/5091f7b4-1e2c-4a51-ba62-4d286d5a2f3e)

after:
![image](https://github.com/user-attachments/assets/bce82330-1c13-4924-abe0-40f1b7865402)


I don't love how this still doesn't fix the wrapping issue when 2 identifiers are in the same row (see green highlight), but I don't think I can fix it without a more drastic change.

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4365

## Other
<!-- Anything not covered above -->
