### PR TITLE
(fix) O3-4516: Use narrow width variant for appointments and ward workspaces

### DIFF
--- a/packages/esm-patient-search-app/src/routes.json
+++ b/packages/esm-patient-search-app/src/routes.json
@@ -36,7 +36,7 @@
       "name": "patient-search-workspace",
       "title": "searchPatient",
       "type": "patient-search-workspace",
-      "width": "wider"
+      "width": "narrow"
     }
   ]
 }

--- a/packages/esm-ward-app/src/routes.json
+++ b/packages/esm-ward-app/src/routes.json
@@ -92,7 +92,7 @@
       "component": "admissionRequestWorkspace",
       "title": "admissionRequests",
       "type": "pending-admission-requests",
-      "width": "wider"
+      "width": "narrow"
     },{
       "name": "create-admission-encounter-workspace",
       "component": "createAdmissionEncounterWorkspace",


### PR DESCRIPTION
## Requirements
I have made sure that the “Create new appointment“ workspace, the “Add patient to queue“ workspace and the “Admission requests“ workspaces now use the “normal“ workspace size.
These widgets now match the correct size as the ticket describes
screenshots
before:
![Appointment-before](https://github.com/user-attachments/assets/7c665668-4119-4ccd-9c3b-0b3e054de25f)
![Admission-request-before](https://github.com/user-attachments/assets/efca7619-67a7-400b-9f6b-6a7c54a63ea8)
![Add patient-before](https://github.com/user-attachments/assets/0d4a5c7c-636f-485f-a1ee-55b15b714f0f)
After:
![Appointment-after](https://github.com/user-attachments/assets/a148b7ed-d029-4ea6-bff7-000fd68f4681)
![Admission-request-after](https://github.com/user-attachments/assets/b6a7c013-8475-408f-bf4c-474f63724197)
![Add-patient-after](https://github.com/user-attachments/assets/e6488513-6828-48d9-a161-5768cf05f891)
Ticket-Link:
[[ticket](https://openmrs.atlassian.net/browse/O3-4516l)](https://openmrs.atlassian.net/browse/O3-4516l)
@denniskigen  review this please