### PR TITLE
(fix) O3-4401: Update active visits query params to display correct count in active visits home tile

### DIFF
--- a/packages/esm-active-visits-app/src/home-page-tiles/active-visits-metric-tile/active-visits.resource.ts
+++ b/packages/esm-active-visits-app/src/home-page-tiles/active-visits-metric-tile/active-visits.resource.ts
@@ -11,6 +11,7 @@ export default function useActiveVisits() {
     let url = `${restBaseUrl}/visit?v=${customRepresentation}&`;
     let urlSearchParams = new URLSearchParams();
 
+    urlSearchParams.append('includeParentLocations', 'true');
     urlSearchParams.append('includeInactive', 'false');
     urlSearchParams.append('totalCount', 'true');
     urlSearchParams.append('location', `${sessionLocation}`);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds the search query param `includeParentLocation` so that non-visit locations will have the correct active visit count in the active visit home tile.

## Screenshots
<!-- Required if you are making UI changes. -->
Before fix:
<img width="1710" alt="Screenshot 2025-01-27 at 9 30 53 PM" src="https://github.com/user-attachments/assets/09f69f58-c857-4955-af8a-c58c15778667" />

After fix:
<img width="1710" alt="Screenshot 2025-01-27 at 9 30 43 PM" src="https://github.com/user-attachments/assets/fd25d677-4397-4876-b8df-b32e73ba48e4" />
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4401

## Other
<!-- Anything not covered above -->
