### PR TITLE
(fix) O3-4387: Fetch active visits from parent location when login location is not a visit location

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ You could provide `yarn start` with as many `sources` arguments as you require. 
 yarn start --sources 'packages/esm-patient-search-app' --sources 'packages/esm-patient-registration-app'
 ```
 
+To run an app locally with the same [configuration that is set in the reference application](https://github.com/openmrs/openmrs-distro-referenceapplication/blob/main/frontend/config-core_demo.json), use:
+
+```bash
+yarn start --config-url /openmrs/spa/config-core_demo.json --sources 'packages/esm-<insert-package-name>-app'
+```
+
 ## Troubleshooting
 
 If you notice that your local version of the application is not working or that there's a mismatch between what you see locally versus what's in the reference application, you likely have outdated versions of core libraries. To update core libraries, run the following commands:

--- a/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
+++ b/packages/esm-active-visits-app/src/active-visits-widget/active-visits.resource.tsx
@@ -39,6 +39,7 @@ export function useActiveVisits() {
     let url = `${restBaseUrl}/visit?v=${customRepresentation}&`;
     let urlSearchParams = new URLSearchParams();
 
+    urlSearchParams.append('includeParentLocations', 'true');
     urlSearchParams.append('includeInactive', 'false');
     urlSearchParams.append('totalCount', 'true');
     urlSearchParams.append('location', `${sessionLocation}`);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates the `useActiveVisits` url to have the `includeParentLocation` search param to account for when a user starts an active visit from a login location that is not a visit location. In situations like such, we should show the active visits from the parent location which is a visit location.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4387

## Other
<!-- Anything not covered above -->
