### PR TITLE
(fix) Center-align items in queue entry status container

### DIFF
--- a/packages/esm-service-queues-app/src/patient-info/patient-banner-queue-entry-status.scss
+++ b/packages/esm-service-queues-app/src/patient-info/patient-banner-queue-entry-status.scss
@@ -5,7 +5,7 @@
 
 .queueEntryStatusContainer {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: layout.$spacing-02;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Follow up to https://github.com/openmrs/openmrs-esm-patient-management/pull/1509.

Changes alignment of items in the queue entry status container from `baseline` to `center` for better visual consistency.

## Screenshots

### Before

![CleanShot 2025-03-17 at 3  36 01@2x](https://github.com/user-attachments/assets/dadada8d-40e1-434a-8d39-6ba60478de1a)

### After

![CleanShot 2025-03-17 at 3  35 42@2x](https://github.com/user-attachments/assets/e9709ed0-a8ed-46e3-88ed-6f54a65fa67b)

Alternative screen: https://github.com/openmrs/openmrs-esm-patient-management/pull/1509#discussion_r1985706313

## Related Issue

https://issues.openmrs.org/browse/O3-4400

## Other
<!-- Anything not covered above -->
