### PR TITLE
(refactor) Optimize patient registration form performance

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/custom-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/custom-field.component.tsx
@@ -1,16 +1,16 @@
-import { useConfig } from '@openmrs/esm-framework';
 import React from 'react';
-import { type RegistrationConfig } from '../../config-schema';
+import { useConfig } from '@openmrs/esm-framework';
 import { AddressField } from './address/custom-address-field.component';
 import { ObsField } from './obs/obs-field.component';
 import { PersonAttributeField } from './person-attributes/person-attribute-field.component';
+import { type RegistrationConfig } from '../../config-schema';
 
 export interface CustomFieldProps {
   name: string;
 }
 
 export function CustomField({ name }: CustomFieldProps) {
-  const config = useConfig() as RegistrationConfig;
+  const config = useConfig<RegistrationConfig>();
   const fieldDefinition = config.fieldDefinitions.filter((def) => def.id == name)[0];
 
   if (fieldDefinition.type === 'person attribute') {

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.component.tsx
@@ -16,7 +16,7 @@ export interface FieldProps {
 }
 
 export function Field({ name }: FieldProps) {
-  const config = useConfig() as RegistrationConfig;
+  const config = useConfig<RegistrationConfig>();
   if (
     !(builtInFields as ReadonlyArray<string>).includes(name) &&
     !config.fieldDefinitions.some((def) => def.id == name)

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-context.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-context.ts
@@ -1,25 +1,27 @@
-import { useConfig } from '@openmrs/esm-framework';
-import { createContext, type SetStateAction } from 'react';
-import { type RegistrationConfig } from '../config-schema';
+import { createContext, type SetStateAction, useContext } from 'react';
+import { type PatientIdentifierType, useConfig } from '@openmrs/esm-framework';
 import { type CapturePhotoProps, type FormValues } from './patient-registration.types';
+import { type RegistrationConfig } from '../config-schema';
 
 export interface PatientRegistrationContextProps {
   currentPhoto: string;
-  identifierTypes: Array<any>;
+  identifierTypes: Array<PatientIdentifierType>;
   inEditMode: boolean;
   initialFormValues: FormValues;
   isOffline: boolean;
+  setCapturePhotoProps(value: SetStateAction<CapturePhotoProps>): void;
+  setFieldTouched(field: string, isTouched?: any, shouldValidate?: boolean): void;
+  setFieldValue(field: string, value: any, shouldValidate?: boolean): void;
   setInitialFormValues?: React.Dispatch<SetStateAction<FormValues>>;
   validationSchema: any;
   values: FormValues;
-  setCapturePhotoProps(value: SetStateAction<CapturePhotoProps>): void;
-  setFieldValue(field: string, value: any, shouldValidate?: boolean): void;
-  setFieldTouched(field: string, isTouched?: any, shouldValidate?: boolean): void;
 }
 
 export const PatientRegistrationContext = createContext<PatientRegistrationContextProps | undefined>(undefined);
 
 export function useFieldConfig(field: string) {
-  const { fieldConfigurations } = useConfig() as RegistrationConfig;
+  const { fieldConfigurations } = useConfig<RegistrationConfig>();
   return fieldConfigurations[field];
 }
+
+export const usePatientRegistrationContext = () => useContext(PatientRegistrationContext);

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
@@ -1,4 +1,8 @@
 import { type Dispatch, useEffect, useMemo, useState } from 'react';
+import { camelCase } from 'lodash-es';
+import { v4 } from 'uuid';
+import dayjs from 'dayjs';
+import useSWR from 'swr';
 import {
   type FetchResponse,
   type OpenmrsResource,
@@ -6,14 +10,10 @@ import {
   openmrsFetch,
   restBaseUrl,
   useConfig,
-  usePatient,
 } from '@openmrs/esm-framework';
-import camelCase from 'lodash-es/camelCase';
-import dayjs from 'dayjs';
-import useSWR from 'swr';
-import { v4 } from 'uuid';
 import { type RegistrationConfig } from '../config-schema';
 import { patientRegistration } from '../constants';
+import { useInitialPatientRelationships } from './section/patient-relationships/relationships.resource';
 import {
   type Encounter,
   type FormValues,
@@ -29,20 +29,22 @@ import {
   getPhonePersonAttributeValueFromFhirPatient,
   latestFirstEncounter,
 } from './patient-registration-utils';
-import { useInitialPatientRelationships } from './section/patient-relationships/relationships.resource';
 
 interface DeathInfoResults {
-  uuid: string;
-  display: string;
   causeOfDeath: OpenmrsResource | null;
+  causeOfDeathNonCoded: string | null;
   dead: boolean;
   deathDate: string;
-  causeOfDeathNonCoded: string | null;
+  display: string;
+  uuid: string;
 }
 
-export function useInitialFormValues(patientUuid: string): [FormValues, Dispatch<FormValues>] {
+export function useInitialFormValues(
+  isLoadingPatientToEdit: boolean,
+  patientToEdit: fhir.Patient,
+  patientUuid: string,
+): [FormValues, Dispatch<FormValues>] {
   const { freeTextFieldConceptUuid } = useConfig<RegistrationConfig>();
-  const { isLoading: isLoadingPatientToEdit, patient: patientToEdit } = usePatient(patientUuid);
   const { data: deathInfo, isLoading: isLoadingDeathInfo } = useInitialPersonDeathInfo(patientUuid);
   const { data: attributes, isLoading: isLoadingAttributes } = useInitialPersonAttributes(patientUuid);
   const { data: identifiers, isLoading: isLoadingIdentifiers } = useInitialPatientIdentifiers(patientUuid);
@@ -50,29 +52,29 @@ export function useInitialFormValues(patientUuid: string): [FormValues, Dispatch
   const { data: encounters } = useInitialEncounters(patientUuid, patientToEdit);
 
   const [initialFormValues, setInitialFormValues] = useState<FormValues>({
-    patientUuid: v4(),
-    givenName: '',
-    middleName: '',
-    familyName: '',
+    additionalFamilyName: '',
     additionalGivenName: '',
     additionalMiddleName: '',
-    additionalFamilyName: '',
     addNameInLocalLanguage: false,
-    gender: '',
+    address: {},
     birthdate: null,
-    yearsEstimated: 0,
-    monthsEstimated: 0,
     birthdateEstimated: false,
-    telephoneNumber: '',
-    isDead: false,
+    deathCause: '',
     deathDate: undefined,
     deathTime: undefined,
     deathTimeFormat: 'AM',
-    deathCause: '',
-    nonCodedCauseOfDeath: '',
-    relationships: [],
+    familyName: '',
+    gender: '',
+    givenName: '',
     identifiers: {},
-    address: {},
+    isDead: false,
+    middleName: '',
+    monthsEstimated: 0,
+    nonCodedCauseOfDeath: '',
+    patientUuid: v4(),
+    relationships: [],
+    telephoneNumber: '',
+    yearsEstimated: 0,
   });
 
   useEffect(() => {
@@ -80,21 +82,20 @@ export function useInitialFormValues(patientUuid: string): [FormValues, Dispatch
       if (patientToEdit) {
         const birthdateEstimated = !/^\d{4}-\d{2}-\d{2}$/.test(patientToEdit.birthDate);
         const [years = 0, months = 0] = patientToEdit.birthDate.split('-').map((val) => parseInt(val));
-        // Please refer: https://github.com/openmrs/openmrs-esm-patient-management/pull/697#issuecomment-1562706118
         const estimatedMonthsAvailable = patientToEdit.birthDate.split('-').length > 1;
         const yearsEstimated = birthdateEstimated ? Math.floor(dayjs().diff(patientToEdit.birthDate, 'month') / 12) : 0;
         const monthsEstimated =
           birthdateEstimated && estimatedMonthsAvailable ? dayjs().diff(patientToEdit.birthDate, 'month') % 12 : 0;
 
-        setInitialFormValues({
-          ...initialFormValues,
+        setInitialFormValues((currentValues) => ({
+          ...currentValues,
           ...getFormValuesFromFhirPatient(patientToEdit),
           address: getAddressFieldValuesFromFhirPatient(patientToEdit),
           ...getPhonePersonAttributeValueFromFhirPatient(patientToEdit),
           birthdateEstimated: !/^\d{4}-\d{2}-\d{2}$/.test(patientToEdit.birthDate),
           yearsEstimated,
           monthsEstimated,
-        });
+        }));
       } else if (!isLoadingPatientToEdit && patientUuid) {
         const registration = await getPatientRegistration(patientUuid);
 
@@ -108,7 +109,7 @@ export function useInitialFormValues(patientUuid: string): [FormValues, Dispatch
         setInitialFormValues(registration._patientRegistrationData.formValues);
       }
     })();
-  }, [initialFormValues, isLoadingPatientToEdit, patientToEdit, patientUuid]);
+  }, [isLoadingPatientToEdit, patientToEdit, patientUuid]);
 
   // Set initial patient death info
   useEffect(() => {
@@ -127,9 +128,9 @@ export function useInitialFormValues(patientUuid: string): [FormValues, Dispatch
         nonCodedCauseOfDeath: deathInfo.causeOfDeathNonCoded,
       }));
     }
-  }, [isLoadingDeathInfo, deathInfo, setInitialFormValues, freeTextFieldConceptUuid]);
+  }, [isLoadingDeathInfo, deathInfo, freeTextFieldConceptUuid]);
 
-  // Set initial patient relationships
+  // Combined effect for relationships and identifiers
   useEffect(() => {
     if (!isLoadingRelationships && relationships) {
       setInitialFormValues((initialFormValues) => ({
@@ -137,35 +138,35 @@ export function useInitialFormValues(patientUuid: string): [FormValues, Dispatch
         relationships,
       }));
     }
-  }, [isLoadingRelationships, relationships, setInitialFormValues]);
 
-  // Set Initial patient identifiers
-  useEffect(() => {
     if (!isLoadingIdentifiers && identifiers) {
       setInitialFormValues((initialFormValues) => ({
         ...initialFormValues,
         identifiers,
       }));
     }
-  }, [isLoadingIdentifiers, identifiers, setInitialFormValues]);
+  }, [isLoadingRelationships, relationships, isLoadingIdentifiers, identifiers]);
 
   // Set Initial person attributes
   useEffect(() => {
     if (!isLoadingAttributes && attributes) {
-      let personAttributes = {};
-      attributes.forEach((attribute) => {
-        personAttributes[attribute.attributeType.uuid] =
-          attribute.attributeType.format === 'org.openmrs.Concept' && typeof attribute.value === 'object'
-            ? attribute.value?.uuid
-            : attribute.value;
-      });
+      const personAttributes = attributes.reduce(
+        (acc, attribute) => ({
+          ...acc,
+          [attribute.attributeType.uuid]:
+            attribute.attributeType.format === 'org.openmrs.Concept' && typeof attribute.value === 'object'
+              ? attribute.value?.uuid
+              : attribute.value,
+        }),
+        {},
+      );
 
       setInitialFormValues((initialFormValues) => ({
         ...initialFormValues,
         attributes: personAttributes,
       }));
     }
-  }, [attributes, setInitialFormValues, isLoadingAttributes]);
+  }, [attributes, isLoadingAttributes]);
 
   // Set Initial registration encounters
   useEffect(() => {
@@ -180,49 +181,73 @@ export function useInitialFormValues(patientUuid: string): [FormValues, Dispatch
   return [initialFormValues, setInitialFormValues];
 }
 
-export function useInitialAddressFieldValues(patientUuid: string, fallback = {}): [object, Dispatch<object>] {
-  const { isLoading, patient } = usePatient(patientUuid);
+export function useInitialAddressFieldValues(
+  fallback = {},
+  isLoadingPatientToEdit: boolean,
+  patientToEdit: fhir.Patient,
+  patientUuid: string,
+): [object, Dispatch<object>] {
   const [initialAddressFieldValues, setInitialAddressFieldValues] = useState<object>(fallback);
 
   useEffect(() => {
     (async () => {
-      if (patient) {
-        setInitialAddressFieldValues({
-          ...initialAddressFieldValues,
-          address: getAddressFieldValuesFromFhirPatient(patient),
-        });
-      } else if (!isLoading && patientUuid) {
+      if (patientToEdit) {
+        setInitialAddressFieldValues((currentValues) => ({
+          ...currentValues,
+          address: getAddressFieldValuesFromFhirPatient(patientToEdit),
+        }));
+      } else if (!isLoadingPatientToEdit && patientUuid) {
         const registration = await getPatientRegistration(patientUuid);
         setInitialAddressFieldValues(registration?._patientRegistrationData.initialAddressFieldValues ?? fallback);
       }
     })();
-  }, [fallback, initialAddressFieldValues, isLoading, patient, patientUuid]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoadingPatientToEdit, patientToEdit, patientUuid]);
 
   return [initialAddressFieldValues, setInitialAddressFieldValues];
 }
 
 export function usePatientUuidMap(
-  patientUuid: string,
   fallback: PatientUuidMapType = {},
+  isLoadingPatientToEdit: boolean,
+  patientToEdit: fhir.Patient,
+  patientUuid: string,
 ): [PatientUuidMapType, Dispatch<PatientUuidMapType>] {
-  const { isLoading: isLoadingPatientToEdit, patient: patientToEdit } = usePatient(patientUuid);
   const { data: attributes } = useInitialPersonAttributes(patientUuid);
   const [patientUuidMap, setPatientUuidMap] = useState(fallback);
 
   useEffect(() => {
-    if (patientToEdit) {
-      setPatientUuidMap({ ...patientUuidMap, ...getPatientUuidMapFromFhirPatient(patientToEdit) });
-    } else if (!isLoadingPatientToEdit && patientUuid) {
-      getPatientRegistration(patientUuid).then((registration) =>
-        setPatientUuidMap(registration?._patientRegistrationData.initialAddressFieldValues ?? fallback),
-      );
+    const abortController = new AbortController();
+
+    async function updatePatientMap() {
+      if (patientToEdit) {
+        setPatientUuidMap((prevMap) => ({
+          ...prevMap,
+          ...getPatientUuidMapFromFhirPatient(patientToEdit),
+        }));
+      } else if (!isLoadingPatientToEdit && patientUuid) {
+        try {
+          const registration = await getPatientRegistration(patientUuid);
+          if (!abortController.signal.aborted) {
+            setPatientUuidMap(registration?._patientRegistrationData.initialAddressFieldValues ?? fallback);
+          }
+        } catch (error) {
+          if (!abortController.signal.aborted) {
+            console.error('Failed to get patient registration:', error);
+          }
+        }
+      }
     }
-  }, [fallback, isLoadingPatientToEdit, patientToEdit, patientUuid, patientUuidMap]);
+
+    updatePatientMap();
+    return () => abortController.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoadingPatientToEdit, patientToEdit, patientUuid]);
 
   useEffect(() => {
     if (attributes) {
-      setPatientUuidMap((prevPatientUuidMap) => ({
-        ...prevPatientUuidMap,
+      setPatientUuidMap((prevMap) => ({
+        ...prevMap,
         ...getPatientAttributeUuidMapForPatient(attributes),
       }));
     }
@@ -278,7 +303,7 @@ export function useInitialPatientIdentifiers(patientUuid: string): {
 }
 
 function useInitialEncounters(patientUuid: string, patientToEdit: fhir.Patient) {
-  const { registrationObs } = useConfig() as RegistrationConfig;
+  const { registrationObs } = useConfig<RegistrationConfig>();
   const { data, error, isLoading } = useSWR<FetchResponse<{ results: Array<Encounter> }>>(
     patientToEdit && registrationObs.encounterTypeUuid
       ? `${restBaseUrl}/encounter?patient=${patientUuid}&v=custom:(encounterDatetime,obs:(concept:ref,value:ref))&encounterType=${registrationObs.encounterTypeUuid}`

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { Button, InlineLoading, Link } from '@carbon/react';
 import { XAxis } from '@carbon/react/icons';
@@ -38,8 +38,8 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
   const { t } = useTranslation();
   const { currentSession, identifierTypes } = useContext(ResourcesContext);
   const { patientUuid: uuidOfPatientToEdit } = useParams();
-  const { isLoading: isLoadingPatientToEdit, patient: patientToEdit } = usePatient(uuidOfPatientToEdit);
   const { search } = useLocation();
+  const { isLoading: isLoadingPatientToEdit, patient: patientToEdit } = usePatient(uuidOfPatientToEdit);
 
   const [initialFormValues, setInitialFormValues] = useInitialFormValues(
     isLoadingPatientToEdit,
@@ -52,6 +52,7 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
     patientToEdit,
     uuidOfPatientToEdit,
   );
+
   const [patientUuidMap] = usePatientUuidMap({}, isLoadingPatientToEdit, patientToEdit, uuidOfPatientToEdit);
 
   const [target, setTarget] = useState<undefined | string>();
@@ -164,8 +165,8 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
     }
   };
 
-  const createContextValue = useMemo(
-    () => (formikProps) => ({
+  const createContextValue = useCallback(
+    (formikProps) => ({
       identifierTypes,
       validationSchema,
       values: formikProps.values,

--- a/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.test.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.test.ts
@@ -1,7 +1,7 @@
+import dayjs from 'dayjs';
 import { getConfig } from '@openmrs/esm-framework';
 import { type RegistrationConfig } from '../../config-schema';
 import { getValidationSchema } from './patient-registration-validation';
-import dayjs from 'dayjs';
 
 const mockGetConfig = jest.mocked(getConfig);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,13 +1825,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/ecma402-abstract@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@formatjs/ecma402-abstract@npm:2.0.0"
+"@formatjs/ecma402-abstract@npm:2.3.3":
+  version: 2.3.3
+  resolution: "@formatjs/ecma402-abstract@npm:2.3.3"
   dependencies:
-    "@formatjs/intl-localematcher": "npm:0.5.4"
-    tslib: "npm:^2.4.0"
-  checksum: 10/41543ba509ea3c7d6530d57b888115f7ca242f13462a951fae4d1d1f28bae10c999f4dea28a71d2f08366d4889a3f5276cae3a16c6f6417b841a84fd314c2234
+    "@formatjs/fast-memoize": "npm:2.2.6"
+    "@formatjs/intl-localematcher": "npm:0.6.0"
+    decimal.js: "npm:10"
+    tslib: "npm:2"
+  checksum: 10/c73a704d5cba3b929a9a303a04b4e8a708bb2dea000ee41808c55b22941a70da01b065697cbc5a25898b2007405abd71f414ab8c327fe953f63ae4120c2cc98d
   languageName: node
   linkType: hard
 
@@ -1841,6 +1843,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/8697fe72a7ece252d600a7d08105f2a2f758e2dd96f54ac0a4c508b1205a559fc08835635e1f8e5ca9dcc3ee61ce1fca4a0e7047b402f29fc96051e293a280ff
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:2.2.6":
+  version: 2.2.6
+  resolution: "@formatjs/fast-memoize@npm:2.2.6"
+  dependencies:
+    tslib: "npm:2"
+  checksum: 10/efa5601dddbd94412ee567d5d067dfd206afa2d08553435f6938e69acba3309b83b9b15021cd30550d5fb93817a53b7691098a11a73f621c2d9318efad49fd76
   languageName: node
   linkType: hard
 
@@ -1865,14 +1876,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/intl-durationformat@npm:^0.2.4":
-  version: 0.2.4
-  resolution: "@formatjs/intl-durationformat@npm:0.2.4"
+"@formatjs/intl-durationformat@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "@formatjs/intl-durationformat@npm:0.7.3"
   dependencies:
-    "@formatjs/ecma402-abstract": "npm:2.0.0"
-    "@formatjs/intl-localematcher": "npm:0.5.4"
-    tslib: "npm:^2.4.0"
-  checksum: 10/5f500409a20d18967e17ffbc222f9b4c4bf7ef08cce20023c33f06d1989c2bc4cf700d1dd1d048748d0a36c882109d5375896a4964d6700f73ec18914c6de4ba
+    "@formatjs/ecma402-abstract": "npm:2.3.3"
+    "@formatjs/intl-localematcher": "npm:0.6.0"
+    tslib: "npm:2"
+  checksum: 10/781c4f1574e01d2155ca90593b0605de883937ade3d5057a6adf19e21379fd80fb5985cf7115d348f572fb25b281add8d851fb9011fea770e9b1ea1cf5e9b5a1
   languageName: node
   linkType: hard
 
@@ -1885,12 +1896,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@formatjs/intl-localematcher@npm:0.5.4":
-  version: 0.5.4
-  resolution: "@formatjs/intl-localematcher@npm:0.5.4"
+"@formatjs/intl-localematcher@npm:0.6.0":
+  version: 0.6.0
+  resolution: "@formatjs/intl-localematcher@npm:0.6.0"
   dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10/780cb29b42e1ea87f2eb5db268577fcdc53da52d9f096871f3a1bb78603b4ba81d208ea0b0b9bc21548797c941ce435321f62d2522795b83b740f90b0ceb5778
+    tslib: "npm:2"
+  checksum: 10/d8fd984c14121949d0ba60732a096aed6dccb2ab93770c4bffaea1170c85f5639d2a71fe6e2c68ab62bf6f3583a9c4b1fcd11bd5fb8837bfb2582228c33398c1
   languageName: node
   linkType: hard
 
@@ -2016,7 +2027,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@internationalized/date@npm:^3.7.0":
+"@internationalized/date@npm:^3.5.5, @internationalized/date@npm:^3.7.0":
   version: 3.7.0
   resolution: "@internationalized/date@npm:3.7.0"
   dependencies:
@@ -3014,9 +3025,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-api@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-api@npm:6.2.1-pre.2794"
+"@openmrs/esm-api@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-api@npm:6.2.1-pre.2807"
   dependencies:
     "@types/fhir": "npm:0.0.31"
     lodash-es: "npm:^4.17.21"
@@ -3025,17 +3036,17 @@ __metadata:
     "@openmrs/esm-error-handling": 6.x
     "@openmrs/esm-navigation": 6.x
     "@openmrs/esm-offline": 6.x
-  checksum: 10/a3ce1e9e2ac4e12aa2464885d63eab57602050f464b51082460b0704a544891a281a3e7b69c5b8600bfbd6f80fdddf967c307b273f44f95a44458db2b14c4dc6
+  checksum: 10/7783a262a8cd72b4f6413da9b360e4805f8437d7b9898e3557b09286753a3a80003c8c0a803e1041d7d500ed1c4903e7821e5a99f4f30255826bc37b550f11b7
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-app-shell@npm:6.2.1-pre.2794"
+"@openmrs/esm-app-shell@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-app-shell@npm:6.2.1-pre.2807"
   dependencies:
     "@carbon/react": "npm:~1.37.0"
-    "@openmrs/esm-framework": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-styleguide": "npm:6.2.1-pre.2794"
+    "@openmrs/esm-framework": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-styleguide": "npm:6.2.1-pre.2807"
     dayjs: "npm:^1.10.4"
     dexie: "npm:^3.0.3"
     html-webpack-plugin: "npm:^5.5.0"
@@ -3060,7 +3071,7 @@ __metadata:
     workbox-strategies: "npm:^6.1.5"
     workbox-webpack-plugin: "npm:^6.1.5"
     workbox-window: "npm:^6.1.5"
-  checksum: 10/329f3a79f9cece657ccef5f198999b6037b1f506fc084e8a0d1a6b856daf32f8ca2c15cb362ba0da10e44f457b29bbac261d11b312319ac17440489d75c1f412
+  checksum: 10/5b1cf1de74cf7bcff98c57e805f9c41909682f91ebb96e9c986c987a68430676c1a8aef6c677ca333588d45196534ce6d5ac2731d3ce98591b15c06745291fe2
   languageName: node
   linkType: hard
 
@@ -3111,9 +3122,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-config@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-config@npm:6.2.1-pre.2794"
+"@openmrs/esm-config@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-config@npm:6.2.1-pre.2807"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
@@ -3121,44 +3132,44 @@ __metadata:
     "@openmrs/esm-state": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/20a5c77295907a56c6b8b5f092372c0d2df66b6e5609c8de39fbeaa1d12eda4dc4c87ccbb95a79150aa9ec1927001eb96edd639bc673a7c8bdab5644c5b3e136
+  checksum: 10/2db99daea1f208215f076f0de9f15a3e98e06d5e33b20a8e1c3cc7ce9e2e4c0f2d17137cbf2b3b42ad86a893860a672795d9f5df16f3f1695e41822afc612281
   languageName: node
   linkType: hard
 
-"@openmrs/esm-context@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-context@npm:6.2.1-pre.2794"
+"@openmrs/esm-context@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-context@npm:6.2.1-pre.2807"
   dependencies:
     immer: "npm:^10.0.4"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
-  checksum: 10/a44c4b52c5743e8cdd9fa2128faa4cead79430c488250bb6533936b6978c8eb83d38686d77262e8176eeefd9924acd150de0da646bb2cc9ddecba4c6fd236095
+  checksum: 10/f7afd7ee826b241ca5aa49846da638ecb178275b5bf6f896794d3573df40e2e63f41ea12d41cc0547e4a0715266b742af53424f52879efc891e4a79b26b67419
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-dynamic-loading@npm:6.2.1-pre.2794"
+"@openmrs/esm-dynamic-loading@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-dynamic-loading@npm:6.2.1-pre.2807"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-translations": 6.x
-  checksum: 10/850b880bff4478e842eda553df810331b389843fc8eb4171a77cbe3134705c6125b49fd6c3d4431b64f1ee02223cdfa3893b17e160514a919e25ebbd332f80d1
+  checksum: 10/39d6094acc67cc23275d63b1634b5ec08a0a0abc05d29dfed7726f4cf4dadfb5876d29196443ee5810908a68c94ebbdce9af67e7ec5c8f4d7cd57429155bca59
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-error-handling@npm:6.2.1-pre.2794"
+"@openmrs/esm-error-handling@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-error-handling@npm:6.2.1-pre.2807"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
-  checksum: 10/602ac435b3d06c439110637ae61a4fc18cc07f57aeef3184ad1077b8234c6016d4f2a33350d17b49caa5ccbd996edd4c2d0ee4ef2cf9090dd4a3a3b382044423
+  checksum: 10/e6e9f74b6c6afa9144c6065ac6affe1a83919429324434aa930c5fc3d0215b38f94c1f0ed5805924e2668a8d15fb3213d4049b99f5bb21b50903b2f3a31d6d6f
   languageName: node
   linkType: hard
 
-"@openmrs/esm-expression-evaluator@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-expression-evaluator@npm:6.2.1-pre.2794"
+"@openmrs/esm-expression-evaluator@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-expression-evaluator@npm:6.2.1-pre.2807"
   dependencies:
     "@jsep-plugin/arrow": "npm:^1.0.5"
     "@jsep-plugin/new": "npm:^1.0.3"
@@ -3167,13 +3178,13 @@ __metadata:
     "@jsep-plugin/template": "npm:^1.0.4"
     "@jsep-plugin/ternary": "npm:^1.1.3"
     jsep: "npm:^1.3.9"
-  checksum: 10/16a9eb46c4fee5cac69ab7709746d81ef5adaf054e0c8643180119ccf2561d4a412bb8f53af65adea2c61153e059db24d08ea8e34c23305cc1fd598b6f276dea
+  checksum: 10/e1df2f2e943651b255d50902445723fd6350e1a07306a0914bbee6c4db31baefb60526e0518caf750eea2947e1743625a8515b27bad816d60fed5046bd10e381
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-extensions@npm:6.2.1-pre.2794"
+"@openmrs/esm-extensions@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-extensions@npm:6.2.1-pre.2807"
   dependencies:
     lodash-es: "npm:^4.17.21"
   peerDependencies:
@@ -3184,44 +3195,44 @@ __metadata:
     "@openmrs/esm-state": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/8ac348b3bb47ec54a7c0040dc90da975719c1b4a743c02e6ed2e4c625bb6d4541d51149c233b9eb7ff66c996cf82f8e4640acffb35b090e47d52f4e9986f2506
+  checksum: 10/5d948c8fa87e4c7e5f4d587add0755de054079d74dc65018c06b696cea1022e6dc5d5d2f1b926ccee8bd74b5c4ee53aa6c9bd4c63ec5616be6e4dcab9769c20a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-feature-flags@npm:6.2.1-pre.2794"
+"@openmrs/esm-feature-flags@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-feature-flags@npm:6.2.1-pre.2807"
   dependencies:
     ramda: "npm:^0.26.1"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
     single-spa: 6.x
-  checksum: 10/cc36ee60ffa93301158e41bff7703a5ae4c1995411532c83ca90ed2d64d06908ceec23dde2d9b573e3362bdf4745100082d4c14cf54ae8eb940a2818d32cd8bb
+  checksum: 10/c39aae51fe4d9656643ffa9eb4f22e4f68c040a68defb42c3294e9fcad8285ce2575cc12ace509a05a6c25b14e97d89f9110d1ecbcc927591e980ac6a453986a
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:6.2.1-pre.2794, @openmrs/esm-framework@npm:next":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-framework@npm:6.2.1-pre.2794"
+"@openmrs/esm-framework@npm:6.2.1-pre.2807, @openmrs/esm-framework@npm:next":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-framework@npm:6.2.1-pre.2807"
   dependencies:
-    "@openmrs/esm-api": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-config": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-context": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-dynamic-loading": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-error-handling": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-expression-evaluator": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-extensions": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-feature-flags": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-globals": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-navigation": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-offline": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-react-utils": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-routes": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-state": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-styleguide": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-translations": "npm:6.2.1-pre.2794"
-    "@openmrs/esm-utils": "npm:6.2.1-pre.2794"
+    "@openmrs/esm-api": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-config": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-context": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-dynamic-loading": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-error-handling": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-expression-evaluator": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-extensions": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-feature-flags": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-globals": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-navigation": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-offline": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-react-utils": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-routes": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-state": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-styleguide": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-translations": "npm:6.2.1-pre.2807"
+    "@openmrs/esm-utils": "npm:6.2.1-pre.2807"
     dayjs: "npm:^1.10.7"
   peerDependencies:
     dayjs: 1.x
@@ -3232,35 +3243,35 @@ __metadata:
     rxjs: 6.x
     single-spa: 6.x
     swr: 2.x
-  checksum: 10/cb14d54f13d084cd5aa1e8fb93d20f567b0c8479718bccd4fa17157205203fb7a1775beb54c837dbe52a36a3b1a3963133254069611ea2a324a0371fd715622d
+  checksum: 10/661d5c11d1c3aca88195c20d5a8477b92c8063051127399156e9e1079d7a7584834c5e75cbc2109c06a1a1ed4fdf6520ecde080eeb6de57417af2033094c4a5e
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-globals@npm:6.2.1-pre.2794"
+"@openmrs/esm-globals@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-globals@npm:6.2.1-pre.2807"
   dependencies:
     "@types/fhir": "npm:0.0.31"
   peerDependencies:
     single-spa: 6.x
-  checksum: 10/b3d8472fb4b9811d755cf39f09bcf84034017786f369b523aaa4c885cb78a0b5f643104cc9c8b9c294cd71a22d8b72e65dcf9df5a647a3b7998de4c59847ea60
+  checksum: 10/b2be71a827fcaa5030bfa18e581daa1f197659466ce38d1b3d4b580f5bbad99e71743df89ac08bbdc2462dc4d0ad9cf6adab131279a80ef0f5a77a01a6fa1554
   languageName: node
   linkType: hard
 
-"@openmrs/esm-navigation@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-navigation@npm:6.2.1-pre.2794"
+"@openmrs/esm-navigation@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-navigation@npm:6.2.1-pre.2807"
   dependencies:
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 6.x
-  checksum: 10/a3ee6696a496adabfebcfd56f904815c85081a87272fd8b655dbae04313016761b58d090c9c2370524dc29a436c4257f7e4ac246d66fe19490efd8cefe48a65c
+  checksum: 10/d4dab3c2d032424348515c3c34f21884de190cd24a0c002181e7792662018ce17032a3c0a9d1901c65868f88db78f7572b3077c077a18a47a197d1a3e2cced47
   languageName: node
   linkType: hard
 
-"@openmrs/esm-offline@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-offline@npm:6.2.1-pre.2794"
+"@openmrs/esm-offline@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-offline@npm:6.2.1-pre.2807"
   dependencies:
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -3271,7 +3282,7 @@ __metadata:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-state": 6.x
     rxjs: 6.x
-  checksum: 10/89a7e1ea0bcf62858f1020bf21164cd40f01b6fd7f3d3132a2ab3dfcedf403a0d9e74927ac2f10bda5988dc303ba675755d60b009374f51f7e7b0719fab9cd61
+  checksum: 10/11ed9fe65306099640a65924eb583091d17148cc52fc97efcc3e94225cb0c9337df5716a4b608820a7256cae73638fd7bc69f75905e423ea19c2fbd3e3f8a75a
   languageName: node
   linkType: hard
 
@@ -3411,9 +3422,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-react-utils@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-react-utils@npm:6.2.1-pre.2794"
+"@openmrs/esm-react-utils@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-react-utils@npm:6.2.1-pre.2807"
   dependencies:
     lodash-es: "npm:^4.17.21"
     single-spa-react: "npm:^6.0.2"
@@ -3434,13 +3445,13 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 10/6818c5c6fdea66fa2a2e38c26a4a57ce8edba02b7b2f72cd2b4871a462283f1b1eb422f00ecd2608bf00f2dfddf6272f5d8fa56219fbfa25323a69064c969be3
+  checksum: 10/ab0111fa35d0c5526ddb3f3dbf51b7ef5eb1695be773e1f6a1fcd5679266f5b1e1c1906b32e04ce25bacfda9722ee471d020346f23e1c6b8d73c3ddb7af4c0b4
   languageName: node
   linkType: hard
 
-"@openmrs/esm-routes@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-routes@npm:6.2.1-pre.2794"
+"@openmrs/esm-routes@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-routes@npm:6.2.1-pre.2807"
   peerDependencies:
     "@openmrs/esm-config": 6.x
     "@openmrs/esm-dynamic-loading": 6.x
@@ -3449,7 +3460,7 @@ __metadata:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-utils": 6.x
     single-spa: 6.x
-  checksum: 10/d143a4ddfb5341fdd5560d821b82f735a20dda25858f02130bbb5d91ad4df1bd81a82e3a7aa1b0023bc6f75ad36a7c9c1c2e8df36260e1cac8150a88a538425a
+  checksum: 10/677eb1ae64d8e6ad0f2a3a3bfcf9ee041d6c5bd7b36a010aa76ebce5f2a21fc66583c1af4831f2670b67a6cd934bfb7b7cbe75e2c93586790df7cce916a21b72
   languageName: node
   linkType: hard
 
@@ -3473,21 +3484,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-state@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-state@npm:6.2.1-pre.2794"
+"@openmrs/esm-state@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-state@npm:6.2.1-pre.2807"
   dependencies:
     zustand: "npm:^4.5.5"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     "@openmrs/esm-utils": 6.x
-  checksum: 10/c3cd5f561766b80cdfeb566bae75d98cf9f9530fa7ff1b3089e751e0e6ac3eba52205cfa1c68ec17e5586dc781fcb3e74cdadea61059d7c0c5b0d5b32863eb0f
+  checksum: 10/f915bb245914762df3cd665c7fc26b66f35afc03d07348852e441b8533605dfd882e834a803b2b32ccd9c53280189bd7dbacd23ca420e851ec2fbf271ffe8428
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-styleguide@npm:6.2.1-pre.2794"
+"@openmrs/esm-styleguide@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-styleguide@npm:6.2.1-pre.2807"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
@@ -3511,34 +3522,36 @@ __metadata:
     react-dom: 18.x
     react-i18next: 11.x
     rxjs: 6.x
-  checksum: 10/bbb95034ca5c99d487e8ce32d0ba22c28989c21145ea8d403e57935c2cc8aefdd174499833c56ca12d074b1a395d08bfb9ea7c4ef86750224a806b86964c04b6
+  checksum: 10/7a6a1909c96a86e7077b18865b44f54cedc951e124ffb5ff37aa02ec4fc05623372184bf9ce4a802a47310ae47374e1df942812a4c588f6a33b7414d50cb2af3
   languageName: node
   linkType: hard
 
-"@openmrs/esm-translations@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-translations@npm:6.2.1-pre.2794"
+"@openmrs/esm-translations@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-translations@npm:6.2.1-pre.2807"
   dependencies:
     i18next: "npm:21.10.0"
   peerDependencies:
     i18next: 21.x
-  checksum: 10/a896a8af84270c5092d35e3f1da7c18d82e935c2597f0981931c958a785ec0565371e1a59e5e91ca4ea1e53e01993bee4aca2611468172b60b9c7044c41bd57c
+  checksum: 10/f346a0dae0d4c39985f54411ac988ecb0bce172495d6f8987cec50191f1e5650fd404b48f4cbde91fc846fb5167325ab3ac5116c9a51da9b0a3dd8d75fb76f78
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/esm-utils@npm:6.2.1-pre.2794"
+"@openmrs/esm-utils@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/esm-utils@npm:6.2.1-pre.2807"
   dependencies:
-    "@formatjs/intl-durationformat": "npm:^0.2.4"
-    "@internationalized/date": "npm:^3.7.0"
+    "@formatjs/intl-durationformat": "npm:^0.7.3"
+    "@internationalized/date": "npm:^3.5.5"
+    any-date-parser: "npm:^2.0.3"
+    lodash-es: "npm:^4.17.21"
     semver: "npm:7.3.2"
   peerDependencies:
     "@openmrs/esm-globals": 6.x
     dayjs: 1.x
     i18next: 21.x
     rxjs: 6.x
-  checksum: 10/b59559248320540b0d1967413d9949002e9cd3719689be12638eb685cd1fcd120acf56ce58533556e1da0b81a902a0a3933c3a98be5d4b5d8889e7e75fcc83ff
+  checksum: 10/fd6a406d93dc86cc509de616ee497a429c031405b30a44bb22a8d2cce9a9659f312874070f564a2ef33763903d7ee0c28ae6f6ab93e182cf67e18240992c6847
   languageName: node
   linkType: hard
 
@@ -3561,9 +3574,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/webpack-config@npm:6.2.1-pre.2794":
-  version: 6.2.1-pre.2794
-  resolution: "@openmrs/webpack-config@npm:6.2.1-pre.2794"
+"@openmrs/webpack-config@npm:6.2.1-pre.2807":
+  version: 6.2.1-pre.2807
+  resolution: "@openmrs/webpack-config@npm:6.2.1-pre.2807"
   dependencies:
     "@swc/core": "npm:^1.3.58"
     clean-webpack-plugin: "npm:^4.0.0"
@@ -3581,7 +3594,7 @@ __metadata:
     webpack-stats-plugin: "npm:^1.0.3"
   peerDependencies:
     webpack: 5.x
-  checksum: 10/484070130a27ed87834d8084593b81161cc93923c804c88abc560934f2d6895046db7c441fcb8f220d8bbaa17bfa96126929335f2995955240544d93d8bd1ad8
+  checksum: 10/6af760c12df5149fcb73e550dda0b11d770c5352810a1c454bf7a8cd0dc2c5805c21e16885734ad75a3ef1d223fe517ba3fe8e675d6be2ea8e6f5219951fef5e
   languageName: node
   linkType: hard
 
@@ -6811,6 +6824,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"any-date-parser@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "any-date-parser@npm:2.0.3"
+  checksum: 10/f2f087690d4f62c5c5edf3814f6b7949be78573e5b792d6485d34b929fda8aeb35c9b53e30984e14e20479db4a11f139af98478d54657425bd9e9e649e2fa6c1
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:^3.0.3, anymatch@npm:~3.1.2":
   version: 3.1.2
   resolution: "anymatch@npm:3.1.2"
@@ -9234,6 +9254,13 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 10/ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:10":
+  version: 10.5.0
+  resolution: "decimal.js@npm:10.5.0"
+  checksum: 10/714d49cf2f2207b268221795ede330e51452b7c451a0c02a770837d2d4faed47d603a729c2aa1d952eb6c4102d999e91c9b952c1aa016db3c5cba9fc8bf4cda2
   languageName: node
   linkType: hard
 
@@ -14546,11 +14573,11 @@ __metadata:
   linkType: hard
 
 "openmrs@npm:next":
-  version: 6.2.1-pre.2794
-  resolution: "openmrs@npm:6.2.1-pre.2794"
+  version: 6.2.1-pre.2807
+  resolution: "openmrs@npm:6.2.1-pre.2807"
   dependencies:
-    "@openmrs/esm-app-shell": "npm:6.2.1-pre.2794"
-    "@openmrs/webpack-config": "npm:6.2.1-pre.2794"
+    "@openmrs/esm-app-shell": "npm:6.2.1-pre.2807"
+    "@openmrs/webpack-config": "npm:6.2.1-pre.2807"
     "@pnpm/npm-conf": "npm:^2.1.0"
     "@swc/core": "npm:^1.3.58"
     autoprefixer: "npm:^10.4.20"
@@ -14589,7 +14616,7 @@ __metadata:
     yargs: "npm:^17.6.2"
   bin:
     openmrs: ./dist/cli.js
-  checksum: 10/5988d2f4b0309e9803142f5e33ece433084396bc6148d33fa6a8a347331c5e562408a75be6adfedfd29f34c4f813237dd9276c0d74eaaaec96c13e8c902d2c65
+  checksum: 10/64becfeb9b8bd89f372f6b228213bc9ad6b98f61c68c8fd5f80005fa2c6b8b92aa709f909cc64cb989beaa1e703822bcad00cc9b5941d0591f87457d7b2aa165
   languageName: node
   linkType: hard
 
@@ -17971,6 +17998,13 @@ __metadata:
     minimist: "npm:^1.2.6"
     strip-bom: "npm:^3.0.0"
   checksum: 10/2041beaedc6c271fc3bedd12e0da0cc553e65d030d4ff26044b771fac5752d0460944c0b5e680f670c2868c95c664a256cec960ae528888db6ded83524e33a14
+  languageName: node
+  linkType: hard
+
+"tslib@npm:2":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Fixes spurious re-renders of the patient registration form by optimizing rendering and state updates. These changes include:

- Memoizing context values with useMemo to prevent unnecessary re-renders
- Fixing potential state staleness by using setState callbacks
- Optimizing form value updates by removing redundant spread operations

Unrelated changes:

- Enhancing type safety
- Updating `@openmrs/esm-framework` to the latest next-tagged version

## Screenshots

For the `console.log` approach, I'm tracking re-renders by creating a mutable ref that persists across renders and then logging and incrementing the ref's value each time the component renders:

```tsx
const rerenderCount = useRef(0);
console.log('rerender', rerenderCount.current++); 
```

### Before

https://github.com/user-attachments/assets/4e7d1a95-8d1e-4cc6-8602-9e27de566f12

### Highlighting re-renders using React devtools

https://github.com/user-attachments/assets/01dcafab-9480-4689-818c-06f5df7c37ab

### After

#### With `console.log`

https://github.com/user-attachments/assets/4516d6f1-ebfc-408d-a61f-4263870c5e00

### React devtools

https://github.com/user-attachments/assets/09d88879-2322-4aaa-a37e-8f16415bf820


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
