### PR TITLE
(feat) O3-4629: Return data saved in workspaces

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.workspace.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.workspace.tsx
@@ -64,6 +64,7 @@ interface AppointmentsFormProps {
   recurringPattern?: RecurringPattern;
   patientUuid?: string;
   context: string;
+  onAppointmentSave?: (appointment: Appointment) => void;
 }
 
 const time12HourFormatRegexPattern = '^(1[0-2]|0?[1-9]):[0-5][0-9]$';
@@ -77,6 +78,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps & DefaultWorkspaceProps> 
   context,
   closeWorkspace,
   promptBeforeClosing,
+  onAppointmentSave,
 }) => {
   const { patient } = usePatient(patientUuid);
   const { mutateAppointments } = useMutateAppointments();
@@ -362,7 +364,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps & DefaultWorkspaceProps> 
       ? saveRecurringAppointments(recurringAppointmentPayload, abortController)
       : saveAppointment(appointmentPayload, abortController)
     ).then(
-      ({ status }) => {
+      ({ status, data }) => {
         if (status === 200) {
           setIsSubmitting(false);
           setIsSuccessful(true);
@@ -376,6 +378,7 @@ const AppointmentsForm: React.FC<AppointmentsFormProps & DefaultWorkspaceProps> 
                 ? t('appointmentEdited', 'Appointment edited')
                 : t('appointmentScheduled', 'Appointment scheduled'),
           });
+          onAppointmentSave?.(data);
         }
         if (status === 204) {
           setIsSubmitting(false);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
Add a new function prop that will allow callers of `appointments-form-workspace` to be able to access a reference to the data saved by that workspace:
```
launchWorkspace('appointments-form-workspace', {
  patientUuid: patient.uuid,
  context: 'creating',
  onAppointmentSave: (appointment) => {
    // use the appointment
  }
})
```

## Related Issue
https://openmrs.atlassian.net/browse/O3-4629