### PR TITLE
(refactor) O3-4551: Refactor "Add patient to queue" form to use rhf and zod

### DIFF
--- a/packages/esm-service-queues-app/src/create-queue-entry/existing-visit-form/existing-visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/existing-visit-form/existing-visit-form.component.tsx
@@ -24,7 +24,7 @@ const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, closeWorks
 
   const { mutateQueueEntries } = useMutateQueueEntries();
   const [callback, setCallback] = useState<{
-    submitQueueEntry: (visit: Visit) => Promise<any>;
+    submitQueueEntry: (visit: Visit) => Promise<unknown>;
   } | null>(null);
 
   const handleCloseWorkspace = useCallback(() => {
@@ -38,27 +38,35 @@ const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, closeWorks
   const handleSubmit = useCallback(
     (event: React.FormEvent) => {
       event.preventDefault();
-      if (!callback) return;
+
+      if (!callback) {
+        return;
+      }
 
       setIsSubmitting(true);
+
       callback
-        ?.submitQueueEntry?.(visit)
-        ?.then(() => {
+        .submitQueueEntry(visit)
+        .then(() => {
           closeWorkspace();
           mutateQueueEntries();
         })
-        ?.finally(() => {
+        .finally(() => {
           setIsSubmitting(false);
         });
     },
     [closeWorkspace, callback, visit, mutateQueueEntries],
   );
 
-  const handleSetOnSubmit = useCallback((onSubmit: (visit: Visit) => Promise<any>) => {
+  const handleSetOnSubmit = useCallback((onSubmit: (visit: Visit) => Promise<unknown>) => {
     setCallback({ submitQueueEntry: onSubmit });
   }, []);
 
-  return visit ? (
+  if (!visit) {
+    return null;
+  }
+
+  return (
     <>
       {isTablet && (
         <Row className={styles.headerGridRow}>
@@ -81,7 +89,7 @@ const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, closeWorks
         </ButtonSet>
       </Form>
     </>
-  ) : null;
+  );
 };
 
 export default ExistingVisitForm;

--- a/packages/esm-service-queues-app/src/create-queue-entry/existing-visit-form/existing-visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/existing-visit-form/existing-visit-form.component.tsx
@@ -17,73 +17,71 @@ interface ExistingVisitFormProps {
  * This is the form that appears when clicking on a search result in the "Add patient to queue" workspace,
  * when the patient already has an active visit.
  */
-const ExistingVisitForm: React.FC<ExistingVisitFormProps> = React.memo(
-  ({ visit, closeWorkspace, handleReturnToSearchList }) => {
-    const { t } = useTranslation();
-    const isTablet = useLayoutType() === 'tablet';
-    const [isSubmitting, setIsSubmitting] = useState(false);
+const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, closeWorkspace, handleReturnToSearchList }) => {
+  const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-    const { mutateQueueEntries } = useMutateQueueEntries();
-    const [callback, setCallback] = useState<{
-      submitQueueEntry: (visit: Visit) => Promise<any>;
-    } | null>(null);
+  const { mutateQueueEntries } = useMutateQueueEntries();
+  const [callback, setCallback] = useState<{
+    submitQueueEntry: (visit: Visit) => Promise<any>;
+  } | null>(null);
 
-    const handleCloseWorkspace = useCallback(() => {
-      if (handleReturnToSearchList) {
-        handleReturnToSearchList();
-      } else {
-        closeWorkspace();
-      }
-    }, [closeWorkspace, handleReturnToSearchList]);
+  const handleCloseWorkspace = useCallback(() => {
+    if (handleReturnToSearchList) {
+      handleReturnToSearchList();
+    } else {
+      closeWorkspace();
+    }
+  }, [closeWorkspace, handleReturnToSearchList]);
 
-    const handleSubmit = useCallback(
-      (event: React.FormEvent) => {
-        event.preventDefault();
-        if (!callback) return;
+  const handleSubmit = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault();
+      if (!callback) return;
 
-        setIsSubmitting(true);
-        callback
-          ?.submitQueueEntry?.(visit)
-          ?.then(() => {
-            closeWorkspace();
-            mutateQueueEntries();
-          })
-          ?.finally(() => {
-            setIsSubmitting(false);
-          });
-      },
-      [closeWorkspace, callback, visit, mutateQueueEntries],
-    );
+      setIsSubmitting(true);
+      callback
+        ?.submitQueueEntry?.(visit)
+        ?.then(() => {
+          closeWorkspace();
+          mutateQueueEntries();
+        })
+        ?.finally(() => {
+          setIsSubmitting(false);
+        });
+    },
+    [closeWorkspace, callback, visit, mutateQueueEntries],
+  );
 
-    const handleSetOnSubmit = useCallback((onSubmit: (visit: Visit) => Promise<any>) => {
-      setCallback({ submitQueueEntry: onSubmit });
-    }, []);
+  const handleSetOnSubmit = useCallback((onSubmit: (visit: Visit) => Promise<any>) => {
+    setCallback({ submitQueueEntry: onSubmit });
+  }, []);
 
-    return visit ? (
-      <>
-        {isTablet && (
-          <Row className={styles.headerGridRow}>
-            <ExtensionSlot
-              name="visit-form-header-slot"
-              className={styles.dataGridRow}
-              state={{ patientUuid: visit.patient.uuid }}
-            />
-          </Row>
-        )}
-        <Form className={classNames(styles.form, styles.container)} onSubmit={handleSubmit}>
-          <QueueFields setOnSubmit={handleSetOnSubmit} />
-          <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
-            <Button className={styles.button} kind="secondary" onClick={handleCloseWorkspace}>
-              {t('discard', 'Discard')}
-            </Button>
-            <Button className={styles.button} disabled={isSubmitting || !callback} kind="primary" type="submit">
-              {t('addPatientToQueue', 'Add patient to queue')}
-            </Button>
-          </ButtonSet>
-        </Form>
-      </>
-    ) : null;
-  },
-);
+  return visit ? (
+    <>
+      {isTablet && (
+        <Row className={styles.headerGridRow}>
+          <ExtensionSlot
+            name="visit-form-header-slot"
+            className={styles.dataGridRow}
+            state={{ patientUuid: visit.patient.uuid }}
+          />
+        </Row>
+      )}
+      <Form className={classNames(styles.form, styles.container)} onSubmit={handleSubmit}>
+        <QueueFields setOnSubmit={handleSetOnSubmit} />
+        <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
+          <Button className={styles.button} kind="secondary" onClick={handleCloseWorkspace}>
+            {t('discard', 'Discard')}
+          </Button>
+          <Button className={styles.button} disabled={isSubmitting || !callback} kind="primary" type="submit">
+            {t('addPatientToQueue', 'Add patient to queue')}
+          </Button>
+        </ButtonSet>
+      </Form>
+    </>
+  ) : null;
+};
 
 export default ExistingVisitForm;

--- a/packages/esm-service-queues-app/src/create-queue-entry/existing-visit-form/existing-visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/existing-visit-form/existing-visit-form.component.tsx
@@ -17,66 +17,73 @@ interface ExistingVisitFormProps {
  * This is the form that appears when clicking on a search result in the "Add patient to queue" workspace,
  * when the patient already has an active visit.
  */
-const ExistingVisitForm: React.FC<ExistingVisitFormProps> = ({ visit, closeWorkspace, handleReturnToSearchList }) => {
-  const { t } = useTranslation();
-  const isTablet = useLayoutType() === 'tablet';
-  const [isSubmitting, setIsSubmitting] = useState(false);
+const ExistingVisitForm: React.FC<ExistingVisitFormProps> = React.memo(
+  ({ visit, closeWorkspace, handleReturnToSearchList }) => {
+    const { t } = useTranslation();
+    const isTablet = useLayoutType() === 'tablet';
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { mutateQueueEntries } = useMutateQueueEntries();
-  const [callback, setCallback] = useState<{
-    submitQueueEntry: (visit: Visit) => Promise<any>;
-  }>(null);
+    const { mutateQueueEntries } = useMutateQueueEntries();
+    const [callback, setCallback] = useState<{
+      submitQueueEntry: (visit: Visit) => Promise<any>;
+    } | null>(null);
 
-  const handleCloseWorkspace = useCallback(() => {
-    if (handleReturnToSearchList) {
-      handleReturnToSearchList();
-    } else {
-      closeWorkspace();
-    }
-  }, [closeWorkspace, handleReturnToSearchList]);
+    const handleCloseWorkspace = useCallback(() => {
+      if (handleReturnToSearchList) {
+        handleReturnToSearchList();
+      } else {
+        closeWorkspace();
+      }
+    }, [closeWorkspace, handleReturnToSearchList]);
 
-  const handleSubmit = useCallback(
-    (event) => {
-      event.preventDefault();
-      setIsSubmitting(true);
+    const handleSubmit = useCallback(
+      (event: React.FormEvent) => {
+        event.preventDefault();
+        if (!callback) return;
 
-      callback
-        ?.submitQueueEntry?.(visit)
-        ?.then(() => {
-          closeWorkspace();
-          mutateQueueEntries();
-        })
-        ?.finally(() => {
-          setIsSubmitting(false);
-        });
-    },
-    [closeWorkspace, callback, visit, mutateQueueEntries],
-  );
+        setIsSubmitting(true);
+        callback
+          ?.submitQueueEntry?.(visit)
+          ?.then(() => {
+            closeWorkspace();
+            mutateQueueEntries();
+          })
+          ?.finally(() => {
+            setIsSubmitting(false);
+          });
+      },
+      [closeWorkspace, callback, visit, mutateQueueEntries],
+    );
 
-  return visit ? (
-    <>
-      {isTablet && (
-        <Row className={styles.headerGridRow}>
-          <ExtensionSlot
-            name="visit-form-header-slot"
-            className={styles.dataGridRow}
-            state={{ patientUuid: visit.patient.uuid }}
-          />
-        </Row>
-      )}
-      <Form className={classNames(styles.form, styles.container)} onSubmit={handleSubmit}>
-        <QueueFields setOnSubmit={(onSubmit) => setCallback({ submitQueueEntry: onSubmit })} />
-        <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
-          <Button className={styles.button} kind="secondary" onClick={handleCloseWorkspace}>
-            {t('discard', 'Discard')}
-          </Button>
-          <Button className={styles.button} disabled={isSubmitting} kind="primary" type="submit">
-            {t('addPatientToQueue', 'Add patient to queue')}
-          </Button>
-        </ButtonSet>
-      </Form>
-    </>
-  ) : null;
-};
+    const handleSetOnSubmit = useCallback((onSubmit: (visit: Visit) => Promise<any>) => {
+      setCallback({ submitQueueEntry: onSubmit });
+    }, []);
+
+    return visit ? (
+      <>
+        {isTablet && (
+          <Row className={styles.headerGridRow}>
+            <ExtensionSlot
+              name="visit-form-header-slot"
+              className={styles.dataGridRow}
+              state={{ patientUuid: visit.patient.uuid }}
+            />
+          </Row>
+        )}
+        <Form className={classNames(styles.form, styles.container)} onSubmit={handleSubmit}>
+          <QueueFields setOnSubmit={handleSetOnSubmit} />
+          <ButtonSet className={isTablet ? styles.tablet : styles.desktop}>
+            <Button className={styles.button} kind="secondary" onClick={handleCloseWorkspace}>
+              {t('discard', 'Discard')}
+            </Button>
+            <Button className={styles.button} disabled={isSubmitting || !callback} kind="primary" type="submit">
+              {t('addPatientToQueue', 'Add patient to queue')}
+            </Button>
+          </ButtonSet>
+        </Form>
+      </>
+    ) : null;
+  },
+);
 
 export default ExistingVisitForm;

--- a/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
@@ -8,19 +8,18 @@ import {
   SelectItem,
   SelectSkeleton,
 } from '@carbon/react';
-import { useTranslation } from 'react-i18next';
-import { ResponsiveWrapper, showSnackbar, useConfig, useSession, type Visit } from '@openmrs/esm-framework';
-import { type ConfigObject } from '../../config-schema';
-import { useQueues } from '../../hooks/useQueues';
-import { useAddPatientToQueueContext } from '../add-patient-to-queue-context';
-import { postQueueEntry } from './queue-fields.resource';
-import { useMutateQueueEntries } from '../../hooks/useQueueEntries';
-import { useQueueLocations } from '../hooks/useQueueLocations';
-import styles from './queue-fields.scss';
 import { Controller, useForm } from 'react-hook-form';
+import { type TFunction, useTranslation } from 'react-i18next';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import type { TFunction } from 'i18next';
+import { ResponsiveWrapper, showSnackbar, useConfig, useSession, type Visit } from '@openmrs/esm-framework';
+import { type ConfigObject } from '../../config-schema';
+import { postQueueEntry } from './queue-fields.resource';
+import { useAddPatientToQueueContext } from '../add-patient-to-queue-context';
+import { useMutateQueueEntries } from '../../hooks/useQueueEntries';
+import { useQueueLocations } from '../hooks/useQueueLocations';
+import { useQueues } from '../../hooks/useQueues';
+import styles from './queue-fields.scss';
 
 export interface QueueFieldsProps {
   setOnSubmit(onSubmit: (visit: Visit) => Promise<any>): void;
@@ -34,11 +33,10 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
   const { queueLocations, isLoading: isLoadingQueueLocations } = useQueueLocations();
   const { sessionLocation } = useSession();
   const {
-    visitQueueNumberAttributeUuid,
     concepts: { defaultStatusConceptUuid, defaultPriorityConceptUuid, emergencyPriorityConceptUuid },
+    visitQueueNumberAttributeUuid,
   } = useConfig<ConfigObject>();
   const { currentServiceQueueUuid } = useAddPatientToQueueContext();
-
   const { mutateQueueEntries } = useMutateQueueEntries();
 
   const QueueServiceSchema = (t: TFunction) =>
@@ -54,7 +52,7 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
       priority: z
         .string({ required_error: t('priorityIsRequired', 'Priority is required') })
         .trim()
-        .min(1, t('priorityIsRequired', 'Priority is required')),      
+        .min(1, t('priorityIsRequired', 'Priority is required')),
     });
 
   const {
@@ -116,15 +114,15 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
         });
     },
     [
-      trigger,
-      queueService,
+      defaultStatusConceptUuid,
+      mutateQueueEntries,
       priority,
       queueLocation,
-      defaultStatusConceptUuid,
-      visitQueueNumberAttributeUuid,
-      mutateQueueEntries,
-      t,
+      queueService,
       sortWeight,
+      t,
+      trigger,
+      visitQueueNumberAttributeUuid,
     ],
   );
 
@@ -145,7 +143,7 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
   }, [queueLocations, sessionLocation.uuid, setValue]);
 
   return (
-    <form>
+    <>
       <section className={styles.section}>
         <div className={styles.sectionTitle}>{t('queueLocation', 'Queue location')}</div>
         <ResponsiveWrapper>
@@ -254,7 +252,7 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
           />
         </section>
       )}
-    </form>
+    </>
   );
 });
 

--- a/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   InlineNotification,
   RadioButton,
@@ -38,6 +38,7 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
     concepts: { defaultStatusConceptUuid, defaultPriorityConceptUuid, emergencyPriorityConceptUuid },
   } = useConfig<ConfigObject>();
   const { currentServiceQueueUuid } = useAddPatientToQueueContext();
+
   const { mutateQueueEntries } = useMutateQueueEntries();
 
   const QueueServiceSchema = (t: TFunction) =>
@@ -53,7 +54,7 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
       priority: z
         .string({ required_error: t('priorityIsRequired', 'Priority is required') })
         .trim()
-        .min(1, t('priorityIsRequired', 'Priority is required')),
+        .min(1, t('priorityIsRequired', 'Priority is required')),      
     });
 
   const {

--- a/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
@@ -42,9 +42,18 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
 
   const QueueServiceSchema = (t: TFunction) =>
     z.object({
-      queueLocation: z.string().trim().min(1, t('queueLocationRequired', 'Queue location is required')),
-      queueService: z.string().trim().min(1, t('queueServiceRequired', 'Queue service is required')),
-      priority: z.string({ required_error: t('priorityIsRequired', 'Priority is required') }).trim(),
+      queueLocation: z
+        .string({ required_error: t('queueLocationRequired', 'Queue location is required') })
+        .trim()
+        .min(1, t('queueLocationRequired', 'Queue location is required')),
+      queueService: z
+        .string({ required_error: t('queueServiceRequired', 'Queue service is required') })
+        .trim()
+        .min(1, t('queueServiceRequired', 'Queue service is required')),
+      priority: z
+        .string({ required_error: t('priorityIsRequired', 'Priority is required') })
+        .trim()
+        .min(1, t('priorityIsRequired', 'Priority is required')),
     });
 
   const {

--- a/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
@@ -185,7 +185,7 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
             ) : (
               <Select
                 {...field}
-                labelText={t('selectQueueService', 'Select a queue service')}
+                labelText={t('selectService', 'Select a service')}
                 id="queueService"
                 invalid={!!errors.queueService}
                 invalidText={errors.queueService?.message}

--- a/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
@@ -17,15 +17,19 @@ import { postQueueEntry } from './queue-fields.resource';
 import { useMutateQueueEntries } from '../../hooks/useQueueEntries';
 import { useQueueLocations } from '../hooks/useQueueLocations';
 import styles from './queue-fields.scss';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { TFunction } from 'i18next';
 
 export interface QueueFieldsProps {
-  setOnSubmit(onSubmit: (visit: Visit) => Promise<any>);
+  setOnSubmit(onSubmit: (visit: Visit) => Promise<any>): void;
 }
 
 /**
  * This component contains form fields for starting a patient's queue entry.
  */
-const QueueFields: React.FC<QueueFieldsProps> = ({ setOnSubmit }) => {
+const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => {
   const { t } = useTranslation();
   const { queueLocations, isLoading: isLoadingQueueLocations } = useQueueLocations();
   const { sessionLocation } = useSession();
@@ -33,61 +37,84 @@ const QueueFields: React.FC<QueueFieldsProps> = ({ setOnSubmit }) => {
     visitQueueNumberAttributeUuid,
     concepts: { defaultStatusConceptUuid, defaultPriorityConceptUuid, emergencyPriorityConceptUuid },
   } = useConfig<ConfigObject>();
-  const [selectedQueueLocation, setSelectedQueueLocation] = useState(queueLocations[0]?.id);
-  const { queues, isLoading: isLoadingQueues } = useQueues(selectedQueueLocation);
-  const [selectedService, setSelectedService] = useState('');
   const { currentServiceQueueUuid } = useAddPatientToQueueContext();
-  const [priority, setPriority] = useState(defaultPriorityConceptUuid);
-  const priorities = queues.find((q) => q.uuid === selectedService)?.allowedPriorities ?? [];
   const { mutateQueueEntries } = useMutateQueueEntries();
-  const memoMutateQueueEntries = useCallback(mutateQueueEntries, [mutateQueueEntries]);
 
+  const QueueServiceSchema = (t: TFunction) =>
+    z.object({
+      queueLocation: z.string().trim().min(1, t('queueLocationRequired', 'Queue location is required')),
+      queueService: z.string().trim().min(1, t('queueServiceRequired', 'Queue service is required')),
+      priority: z.string({ required_error: t('priorityIsRequired', 'Priority is required') }).trim(),
+    });
+
+  const {
+    control,
+    watch,
+    setValue,
+    trigger,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(QueueServiceSchema(t)),
+    defaultValues: {
+      queueLocation: queueLocations[0]?.id || '',
+      queueService: '',
+      priority: defaultPriorityConceptUuid,
+    },
+    mode: 'onChange',
+  });
+
+  const queueLocation = watch('queueLocation');
+  const queueService = watch('queueService');
+  const priority = watch('priority');
+  const { queues, isLoading: isLoadingQueues } = useQueues(queueLocation);
+  const priorities = queues.find((q) => q.uuid === queueService)?.allowedPriorities ?? [];
   const sortWeight = priority === emergencyPriorityConceptUuid ? 1 : 0;
 
   const onSubmit = useCallback(
-    (visit: Visit) => {
-      if (selectedQueueLocation && selectedService && priority) {
-        return postQueueEntry(
-          visit.uuid,
-          selectedService,
-          visit.patient.uuid,
-          priority,
-          defaultStatusConceptUuid,
-          sortWeight,
-          selectedQueueLocation,
-          visitQueueNumberAttributeUuid,
-        )
-          .then(() => {
-            showSnackbar({
-              kind: 'success',
-              isLowContrast: true,
-              title: t('addedPatientToQueue', 'Added patient to queue'),
-              subtitle: t('queueEntryAddedSuccessfully', 'Queue entry added successfully'),
-            });
-            memoMutateQueueEntries();
-          })
-          .catch((error) => {
-            showSnackbar({
-              title: t('queueEntryError', 'Error adding patient to the queue'),
-              kind: 'error',
-              isLowContrast: false,
-              subtitle: error?.message,
-            });
-            throw error;
-          });
-      } else {
-        return Promise.resolve();
+    async (visit: Visit) => {
+      const isValid = await trigger();
+      if (!isValid) {
+        return Promise.reject(new Error('Form validation failed'));
       }
+      return postQueueEntry(
+        visit.uuid,
+        queueService,
+        visit.patient.uuid,
+        priority,
+        defaultStatusConceptUuid,
+        sortWeight,
+        queueLocation,
+        visitQueueNumberAttributeUuid,
+      )
+        .then(() => {
+          showSnackbar({
+            kind: 'success',
+            isLowContrast: true,
+            title: t('addedPatientToQueue', 'Added patient to queue'),
+            subtitle: t('queueEntryAddedSuccessfully', 'Queue entry added successfully'),
+          });
+          mutateQueueEntries();
+        })
+        .catch((error) => {
+          showSnackbar({
+            title: t('queueEntryError', 'Error adding patient to the queue'),
+            kind: 'error',
+            isLowContrast: false,
+            subtitle: error?.message,
+          });
+          throw error;
+        });
     },
     [
-      selectedQueueLocation,
-      selectedService,
+      trigger,
+      queueService,
       priority,
-      sortWeight,
+      queueLocation,
       defaultStatusConceptUuid,
       visitQueueNumberAttributeUuid,
-      memoMutateQueueEntries,
+      mutateQueueEntries,
       t,
+      sortWeight,
     ],
   );
 
@@ -97,115 +124,128 @@ const QueueFields: React.FC<QueueFieldsProps> = ({ setOnSubmit }) => {
 
   useEffect(() => {
     if (currentServiceQueueUuid) {
-      setSelectedService(currentServiceQueueUuid);
+      setValue('queueService', currentServiceQueueUuid, { shouldValidate: true });
     }
-  }, [currentServiceQueueUuid, queues]);
+  }, [currentServiceQueueUuid, setValue]);
 
   useEffect(() => {
     if (queueLocations.map((l) => l.id).includes(sessionLocation.uuid)) {
-      setSelectedQueueLocation(sessionLocation.uuid);
+      setValue('queueLocation', sessionLocation.uuid, { shouldValidate: true });
     }
-  }, [queueLocations, sessionLocation.uuid]);
+  }, [queueLocations, sessionLocation.uuid, setValue]);
 
   return (
-    <div>
+    <form>
       <section className={styles.section}>
         <div className={styles.sectionTitle}>{t('queueLocation', 'Queue location')}</div>
         <ResponsiveWrapper>
-          {isLoadingQueueLocations ? (
-            <SelectSkeleton />
-          ) : (
-            <Select
-              labelText={t('selectQueueLocation', 'Select a queue location')}
-              id="queueLocation"
-              name="queueLocation"
-              invalidText="Required"
-              value={selectedQueueLocation}
-              onChange={(event) => setSelectedQueueLocation(event.target.value)}>
-              {!selectedQueueLocation ? (
-                <SelectItem text={t('selectQueueLocation', 'Select a queue location')} value="" />
-              ) : null}
-              {queueLocations?.length > 0 &&
-                queueLocations.map((location) => (
-                  <SelectItem key={location.id} text={location.name} value={location.id}>
-                    {location.name}
-                  </SelectItem>
-                ))}
-            </Select>
-          )}
+          <Controller
+            name="queueLocation"
+            control={control}
+            render={({ field }) =>
+              isLoadingQueueLocations ? (
+                <SelectSkeleton />
+              ) : (
+                <Select
+                  {...field}
+                  labelText={t('selectQueueLocation', 'Select a queue location')}
+                  id="queueLocation"
+                  invalid={!!errors.queueLocation}
+                  invalidText={errors.queueLocation?.message}
+                  onChange={(event) => field.onChange(event.target.value)}>
+                  <SelectItem text={t('selectQueueLocation', 'Select a queue location')} value="" />
+                  {queueLocations?.map((location) => (
+                    <SelectItem key={location.id} text={location.name} value={location.id}>
+                      {location.name}
+                    </SelectItem>
+                  ))}
+                </Select>
+              )
+            }
+          />
         </ResponsiveWrapper>
       </section>
 
       <section className={styles.section}>
         <div className={styles.sectionTitle}>{t('service', 'Service')}</div>
-        {isLoadingQueues ? (
-          <SelectSkeleton />
-        ) : !queues?.length ? (
-          <InlineNotification
-            className={styles.inlineNotification}
-            kind={'error'}
-            lowContrast
-            subtitle={t('configureServices', 'Please configure services to continue.')}
-            title={t('noServicesConfigured', 'No services configured')}
-          />
-        ) : (
-          <Select
-            labelText={t('selectService', 'Select a service')}
-            id="service"
-            name="service"
-            invalidText="Required"
-            value={selectedService}
-            onChange={(event) => setSelectedService(event.target.value)}>
-            {!selectedService ? <SelectItem text={t('selectQueueService', 'Select a queue service')} value="" /> : null}
-            {queues?.length > 0 &&
-              queues.map((service) => (
-                <SelectItem key={service.uuid} text={service.name} value={service.uuid}>
-                  {service.name}
-                </SelectItem>
-              ))}
-          </Select>
-        )}
+        <Controller
+          name="queueService"
+          control={control}
+          render={({ field }) =>
+            isLoadingQueues ? (
+              <SelectSkeleton />
+            ) : !queues?.length ? (
+              <InlineNotification
+                className={styles.inlineNotification}
+                kind={'error'}
+                lowContrast
+                subtitle={t('configureServices', 'Please configure services to continue.')}
+                title={t('noServicesConfigured', 'No services configured')}
+              />
+            ) : (
+              <Select
+                {...field}
+                labelText={t('selectQueueService', 'Select a queue service')}
+                id="queueService"
+                invalid={!!errors.queueService}
+                invalidText={errors.queueService?.message}
+                onChange={(event) => field.onChange(event.target.value)}>
+                <SelectItem text={t('selectQueueService', 'Select a queue service')} value="" />
+                {queues?.map((service) => (
+                  <SelectItem key={service.uuid} text={service.name} value={service.uuid}>
+                    {service.name}
+                  </SelectItem>
+                ))}
+              </Select>
+            )
+          }
+        />
       </section>
-
       {/* Status section of the form would go here; historical version of this code can be found at
           https://github.com/openmrs/openmrs-esm-patient-management/blame/6c31e5ff2579fc89c2fd0d12c13510a1f2e913e0/packages/esm-service-queues-app/src/patient-search/visit-form-queue-fields/visit-form-queue-fields.component.tsx#L115 */}
 
-      {selectedService ? (
+      {queueService && (
         <section className={styles.section}>
           <div className={styles.sectionTitle}>{t('priority', 'Priority')}</div>
-          {isLoadingQueues ? (
-            <RadioButtonGroup>
-              <RadioButtonSkeleton />
-              <RadioButtonSkeleton />
-              <RadioButtonSkeleton />
-            </RadioButtonGroup>
-          ) : !priorities?.length ? (
-            <InlineNotification
-              className={styles.inlineNotification}
-              kind={'error'}
-              lowContrast
-              title={t('noPrioritiesForServiceTitle', 'No priorities available')}>
-              {t(
-                'noPrioritiesForService',
-                'The selected service does not have any allowed priorities. This is an error in configuration. Please contact your system administrator.',
-              )}
-            </InlineNotification>
-          ) : priorities.length ? (
-            <RadioButtonGroup
-              className={styles.radioButtonWrapper}
-              name="priority"
-              id="priority"
-              defaultSelected={defaultPriorityConceptUuid}
-              onChange={(uuid) => setPriority(uuid)}>
-              {priorities.map(({ uuid, display }) => (
-                <RadioButton key={uuid} labelText={display} value={uuid} />
-              ))}
-            </RadioButtonGroup>
-          ) : null}
+          <Controller
+            name="priority"
+            control={control}
+            render={({ field }) =>
+              isLoadingQueues ? (
+                <RadioButtonGroup>
+                  <RadioButtonSkeleton />
+                  <RadioButtonSkeleton />
+                  <RadioButtonSkeleton />
+                </RadioButtonGroup>
+              ) : !priorities?.length ? (
+                <InlineNotification
+                  className={styles.inlineNotification}
+                  kind={'error'}
+                  lowContrast
+                  title={t('noPrioritiesForServiceTitle', 'No priorities available')}>
+                  {t(
+                    'noPrioritiesForService',
+                    'The selected service does not have any allowed priorities. This is an error in configuration. Please contact your system administrator.',
+                  )}
+                </InlineNotification>
+              ) : (
+                <RadioButtonGroup
+                  {...field}
+                  className={styles.radioButtonWrapper}
+                  id="priority"
+                  valueSelected={field.value}
+                  onChange={(uuid) => field.onChange(uuid)}>
+                  {priorities.map(({ uuid, display }) => (
+                    <RadioButton key={uuid} labelText={display} value={uuid} />
+                  ))}
+                </RadioButtonGroup>
+              )
+            }
+          />
         </section>
-      ) : null}
-    </div>
+      )}
+    </form>
   );
-};
+});
 
 export default QueueFields;

--- a/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/queue-fields.component.tsx
@@ -22,7 +22,7 @@ import { useQueues } from '../../hooks/useQueues';
 import styles from './queue-fields.scss';
 
 export interface QueueFieldsProps {
-  setOnSubmit(onSubmit: (visit: Visit) => Promise<any>): void;
+  setOnSubmit(onSubmit: (visit: Visit) => Promise<void>): void;
 }
 
 /**
@@ -57,18 +57,18 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
 
   const {
     control,
-    watch,
+    formState: { errors },
     setValue,
     trigger,
-    formState: { errors },
+    watch,
   } = useForm({
-    resolver: zodResolver(QueueServiceSchema(t)),
     defaultValues: {
+      priority: defaultPriorityConceptUuid,
       queueLocation: queueLocations[0]?.id || '',
       queueService: '',
-      priority: defaultPriorityConceptUuid,
     },
     mode: 'onChange',
+    resolver: zodResolver(QueueServiceSchema(t)),
   });
 
   const queueLocation = watch('queueLocation');
@@ -143,7 +143,7 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
   }, [queueLocations, sessionLocation.uuid, setValue]);
 
   return (
-    <>
+    <div>
       <section className={styles.section}>
         <div className={styles.sectionTitle}>{t('queueLocation', 'Queue location')}</div>
         <ResponsiveWrapper>
@@ -252,7 +252,7 @@ const QueueFields: React.FC<QueueFieldsProps> = React.memo(({ setOnSubmit }) => 
           />
         </section>
       )}
-    </>
+    </div>
   );
 });
 

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -159,6 +159,7 @@
   "queueService": "Queue service",
   "queueServiceCreated": "Queue service created",
   "queueServiceCreatedSuccessfully": "Queue service created successfully",
+  "queueServiceRequired": "Queue service is required",
   "queueStatus": "Queue status",
   "refills": "Refills",
   "remove": "Remove",


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [X] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
 Currently, when adding a patient to the queue for a patient who has an active visit, the queue form renders upon clicking on the patient banner. However, if the form is submitted without selecting a required service, it allows submission without any validation or error message. This behavior is not intended, as the "Service" field is mandatory for submission
## Expected Behavior
 The form should not be submitted unless a service is selected. If the user attempts to submit the form without selecting a service, a validation message should be displayed indicating that the "Service" field is required. This will prevent the form from being submitted until the necessary information is provided.

## Screenshots
### Before

https://github.com/user-attachments/assets/c0edc448-ccee-4c9e-a37d-89d909cd972a
#### This component render multiple times 

https://github.com/user-attachments/assets/ca9d2ee1-d1ab-4b1b-9506-bdf7ba271fa9



### After 

https://github.com/user-attachments/assets/4a1d0975-f060-478e-b945-a51c3021dd3c

https://github.com/user-attachments/assets/5c4d8be3-7753-452c-a0ad-273863b5c3df





<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[jira ticket](https://openmrs.atlassian.net/browse/O3-4551)

## Other
<!-- Anything not covered above -->
