### PR TITLE
(test) Use UI flow instead of direct API calls to test removing a patient from a list

### DIFF
--- a/e2e/specs/patient-list.spec.ts
+++ b/e2e/specs/patient-list.spec.ts
@@ -73,17 +73,28 @@ test('Manage patients in a list', async ({ api, page }) => {
     await patientListPage.goto(cohort.uuid);
   });
 
-  await test.step('Then I should be able to add and remove patients from that list', async () => {
+  await test.step('Then I should be able to add a patient to the list', async () => {
     // Add a patient to the list
     cohortMember = await addPatientToCohort(api, cohort.uuid, patient.uuid);
     await patientListPage.goto(cohort.uuid);
     await expect(patientListPage.patientListHeader()).toHaveText(/1 patients/);
     await expect(patientListPage.patientsTable()).toHaveText(new RegExp(patient.person.display));
+  });
 
-    // Remove a patient from the list
-    await removePatientFromCohort(api, cohortMember.uuid);
-    await patientListPage.goto(cohort.uuid);
-    await expect(patientListPage.patientListHeader()).toHaveText(/0 patients/);
+  await test.step('And when I click on the bin icon to remove the patient from the list', async () => {
+    await page.getByRole('button', { name: /remove from list/i }).click();
+  });
+
+  await test.step("Then I click the 'Remove from list' in the delete modal to confirm the action", async () => {
+    await page.getByRole('button', { name: 'danger Remove from list' }).click();
+  });
+
+  await test.step('And then I should see a success message', async () => {
+    await expect(page.getByText(/patient removed from list/i)).toBeVisible();
+  });
+
+  await test.step('And then the patient count should update to zero', async () => {
+    await expect(page.getByText(/0 patients/)).toBeVisible();
     cohortMember = null;
   });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The e2e test for managing a patient list heavily relies on directly making API  calls rather than interacting with the user interface, which defeats the purpose of it existing. This updates just the delete patient to hopefully get more info as to why it fails in [this](https://github.com/openmrs/openmrs-esm-core/pull/1280) PR.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
