### PR TITLE
(chore) Exclude patient list apps from e2e test environment

### DIFF
--- a/e2e/specs/patient-list.spec.ts
+++ b/e2e/specs/patient-list.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-skipped-test */
 import { test } from '../core';
 import { PatientListsPage } from '../pages';
 import { expect } from '@playwright/test';
@@ -21,7 +22,7 @@ test.beforeEach(async ({ api }) => {
   cohort = await generateRandomCohort(api);
 });
 
-test('Create and edit a patient list', async ({ page }) => {
+test.skip('Create and edit a patient list', async ({ page }) => {
   const patientListPage = new PatientListsPage(page);
 
   await test.step('When I visit the patient lists page', async () => {
@@ -66,7 +67,7 @@ test('Create and edit a patient list', async ({ page }) => {
   });
 });
 
-test('Manage patients in a list', async ({ api, page }) => {
+test.skip('Manage patients in a list', async ({ api, page }) => {
   const patientListPage = new PatientListsPage(page);
 
   await test.step("When I visit a specific patient list's page", async () => {

--- a/e2e/specs/return-to-patient-list.spec.ts
+++ b/e2e/specs/return-to-patient-list.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-skipped-test */
 import { test } from '../core';
 import { PatientListsPage } from '../pages';
 import { expect } from '@playwright/test';
@@ -21,7 +22,7 @@ test.beforeEach(async ({ api }) => {
   cohortMembership = await addPatientToCohort(api, cohort.uuid, patient.uuid);
 });
 
-test('Return to patient list from the patient chart', async ({ page }) => {
+test.skip('Return to patient list from the patient chart', async ({ page }) => {
   const patientListPage = new PatientListsPage(page);
 
   await test.step('When I navigate to the patient list', async () => {
@@ -47,7 +48,7 @@ test('Return to patient list from the patient chart', async ({ page }) => {
   });
 });
 
-test('Return to patient list after navigating to visits page from the patient chart', async ({ page }) => {
+test.skip('Return to patient list after navigating to visits page from the patient chart', async ({ page }) => {
   const patientListPage = new PatientListsPage(page);
 
   await test.step('When I navigate to the patient list', async () => {
@@ -81,7 +82,7 @@ test('Return to patient list after navigating to visits page from the patient ch
   });
 });
 
-test('Return to patient list after navigating to visits and refreshing the page', async ({ page }) => {
+test.skip('Return to patient list after navigating to visits and refreshing the page', async ({ page }) => {
   const patientListPage = new PatientListsPage(page);
 
   await test.step('When I navigate to the patient list', async () => {
@@ -104,7 +105,7 @@ test('Return to patient list after navigating to visits and refreshing the page'
     await page.getByRole('link', { name: 'Visits' }).click();
   });
 
-  await test.step('And I refesh the page', async () => {
+  await test.step('And I refresh the page', async () => {
     await page.reload();
   });
 
@@ -119,7 +120,7 @@ test('Return to patient list after navigating to visits and refreshing the page'
   });
 });
 
-test('Return to patient list from the patient chart on a new tab', async ({ page, context }) => {
+test.skip('Return to patient list from the patient chart on a new tab', async ({ page, context }) => {
   const patientListPage = new PatientListsPage(page);
   const locator = page.locator('table tbody tr td:nth-child(1) a');
   const pagePromise = context.waitForEvent('page');

--- a/e2e/support/github/run-e2e-docker-env.sh
+++ b/e2e/support/github/run-e2e-docker-env.sh
@@ -5,7 +5,7 @@ script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # create a temporary working directory
 working_dir=$(mktemp -d "${TMPDIR:-/tmp/}openmrs-e2e-frontends.XXXXXXXXXX")
 # get a list of all the apps in this workspace
-apps=$(yarn workspaces list --json | jq -r 'if .location | test("-app$") then .name else empty end')
+apps=$(yarn workspaces list --json | jq -r 'if (.location | test("-app$")) and (.location | test("patient-list") | not) then .name else empty end')
 # this array will hold all of the packed app names
 app_names=()
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Modifies the `jq` filter in `run-e2e-docker-env.sh` to exclude the `patient-list-management` and `patient-lists-app` frontend modules from the test environment. This change is necessary following the removal of these apps from the distro in https://github.com/openmrs/openmrs-distro-referenceapplication/pull/892.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
