### PR TITLE
(fix) O3-3286: Change scheduled appointments metrics card label

### DIFF
--- a/packages/esm-appointments-app/src/appointments.test.tsx
+++ b/packages/esm-appointments-app/src/appointments.test.tsx
@@ -7,7 +7,7 @@ describe('Appointments', () => {
   it('renders the appointments dashboard', async () => {
     render(<Appointments />);
 
-    await screen.findByText(/^appointments$/i);
+    await screen.findByRole('combobox');
 
     expect(screen.getByRole('button', { name: /appointments calendar/i })).toBeInTheDocument();
     expect(screen.getByTestId('appointment-date-picker')).toBeInTheDocument();

--- a/packages/esm-appointments-app/src/metrics/appointments-metrics.component.tsx
+++ b/packages/esm-appointments-app/src/metrics/appointments-metrics.component.tsx
@@ -49,7 +49,7 @@ const AppointmentsMetrics: React.FC<AppointmentMetricsProps> = ({ appointmentSer
         <MetricsCard
           count={{ pendingAppointments: filteredPendingAppointments, arrivedAppointments: filteredArrivedAppointments }}
           headerLabel={t('scheduledAppointments', 'Scheduled appointments')}
-          label={t('patients', 'Patients')}
+          label={t('appointments', 'Appointments')}
           value={totalScheduledAppointments}
         />
         <MetricsCard

--- a/packages/esm-appointments-app/src/metrics/appointments-metrics.test.tsx
+++ b/packages/esm-appointments-app/src/metrics/appointments-metrics.test.tsx
@@ -27,7 +27,7 @@ jest.mock('../hooks/useClinicalMetrics', () => ({
 }));
 
 describe('Appointment metrics', () => {
-  it('renders metrics from the appointments list', async () => {
+  it('should render metrics cards with the correct data', async () => {
     mockOpenmrsFetch.mockResolvedValueOnce({
       data: [],
     } as unknown as FetchResponse);
@@ -36,7 +36,7 @@ describe('Appointment metrics', () => {
 
     await screen.findByText(/appointment metrics/i);
     expect(screen.getByText(/scheduled appointments/i)).toBeInTheDocument();
-    expect(screen.getByText(/patients/i)).toBeInTheDocument();
+    expect(screen.getByText(/^appointments$/i)).toBeInTheDocument();
     expect(screen.getByText(/16/i)).toBeInTheDocument();
     expect(screen.getByText(/4/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Updates the label in the scheduled appointments card to 'Appointments' to more accurately reflect the data it represents.
    
Also updates a couple of tests to adapt to the new change.


## Screenshots

### Before
![before](https://github.com/user-attachments/assets/ae8a320d-f193-40bb-a6fa-2f68e952c2d9)

### After
![after](https://github.com/user-attachments/assets/ad6cc500-a497-41d6-bf94-2277993f800f)

### Related issue
https://openmrs.atlassian.net/browse/O3-3286
