### PR TITLE
(fix) O3-4569: Fix layout overflow in Clear Queue modal and Add Provider Queue Room component

### DIFF
--- a/packages/esm-service-queues-app/src/add-provider-queue-room-modal/add-provider-queue-room.modal.tsx
+++ b/packages/esm-service-queues-app/src/add-provider-queue-room-modal/add-provider-queue-room.modal.tsx
@@ -161,7 +161,7 @@ const AddProviderQueueRoomModal: React.FC<AddProviderQueueRoomModalProps> = ({ c
   );
 
   return (
-    <div>
+    <div className={styles.modalContainer}>
       <Form onSubmit={handleSubmit(onSubmit)}>
         <ModalHeader closeModal={closeModal} title={t('addAProviderQueueRoom', 'Add provider queue room')} />
         <ModalBody>

--- a/packages/esm-service-queues-app/src/add-provider-queue-room-modal/add-provider-queue-room.scss
+++ b/packages/esm-service-queues-app/src/add-provider-queue-room-modal/add-provider-queue-room.scss
@@ -15,3 +15,24 @@
 .errorNotification {
   margin-top: layout.$spacing-02;
 }
+
+@media (max-width: 672px) {
+  .modalContainer {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 50%;
+    background: white;
+  }
+  :global(.cds--modal-container) {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/packages/esm-service-queues-app/src/clear-queue-entries-modal/clear-queue-entries.modal.tsx
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-modal/clear-queue-entries.modal.tsx
@@ -43,7 +43,7 @@ const ClearQueueEntriesModal: React.FC<ClearQueueEntriesModalProps> = ({ queueEn
   }, [closeModal, mutateQueueEntries, t, queueEntries]);
 
   return (
-    <div>
+    <div className={styles.modalContainer}>
       <ModalHeader
         closeModal={closeModal}
         label={t('serviceQueue', 'Service queue')}

--- a/packages/esm-service-queues-app/src/clear-queue-entries-modal/clear-queue-entries.scss
+++ b/packages/esm-service-queues-app/src/clear-queue-entries-modal/clear-queue-entries.scss
@@ -5,3 +5,24 @@
   @include type.type-style('heading-compact-01');
   color: $ui-05;
 }
+
+@media (max-width: 672px) {
+  .modalContainer {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 50%;
+    background: white;
+  }
+  :global(.cds--modal-container) {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR addresses the layout overflow issue in the 'Clear Queue' modal and 'Add Provider Queue Room' component when the screen width is 672px or below. Previously, the UI became inconsistent and unresponsive due to improper positioning and width constraints.
## Screenshots
### Before:

https://github.com/user-attachments/assets/46aae9ee-afe8-48c1-92cb-c174c4384a91


### After:
https://github.com/user-attachments/assets/8244b14b-b2b2-46d8-aa37-629e8cf5f336


## Related Issue
https://openmrs.atlassian.net/browse/O3-4569

## Other
<!-- Anything not covered above -->


