### PR TITLE
(Fix) Search bar on service queues table should always be open 

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/default-queue-table.component.tsx
@@ -153,6 +153,7 @@ function QueueTableSection() {
             onChange={(e) => setSearchTerm(e.target.value)}
             placeholder={t('searchThisList', 'Search this list')}
             size={isDesktop(layout) ? 'sm' : 'lg'}
+            persistent
           />
           <ClearQueueEntries queueEntries={filteredQueueEntries} />
         </>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, to search the table on the service queues page, the user has to click the spyglass icon to expand the search bar. 
I fixed this now and user no need to click on spyglass icon to expand the search bar.
## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/user-attachments/assets/2f43da3f-a8bd-4961-a1ad-1cd33886b240)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
