### PR TITLE
(fix) O3-4386: Fix the tooltip position in the ward allocation table in bed management

### DIFF
--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration-table.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration-table.component.tsx
@@ -119,7 +119,7 @@ const BedAdministrationTable: React.FC = () => {
             iconDescription={t('editBed', 'Edit bed')}
             hasIconOnly
             size={responsiveSize}
-            tooltipAlignment="start"
+            tooltipPosition="right"
           />
         </>
       ),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR addresses the issue regarding the position of the tooltip for the edit button in the ward allocation.

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/user-attachments/assets/1f81ab8a-d1e1-423f-b659-df8c86a0371b)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4386

## Other
<!-- Anything not covered above -->
