### PR TITLE
(fix) Standardize appointment component props and fix filter behaviour

### DIFF
--- a/packages/esm-appointments-app/src/appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments.component.tsx
@@ -10,7 +10,7 @@ import SelectedDateContext from './hooks/selectedDateContext';
 
 const Appointments: React.FC = () => {
   const { t } = useTranslation();
-  const [appointmentServiceType, setAppointmentServiceType] = useState<string[]>([]);
+  const [appointmentServiceTypes, setAppointmentServiceTypes] = useState<string[]>([]);
   const [selectedDate, setSelectedDate] = useState(dayjs().startOf('day').format(omrsDateFormat));
 
   const params = useParams();
@@ -23,19 +23,19 @@ const Appointments: React.FC = () => {
 
   useEffect(() => {
     if (params.serviceType) {
-      setAppointmentServiceType([params.serviceType]);
+      setAppointmentServiceTypes([params.serviceType]);
     }
   }, [params.serviceType]);
 
   return (
     <SelectedDateContext.Provider value={{ selectedDate, setSelectedDate }}>
       <AppointmentsHeader
-        appointmentServiceType={appointmentServiceType}
-        onChange={setAppointmentServiceType}
+        appointmentServiceTypes={appointmentServiceTypes}
+        onChange={setAppointmentServiceTypes}
         title={t('appointments', 'Appointments')}
       />
-      <AppointmentMetrics appointmentServiceType={appointmentServiceType} />
-      <AppointmentTabs appointmentServiceType={appointmentServiceType} />
+      <AppointmentMetrics appointmentServiceTypes={appointmentServiceTypes} />
+      <AppointmentTabs appointmentServiceTypes={appointmentServiceTypes} />
     </SelectedDateContext.Provider>
   );
 };

--- a/packages/esm-appointments-app/src/appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments.component.tsx
@@ -10,7 +10,7 @@ import SelectedDateContext from './hooks/selectedDateContext';
 
 const Appointments: React.FC = () => {
   const { t } = useTranslation();
-  const [appointmentServiceTypes, setAppointmentServiceTypes] = useState<string[]>([]);
+  const [appointmentServiceTypes, setAppointmentServiceTypes] = useState<Array<string>>([]);
   const [selectedDate, setSelectedDate] = useState(dayjs().startOf('day').format(omrsDateFormat));
 
   const params = useParams();

--- a/packages/esm-appointments-app/src/appointments/appointment-tabs.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-tabs.component.tsx
@@ -8,10 +8,10 @@ import UnscheduledAppointments from './unscheduled/unscheduled-appointments.comp
 import styles from './appointment-tabs.scss';
 
 interface AppointmentTabsProps {
-  appointmentServiceType: string[];
+  appointmentServiceTypes: string[];
 }
 
-const AppointmentTabs: React.FC<AppointmentTabsProps> = ({ appointmentServiceType }) => {
+const AppointmentTabs: React.FC<AppointmentTabsProps> = ({ appointmentServiceTypes }) => {
   const { t } = useTranslation();
   const { showUnscheduledAppointmentsTab } = useConfig<ConfigObject>();
   const [activeTabIndex, setActiveTabIndex] = useState(0);
@@ -30,7 +30,7 @@ const AppointmentTabs: React.FC<AppointmentTabsProps> = ({ appointmentServiceTyp
           </TabList>
           <TabPanels>
             <TabPanel className={styles.tabPanel}>
-              <ScheduledAppointments appointmentServiceType={appointmentServiceType} />
+              <ScheduledAppointments appointmentServiceTypes={appointmentServiceTypes} />
             </TabPanel>
             <TabPanel className={styles.tabPanel}>
               <UnscheduledAppointments />
@@ -38,7 +38,7 @@ const AppointmentTabs: React.FC<AppointmentTabsProps> = ({ appointmentServiceTyp
           </TabPanels>
         </Tabs>
       ) : (
-        <ScheduledAppointments appointmentServiceType={appointmentServiceType} />
+        <ScheduledAppointments appointmentServiceTypes={appointmentServiceTypes} />
       )}
     </div>
   );

--- a/packages/esm-appointments-app/src/appointments/appointment-tabs.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-tabs.component.tsx
@@ -8,7 +8,7 @@ import UnscheduledAppointments from './unscheduled/unscheduled-appointments.comp
 import styles from './appointment-tabs.scss';
 
 interface AppointmentTabsProps {
-  appointmentServiceTypes: string[];
+  appointmentServiceTypes: Array<string>;
 }
 
 const AppointmentTabs: React.FC<AppointmentTabsProps> = ({ appointmentServiceTypes }) => {

--- a/packages/esm-appointments-app/src/appointments/appointment-tabs.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/appointment-tabs.test.tsx
@@ -11,7 +11,7 @@ describe('AppointmentTabs', () => {
   xit(`renders tabs showing different appointment lists`, async () => {
     mockOpenmrsFetch.mockResolvedValue({ ...mockAppointmentsData } as unknown as FetchResponse);
 
-    renderWithSwr(<AppointmentTabs appointmentServiceType="" />);
+    renderWithSwr(<AppointmentTabs appointmentServiceTypes={['service-type-uuid']} />);
 
     await waitForLoadingToFinish();
 

--- a/packages/esm-appointments-app/src/appointments/details/appointment-details.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/details/appointment-details.component.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import styles from './appointment-details.scss';
-import { usePatientAppointmentHistory } from '../../hooks/usePatientAppointmentHistory';
+import { useTranslation } from 'react-i18next';
 import { formatDate, formatDatetime, usePatient } from '@openmrs/esm-framework';
+import { usePatientAppointmentHistory } from '../../hooks/usePatientAppointmentHistory';
 import { getGender } from '../../helpers';
 import { type Appointment } from '../../types';
-import { useTranslation } from 'react-i18next';
+import styles from './appointment-details.scss';
 
 interface AppointmentDetailsProps {
   appointment: Appointment;
@@ -21,6 +21,7 @@ const AppointmentDetails: React.FC<AppointmentDetailsProps> = ({ appointment }) 
       setIsEnabledQuery(true);
     }
   }, [appointmentsCount, isLoading]);
+
   return (
     <div className={styles.appointmentDetailsContainer}>
       <p className={styles.title}>{appointment.service.name}</p>

--- a/packages/esm-appointments-app/src/appointments/scheduled/appointments-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/scheduled/appointments-list.component.tsx
@@ -4,35 +4,39 @@ import { useAppointmentList } from '../../hooks/useAppointmentList';
 import AppointmentsTable from '../common-components/appointments-table.component';
 
 interface AppointmentsListProps {
-  appointmentServiceType?: string[];
+  appointmentServiceTypes?: string[];
+  date: string;
+  excludeCancelledAppointments?: boolean;
   status?: string;
   title: string;
-  date: string;
-  filterCancelled?: boolean;
 }
+
 const AppointmentsList: React.FC<AppointmentsListProps> = ({
-  appointmentServiceType,
+  appointmentServiceTypes,
+  date,
+  excludeCancelledAppointments = false,
   status,
   title,
-  date,
-  filterCancelled = false,
 }) => {
   const { appointmentList, isLoading } = useAppointmentList(status, date);
 
-  const appointments = filterByServiceType(appointmentList, appointmentServiceType).map((appointment) => ({
-    id: appointment.uuid,
-    ...appointment,
-  }));
+  const appointmentsFilteredByServiceType = filterByServiceType(appointmentList, appointmentServiceTypes).map(
+    (appointment) => ({
+      id: appointment.uuid,
+      ...appointment,
+    }),
+  );
 
-  const activeAppointments = filterCancelled
-    ? appointments.filter((appointment) => appointment.status !== 'Cancelled')
-    : appointments;
+  const activeAppointments = excludeCancelledAppointments
+    ? appointmentsFilteredByServiceType.filter((appointment) => appointment.status !== 'Cancelled')
+    : appointmentsFilteredByServiceType;
+
   return (
     <AppointmentsTable
       appointments={activeAppointments}
+      hasActiveFilters={appointmentServiceTypes?.length > 0}
       isLoading={isLoading}
       tableHeading={title}
-      hasActiveFilters={appointmentServiceType?.length > 0 || filterCancelled}
     />
   );
 };

--- a/packages/esm-appointments-app/src/appointments/scheduled/appointments-list.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/scheduled/appointments-list.component.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { filterByServiceType } from '../utils';
 import { useAppointmentList } from '../../hooks/useAppointmentList';
 import AppointmentsTable from '../common-components/appointments-table.component';
 
 interface AppointmentsListProps {
-  appointmentServiceTypes?: string[];
+  appointmentServiceTypes?: Array<string>;
   date: string;
   excludeCancelledAppointments?: boolean;
   status?: string;
@@ -27,9 +27,11 @@ const AppointmentsList: React.FC<AppointmentsListProps> = ({
     }),
   );
 
-  const activeAppointments = excludeCancelledAppointments
-    ? appointmentsFilteredByServiceType.filter((appointment) => appointment.status !== 'Cancelled')
-    : appointmentsFilteredByServiceType;
+  const activeAppointments = useMemo(() => {
+    return excludeCancelledAppointments
+      ? appointmentsFilteredByServiceType.filter((appointment) => appointment.status !== 'Cancelled')
+      : appointmentsFilteredByServiceType;
+  }, [excludeCancelledAppointments, appointmentsFilteredByServiceType]);
 
   return (
     <AppointmentsTable

--- a/packages/esm-appointments-app/src/appointments/scheduled/early-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/scheduled/early-appointments.component.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { useEarlyAppointmentList } from '../../hooks/useAppointmentList';
-import { filterByServiceType } from '../utils';
-import AppointmentsTable from '../common-components/appointments-table.component';
 import { useTranslation } from 'react-i18next';
+import { filterByServiceType } from '../utils';
+import { useEarlyAppointmentList } from '../../hooks/useAppointmentList';
+import AppointmentsTable from '../common-components/appointments-table.component';
 
 interface EarlyAppointmentsProps {
-  appointmentServiceType?: string[];
+  appointmentServiceTypes?: string[];
   date: string;
 }
 
@@ -13,11 +13,11 @@ interface EarlyAppointmentsProps {
  * Component to display early appointments
  * Note that although we define this extension in routes.jsx, we currently don't wire it into the scheduled-appointments-panels-slot by default because it requests a custom endpoint (see useEarlyAppointments) not provided by the standard Bahmni Appointments module
  */
-const EarlyAppointments: React.FC<EarlyAppointmentsProps> = ({ appointmentServiceType, date }) => {
+const EarlyAppointments: React.FC<EarlyAppointmentsProps> = ({ appointmentServiceTypes, date }) => {
   const { t } = useTranslation();
   const { earlyAppointmentList, isLoading } = useEarlyAppointmentList(date);
 
-  const appointments = filterByServiceType(earlyAppointmentList, appointmentServiceType).map((appointment, index) => {
+  const appointments = filterByServiceType(earlyAppointmentList, appointmentServiceTypes).map((appointment, index) => {
     return {
       id: `${index}`,
       ...appointment,

--- a/packages/esm-appointments-app/src/appointments/scheduled/early-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/scheduled/early-appointments.component.tsx
@@ -5,7 +5,7 @@ import { useEarlyAppointmentList } from '../../hooks/useAppointmentList';
 import AppointmentsTable from '../common-components/appointments-table.component';
 
 interface EarlyAppointmentsProps {
-  appointmentServiceTypes?: string[];
+  appointmentServiceTypes?: Array<string>;
   date: string;
 }
 

--- a/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
@@ -18,14 +18,14 @@ import styles from './scheduled-appointments.scss';
 dayjs.extend(isSameOrBefore);
 
 interface ScheduledAppointmentsProps {
-  appointmentServiceType?: string[];
+  appointmentServiceTypes?: string[];
 }
 
 type DateType = 'pastDate' | 'today' | 'futureDate';
 
 const scheduledAppointmentsPanelsSlot = 'scheduled-appointments-panels-slot';
 
-const ScheduledAppointments: React.FC<ScheduledAppointmentsProps> = ({ appointmentServiceType }) => {
+const ScheduledAppointments: React.FC<ScheduledAppointmentsProps> = ({ appointmentServiceTypes }) => {
   const { t } = useTranslation();
   const { selectedDate } = useContext(SelectedDateContext);
   const layout = useLayoutType();
@@ -81,22 +81,22 @@ const ScheduledAppointments: React.FC<ScheduledAppointmentsProps> = ({ appointme
         onChange={({ name }) => setCurrentTab(name)}
         selectedIndex={panelsToShow.findIndex((panel) => panel.name == currentTab) ?? 0}
         selectionMode="manual">
-        {panelsToShow.map((panel) => {
-          return <Switch key={`panel-${panel.name}`} name={panel.name} text={t(panel.config.title)} />;
-        })}
+        {panelsToShow.map((panel) => (
+          <Switch key={`panel-${panel.name}`} name={panel.name} text={t(panel.config.title)} />
+        ))}
       </ContentSwitcher>
 
       <ExtensionSlot name={scheduledAppointmentsPanelsSlot}>
         {(extension) => {
           return (
             <ExtensionWrapper
-              extension={extension}
+              appointmentServiceTypes={appointmentServiceTypes}
               currentTab={currentTab}
-              appointmentServiceType={appointmentServiceType}
               date={selectedDate}
               dateType={dateType}
-              showExtensionTab={showExtension}
+              extension={extension}
               hideExtensionTab={hideExtension}
+              showExtensionTab={showExtension}
             />
           );
         }}
@@ -133,7 +133,7 @@ function useAllowedExtensions() {
 function ExtensionWrapper({
   extension,
   currentTab,
-  appointmentServiceType,
+  appointmentServiceTypes,
   date,
   dateType,
   showExtensionTab,
@@ -141,7 +141,7 @@ function ExtensionWrapper({
 }: {
   extension: ConnectedExtension;
   currentTab: string;
-  appointmentServiceType: string[];
+  appointmentServiceTypes: string[];
   date: string;
   dateType: DateType;
   showExtensionTab: (extension: string) => void;
@@ -173,7 +173,7 @@ function ExtensionWrapper({
       <Extension
         state={{
           date,
-          appointmentServiceType,
+          appointmentServiceTypes,
           status: extension.config?.status,
           title: extension.config?.title,
         }}

--- a/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
@@ -18,7 +18,7 @@ import styles from './scheduled-appointments.scss';
 dayjs.extend(isSameOrBefore);
 
 interface ScheduledAppointmentsProps {
-  appointmentServiceTypes?: string[];
+  appointmentServiceTypes?: Array<string>;
 }
 
 type DateType = 'pastDate' | 'today' | 'futureDate';
@@ -141,7 +141,7 @@ function ExtensionWrapper({
 }: {
   extension: ConnectedExtension;
   currentTab: string;
-  appointmentServiceTypes: string[];
+  appointmentServiceTypes: Array<string>;
   date: string;
   dateType: DateType;
   showExtensionTab: (extension: string) => void;

--- a/packages/esm-appointments-app/src/appointments/utils.tsx
+++ b/packages/esm-appointments-app/src/appointments/utils.tsx
@@ -73,7 +73,7 @@ export function useAppointmentSearchResults(data: Appointment[], searchString: s
   }, [searchString, data]);
 }
 
-export function filterByServiceType(appointmentList: any[], appointmentServiceTypes: string[]) {
+export function filterByServiceType(appointmentList: Array<Appointment>, appointmentServiceTypes: Array<string>) {
   return appointmentServiceTypes?.length > 0
     ? appointmentList.filter(({ service }) => appointmentServiceTypes.includes(service.uuid))
     : appointmentList;

--- a/packages/esm-appointments-app/src/appointments/utils.tsx
+++ b/packages/esm-appointments-app/src/appointments/utils.tsx
@@ -73,8 +73,8 @@ export function useAppointmentSearchResults(data: Appointment[], searchString: s
   }, [searchString, data]);
 }
 
-export function filterByServiceType(appointmentList: any[], appointmentServiceType: string[]) {
-  return appointmentServiceType?.length > 0
-    ? appointmentList.filter(({ service }) => appointmentServiceType.includes(service.uuid))
+export function filterByServiceType(appointmentList: any[], appointmentServiceTypes: string[]) {
+  return appointmentServiceTypes?.length > 0
+    ? appointmentList.filter(({ service }) => appointmentServiceTypes.includes(service.uuid))
     : appointmentList;
 }

--- a/packages/esm-appointments-app/src/header/appointments-header.component.tsx
+++ b/packages/esm-appointments-app/src/header/appointments-header.component.tsx
@@ -55,8 +55,6 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, appointme
         {typeof onChange === 'function' && (
           <MultiSelect
             id="serviceTypeMultiSelect"
-            // TODO: Figure out why we need to set the initial selected items
-            initialSelectedItems={serviceTypeOptions.length > 0 ? [serviceTypeOptions[0].id] : []}
             items={serviceTypeOptions}
             itemToString={(item) => (item ? item.label : '')}
             label={t('filterAppointmentsByServiceType', 'Filter appointments by service type')}

--- a/packages/esm-appointments-app/src/header/appointments-header.component.tsx
+++ b/packages/esm-appointments-app/src/header/appointments-header.component.tsx
@@ -10,11 +10,11 @@ import styles from './appointments-header.scss';
 
 interface AppointmentHeaderProps {
   title: string;
-  appointmentServiceTypes?: string[];
+  appointmentServiceTypes?: Array<string>;
   onChange?: (evt) => void;
 }
 
-const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, appointmentServiceTypes, onChange }) => {
+const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, onChange }) => {
   const { t } = useTranslation();
   const { selectedDate, setSelectedDate } = useContext(SelectedDateContext);
   const { serviceTypes } = useAppointmentServices();

--- a/packages/esm-appointments-app/src/header/appointments-header.component.tsx
+++ b/packages/esm-appointments-app/src/header/appointments-header.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { DatePicker, DatePickerInput, MultiSelect } from '@carbon/react';
@@ -10,11 +10,11 @@ import styles from './appointments-header.scss';
 
 interface AppointmentHeaderProps {
   title: string;
-  appointmentServiceType?: string[];
+  appointmentServiceTypes?: string[];
   onChange?: (evt) => void;
 }
 
-const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, appointmentServiceType, onChange }) => {
+const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, appointmentServiceTypes, onChange }) => {
   const { t } = useTranslation();
   const { selectedDate, setSelectedDate } = useContext(SelectedDateContext);
   const { serviceTypes } = useAppointmentServices();
@@ -55,11 +55,12 @@ const AppointmentsHeader: React.FC<AppointmentHeaderProps> = ({ title, appointme
         {typeof onChange === 'function' && (
           <MultiSelect
             id="serviceTypeMultiSelect"
-            label={t('filterAppointmentsByServiceType', 'Filter appointments by service type')}
+            // TODO: Figure out why we need to set the initial selected items
+            initialSelectedItems={serviceTypeOptions.length > 0 ? [serviceTypeOptions[0].id] : []}
             items={serviceTypeOptions}
             itemToString={(item) => (item ? item.label : '')}
+            label={t('filterAppointmentsByServiceType', 'Filter appointments by service type')}
             onChange={handleMultiSelectChange}
-            initialSelectedItems={serviceTypeOptions.length > 0 ? [serviceTypeOptions[0].id] : []}
             type="inline"
           />
         )}

--- a/packages/esm-appointments-app/src/home/home-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/home/home-appointments.component.tsx
@@ -12,7 +12,7 @@ const HomeAppointments = () => {
     <div className={styles.container}>
       <AppointmentsList
         date={toOmrsIsoString(dayjs().startOf('day').toDate())}
-        filterCancelled
+        excludeCancelledAppointments
         title={t('todays', "Today's")}
       />
     </div>

--- a/packages/esm-appointments-app/src/hooks/useClinicalMetrics.ts
+++ b/packages/esm-appointments-app/src/hooks/useClinicalMetrics.ts
@@ -1,16 +1,16 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import { uniqBy } from 'lodash-es';
 import dayjs from 'dayjs';
 import useSWR from 'swr';
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
-import { type Appointment, type AppointmentSummary } from '../types';
 import { omrsDateFormat } from '../constants';
 import {
-  getHighestAppointmentServiceLoad,
   flattenAppointmentSummary,
+  getHighestAppointmentServiceLoad,
   getServiceCountByAppointmentType,
 } from '../helpers';
 import SelectedDateContext from './selectedDateContext';
+import { type Appointment, type AppointmentSummary } from '../types';
 
 export const useClinicalMetrics = () => {
   const { selectedDate } = useContext(SelectedDateContext);
@@ -36,13 +36,26 @@ export const useClinicalMetrics = () => {
   };
 };
 
-export function useAllAppointmentsByDate() {
+export const useAppointmentsForDate = () => {
   const { selectedDate } = useContext(SelectedDateContext);
-  const apiUrl = `${restBaseUrl}/appointment/all?forDate=${selectedDate}`;
+  const url = selectedDate ? `${restBaseUrl}/appointment/all?forDate=${selectedDate}` : null;
+
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: Array<Appointment> }, Error>(
-    apiUrl,
+    url,
     openmrsFetch,
   );
+
+  return {
+    data,
+    error,
+    isLoading,
+    isValidating,
+    mutate,
+  };
+};
+
+export const useAllAppointmentsByDate = () => {
+  const { data, error, isLoading, isValidating, mutate } = useAppointmentsForDate();
 
   const providersArray = data?.data?.flatMap(({ providers }) => providers ?? []) ?? [];
   const validProviders = providersArray.filter((provider) => provider.response === 'ACCEPTED');
@@ -56,26 +69,22 @@ export function useAllAppointmentsByDate() {
     mutate,
     totalProviders: providersCount ? providersCount : 0,
   };
-}
+};
 
 export const useScheduledAppointments = (appointmentServiceTypeUuids: string[]) => {
-  const { selectedDate } = useContext(SelectedDateContext);
-  const url = `${restBaseUrl}/appointment/all?forDate=${selectedDate}`;
+  const { data, error, isLoading } = useAppointmentsForDate();
 
-  const { data, error, isLoading } = useSWR<
-    {
-      data: Array<Appointment>;
-    },
-    Error
-  >(url, selectedDate ? openmrsFetch : null);
+  const totalScheduledAppointments = useMemo(() => {
+    const appointments = data?.data ?? [];
 
-  const appointments = data?.data ?? [];
+    if (appointmentServiceTypeUuids.length === 0) {
+      return appointments.length;
+    }
 
-  const totalScheduledAppointments =
-    appointmentServiceTypeUuids.length > 0
-      ? appointments.filter((appointment) => appointmentServiceTypeUuids.includes(appointment?.service?.uuid))
-          ?.length ?? 0
-      : appointments.length ?? 0;
+    return appointments.filter(
+      (appointment) => appointment.service && appointmentServiceTypeUuids.includes(appointment.service.uuid),
+    ).length;
+  }, [data?.data, appointmentServiceTypeUuids]);
 
   return {
     error,

--- a/packages/esm-appointments-app/src/metrics/appointments-metrics.component.tsx
+++ b/packages/esm-appointments-app/src/metrics/appointments-metrics.component.tsx
@@ -9,7 +9,7 @@ import MetricsHeader from './metrics-header.component';
 import styles from './appointments-metrics.scss';
 
 interface AppointmentMetricsProps {
-  appointmentServiceTypes: string[];
+  appointmentServiceTypes: Array<string>;
 }
 
 const AppointmentsMetrics: React.FC<AppointmentMetricsProps> = ({ appointmentServiceTypes }) => {

--- a/packages/esm-appointments-app/src/metrics/appointments-metrics.component.tsx
+++ b/packages/esm-appointments-app/src/metrics/appointments-metrics.component.tsx
@@ -1,23 +1,23 @@
 import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ErrorState, formatDate, parseDate } from '@openmrs/esm-framework';
-import { useClinicalMetrics, useAllAppointmentsByDate, useScheduledAppointment } from '../hooks/useClinicalMetrics';
+import { useClinicalMetrics, useAllAppointmentsByDate, useScheduledAppointments } from '../hooks/useClinicalMetrics';
 import { useAppointmentList } from '../hooks/useAppointmentList';
+import SelectedDateContext from '../hooks/selectedDateContext';
 import MetricsCard from './metrics-card.component';
 import MetricsHeader from './metrics-header.component';
 import styles from './appointments-metrics.scss';
-import SelectedDateContext from '../hooks/selectedDateContext';
 
 interface AppointmentMetricsProps {
-  appointmentServiceType: string[];
+  appointmentServiceTypes: string[];
 }
 
-const AppointmentsMetrics: React.FC<AppointmentMetricsProps> = ({ appointmentServiceType }) => {
+const AppointmentsMetrics: React.FC<AppointmentMetricsProps> = ({ appointmentServiceTypes }) => {
   const { t } = useTranslation();
 
   const { highestServiceLoad, error } = useClinicalMetrics();
   const { totalProviders } = useAllAppointmentsByDate();
-  const { totalScheduledAppointments } = useScheduledAppointment(appointmentServiceType);
+  const { totalScheduledAppointments } = useScheduledAppointments(appointmentServiceTypes);
 
   const { selectedDate } = useContext(SelectedDateContext);
   const formattedStartDate = formatDate(parseDate(selectedDate), { mode: 'standard', time: false });
@@ -26,11 +26,12 @@ const AppointmentsMetrics: React.FC<AppointmentMetricsProps> = ({ appointmentSer
   const { appointmentList: arrivedAppointments } = useAppointmentList('CheckedIn');
   const { appointmentList: pendingAppointments } = useAppointmentList('Scheduled');
 
-  const filteredArrivedAppointments = appointmentServiceType
-    ? arrivedAppointments.filter(({ service }) => appointmentServiceType.includes(service.uuid))
+  const filteredArrivedAppointments = appointmentServiceTypes
+    ? arrivedAppointments.filter(({ service }) => appointmentServiceTypes.includes(service.uuid))
     : arrivedAppointments;
-  const filteredPendingAppointments = appointmentServiceType
-    ? pendingAppointments.filter(({ service }) => appointmentServiceType.includes(service.uuid))
+
+  const filteredPendingAppointments = appointmentServiceTypes
+    ? pendingAppointments.filter(({ service }) => appointmentServiceTypes.includes(service.uuid))
     : pendingAppointments;
 
   if (error) {
@@ -46,22 +47,22 @@ const AppointmentsMetrics: React.FC<AppointmentMetricsProps> = ({ appointmentSer
       <MetricsHeader />
       <section className={styles.cardContainer}>
         <MetricsCard
+          count={{ pendingAppointments: filteredPendingAppointments, arrivedAppointments: filteredArrivedAppointments }}
+          headerLabel={t('scheduledAppointments', 'Scheduled appointments')}
           label={t('patients', 'Patients')}
           value={totalScheduledAppointments}
-          headerLabel={t('scheduledAppointments', 'Scheduled appointments')}
-          count={{ pendingAppointments: filteredPendingAppointments, arrivedAppointments: filteredArrivedAppointments }}
         />
         <MetricsCard
+          headerLabel={t('highestServiceVolume', 'Highest volume service: {{time}}', { time: formattedStartDate })}
           label={
             highestServiceLoad?.count !== 0 ? t(highestServiceLoad?.serviceName) : t('serviceName', 'Service name')
           }
           value={highestServiceLoad?.count ?? '--'}
-          headerLabel={t('highestServiceVolume', 'Highest volume service: {{time}}', { time: formattedStartDate })}
         />
         <MetricsCard
+          headerLabel={t('providersBooked', 'Providers booked: {{time}}', { time: formattedStartDate })}
           label={t('providers', 'Providers')}
           value={totalProviders}
-          headerLabel={t('providersBooked', 'Providers booked: {{time}}', { time: formattedStartDate })}
         />
       </section>
     </>

--- a/packages/esm-appointments-app/src/metrics/appointments-metrics.test.tsx
+++ b/packages/esm-appointments-app/src/metrics/appointments-metrics.test.tsx
@@ -18,7 +18,7 @@ jest.mock('../hooks/useClinicalMetrics', () => ({
     isLoading: mockProvidersCount.isLoading,
     error: mockProvidersCount.error,
   }),
-  useScheduledAppointment: jest.fn().mockReturnValue({
+  useScheduledAppointments: jest.fn().mockReturnValue({
     totalScheduledAppointments: mockAppointmentMetrics.totalAppointments,
   }),
   useAppointmentDate: jest.fn().mockReturnValue({
@@ -32,7 +32,7 @@ describe('Appointment metrics', () => {
       data: [],
     } as unknown as FetchResponse);
 
-    render(<AppointmentsMetrics appointmentServiceType="consultation-service-uuid" />);
+    render(<AppointmentsMetrics appointmentServiceTypes={['consultation-service-uuid']} />);
 
     await screen.findByText(/appointment metrics/i);
     expect(screen.getByText(/scheduled appointments/i)).toBeInTheDocument();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Relates to https://github.com/openmrs/openmrs-esm-patient-management/pull/1449.

Makes the following refactors to the Appointments app:

- Rename `appointmentServiceType` to `appointmentServiceTypes` in components that use it. Prior to https://github.com/openmrs/openmrs-esm-patient-management/pull/1449, this prop was a string, but is now an array of strings. The refactor also updates the components to handle the new prop type.
- Rename the `filterCancelled` prop to `excludeCancelledAppointments` in components that use it. The latter is more descriptive of the purpose of the prop.
- Fix `hasActiveFilters` logic to only consider service type filters. There's a tangential issue where the Today's appointments component shows an empty filter state when it shouldn't. It should show an empty state instead if there are no scheduled appointments for today. Cleaning up this logic allows me to isolate that issue so it can be fixed in a separate PR.

Additionally, following this [discussion](https://github.com/openmrs/openmrs-esm-patient-management/pull/1504#discussion_r1971535142), this PR modifies the appointments service type filter. It removes the `initialSelectedItem` prop from the `MultiSelect` component, which previously auto-selected the first available service type from the backend. With this change, the filter starts in a blank state, showing all appointments by default. Users must now explicitly select which service types they want to filter by, making the filter behavior more intuitive and predictable.

## Screenshots

### No pre-selected filters

![CleanShot 2025-02-26 at 8  52 01@2x](https://github.com/user-attachments/assets/e0458188-f1dd-4abf-87ac-c6900cc9fd70)

## Related Issue
https://openmrs.atlassian.net/browse/O3-4335

## Other
<!-- Anything not covered above -->
