### PR TITLE
(fix) Fix avatar spacing in appointments patient header

### DIFF
--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-header.scss
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-header.scss
@@ -6,16 +6,27 @@
 }
 
 .patientAvatar {
-  width: layout.$spacing-11;
-  height: layout.$spacing-11;
+  width: 3.5rem;
+  height: 3.5rem;
   margin: layout.$spacing-05;
-  border-radius: 1px;
 }
 
 .divider {
   border: 0;
   border-top: 0.075rem solid colors.$gray-20;
   width: 100%;
+}
+
+.backButton {
+  svg {
+    order: 1;
+    margin-right: layout.$spacing-03;
+    margin-left: 0;
+  }
+
+  span {
+    order: 2;
+  }
 }
 
 // Overriding styles for RTL support

--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-header.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-header.tsx
@@ -1,9 +1,9 @@
+import React from 'react';
 import { Button } from '@carbon/react';
 import { ArrowLeft } from '@carbon/react/icons';
-import { PatientBannerPatientInfo, PatientPhoto, getPatientName } from '@openmrs/esm-framework';
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { PatientBannerPatientInfo, PatientPhoto, getPatientName } from '@openmrs/esm-framework';
 import styles from './patient-appointments-header.scss';
 
 interface PatientAppointmentsHeaderProps {
@@ -16,13 +16,14 @@ const PatientAppointmentsHeader: React.FC<PatientAppointmentsHeaderProps> = ({ p
   const patientName = getPatientName(patient);
 
   return (
-    <div>
+    <header>
       <div className={styles.titleContainer}>
         <Button
+          className={styles.backButton}
+          iconDescription={t('back', 'Back')}
           kind="ghost"
           onClick={() => navigate(-1)}
           renderIcon={ArrowLeft}
-          iconDescription={t('back', 'Back')}
           size="lg">
           <span>{t('back', 'Back')}</span>
         </Button>
@@ -35,7 +36,7 @@ const PatientAppointmentsHeader: React.FC<PatientAppointmentsHeaderProps> = ({ p
         <PatientBannerPatientInfo patient={patient}></PatientBannerPatientInfo>
       </div>
       <div className={styles.divider}></div>
-    </div>
+    </header>
   );
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes the avatar spacing in the appointments patient header to align with standard dimensions. Other changes include:

- Fixing the positioning of the SVG icon in the back button.
- Removing a redundant border radius from the patient avatar.
- Updating the container to be a header element to improve semantics.

## Screenshots

### Before (note the overt spacing around the avatar and the back button SVG positioning)

![CleanShot 2025-02-20 at 12  41 54@2x](https://github.com/user-attachments/assets/fb747fe3-5c67-4998-9b9a-54c2fec03b7c)

### After

![CleanShot 2025-02-20 at 12  41 35@2x](https://github.com/user-attachments/assets/f09f7ac7-c6a5-457d-9389-738d1f205d9a)

## Related Issue
https://openmrs.atlassian.net/issues/O3-4211

## Other
<!-- Anything not covered above -->
