### PR TITLE
fix/03-4539: Patient identifier fails to save after update

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -328,7 +328,7 @@ export class FormManager {
         addresses: [values.address],
         ...FormManager.getPatientDeathInfo(values, config),
       },
-      identifiers,
+      identifiers: !isNewPatient && values.patientUuid ? [] : identifiers,
     };
   }
 

--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -328,7 +328,7 @@ export class FormManager {
         addresses: [values.address],
         ...FormManager.getPatientDeathInfo(values, config),
       },
-      identifiers: !isNewPatient && values.patientUuid ? [] : identifiers,
+      identifiers: isNewPatient || !values.patientUuid ? identifiers : undefined,
     };
   }
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Identify the source of the unnecessary request to /ws/rest/v1/patient/<uuid> and modify it to exclude identifiers from the payload when updating an existing patient. Ensure that identifier updates are handled only through /ws/rest/v1/patient/<uuid>/identifier/<identifier uuid>.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/643754b2-1156-46ec-8e1b-d469195bfa9d



## Related Issue
https://openmrs.atlassian.net/browse/O3-4539

## Other
<!-- Anything not covered above -->
