### PR TITLE
(feat) Validate identifier regex patterns in the registration form

### DIFF
--- a/packages/esm-patient-registration-app/src/offline.resources.ts
+++ b/packages/esm-patient-registration-app/src/offline.resources.ts
@@ -93,7 +93,7 @@ export async function fetchPatientIdentifierTypesWithSources(): Promise<Array<Pa
 async function fetchPatientIdentifierTypes(): Promise<Array<FetchedPatientIdentifierType>> {
   const [patientIdentifierTypesResponse, primaryIdentifierTypeResponse] = await Promise.all([
     cacheAndFetch(
-      `${restBaseUrl}/patientidentifiertype?v=custom:(display,uuid,name,format,required,uniquenessBehavior)`,
+      `${restBaseUrl}/patientidentifiertype?v=custom:(display,uuid,name,format,formatDescription,required,uniquenessBehavior)`,
     ),
     cacheAndFetch(`${restBaseUrl}/metadatamapping/termmapping?v=full&code=emr.primaryIdentifierType`),
   ]);
@@ -150,6 +150,7 @@ function mapPatientIdentifierType(patientIdentifierType, isPrimary) {
     required: patientIdentifierType.required,
     uuid: patientIdentifierType.uuid,
     format: patientIdentifierType.format,
+    formatDescription: patientIdentifierType.formatDescription,
     isPrimary,
     uniquenessBehavior: patientIdentifierType.uniquenessBehavior,
   };

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
@@ -57,9 +57,8 @@ const IdentifierInput: React.FC<IdentifierInputProps> = ({ patientIdentifier, fi
       if (regex.test(value)) {
         return;
       }
-      return t('invalidIdentifierFormat', '{{description}}', {
-        description: identifierType.formatDescription || `Expected format: ${identifierType.format}`,
-      });
+
+      return identifierType.formatDescription ?? `Expected format: ${identifierType.format}`;
     } catch (e) {
       console.error('Invalid regex pattern:', identifierType.format);
       return;

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useField } from 'formik';
+import { useField, Field } from 'formik';
 import { Button } from '@carbon/react';
 import { TrashCan, Edit, Reset } from '@carbon/react/icons';
 import { type RegistrationConfig } from '../../../../config-schema';
@@ -42,6 +42,29 @@ const IdentifierInput: React.FC<IdentifierInputProps> = ({ patientIdentifier, fi
     });
     return map;
   }, [defaultPatientIdentifierTypes]);
+
+  const validateInput = (value: string) => {
+    if (!value || value === '') {
+      return;
+    }
+
+    if (!identifierType?.format) {
+      return;
+    }
+
+    try {
+      const regex = new RegExp(identifierType.format);
+      if (regex.test(value)) {
+        return;
+      }
+      return t('invalidIdentifierFormat', '{{description}}', {
+        description: identifierType.formatDescription || `Expected format: ${identifierType.format}`,
+      });
+    } catch (e) {
+      console.error('Invalid regex pattern:', identifierType.format);
+      return;
+    }
+  };
 
   const handleReset = useCallback(() => {
     setHideInputField(true);
@@ -93,17 +116,20 @@ const IdentifierInput: React.FC<IdentifierInputProps> = ({ patientIdentifier, fi
   return (
     <div className={styles.IDInput}>
       {!hideInputField ? (
-        <Input
-          id={name}
-          labelText={identifierName}
-          name={name}
-          disabled={disabled}
-          required={required}
-          invalid={!!(identifierFieldMeta.touched && identifierFieldMeta.error)}
-          invalidText={identifierFieldMeta.error && t(identifierFieldMeta.error)}
-          // t('identifierValueRequired', 'Identifier value is required')
-          {...identifierField}
-        />
+        <Field name={name} validate={validateInput}>
+          {({ field, form: { touched, errors } }) => (
+            <Input
+              id={name}
+              labelText={identifierName}
+              name={name}
+              disabled={disabled}
+              required={required}
+              invalid={errors[name] && touched[name]}
+              invalidText={errors[name] && t(errors[name])}
+              {...field}
+            />
+          )}
+        </Field>
       ) : (
         <div className={styles.textID}>
           <p data-testid="identifier-label" className={styles.label}>

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.test.tsx
@@ -40,6 +40,26 @@ const mockIdentifierTypes = [
     uniquenessBehavior: 'UNIQUE' as const,
     uuid: '05a29f94-c0ed-11e2-94be-8c13b969e334',
   },
+  {
+    fieldName: 'ssn',
+    format: '^[A-Z]{1}-[0-9]{7}$',
+    formatDescription: 'Identifier should be one letter, followed by a dash, and then 7 digits e.g. A-1234567',
+    identifierSources: [
+      {
+        uuid: '01af8526-cea4-4175-aa90-340acb411771',
+        name: 'Generator 2 for SSN',
+        autoGenerationOption: {
+          manualEntryEnabled: true,
+          automaticGenerationEnabled: false,
+        },
+      },
+    ],
+    isPrimary: false,
+    name: 'SSN',
+    required: true,
+    uniquenessBehavior: 'UNIQUE' as const,
+    uuid: 'a71403f3-8584-4289-ab41-2b4e5570bd45',
+  },
 ];
 
 const mockResourcesContextValue: Resources = {
@@ -53,18 +73,35 @@ const mockResourcesContextValue: Resources = {
   identifierTypes: [...mockIdentifierTypes],
 };
 
+const mockInitialFormValues = {
+  additionalFamilyName: '',
+  additionalGivenName: '',
+  additionalMiddleName: '',
+  addNameInLocalLanguage: false,
+  address: {},
+  attributes: {},
+  birthdate: null,
+  deathDate: null,
+  familyName: '',
+  gender: '',
+  givenName: '',
+  identifiers: {},
+  middleName: '',
+  relationships: [],
+} as FormValues;
+
 const mockContextValues: PatientRegistrationContextProps = {
   currentPhoto: '',
   inEditMode: false,
   identifierTypes: [],
-  initialFormValues: {} as FormValues,
+  initialFormValues: mockInitialFormValues,
   isOffline: false,
   setCapturePhotoProps: jest.fn(),
   setFieldValue: jest.fn(),
   setInitialFormValues: jest.fn(),
   setFieldTouched: jest.fn(),
   validationSchema: null,
-  values: {} as FormValues,
+  values: mockInitialFormValues,
 };
 
 const mockUseConfig = jest.mocked(useConfig<RegistrationConfig>);
@@ -201,5 +238,98 @@ describe('identifier input', () => {
         });
       });
     });
+  });
+
+  it('validates identifier format correctly for identifier types with regex formats', async () => {
+    const user = userEvent.setup();
+
+    const ssnIdentifier = {
+      ...openmrsID,
+      autoGeneration: false,
+      format: '^[A-Z]{1}-[0-9]{7}$',
+      identifierName: 'SSN',
+      identifierTypeUuid: 'a71403f3-8584-4289-ab41-2b4e5570bd45',
+      identifierValue: undefined,
+      initialValue: '',
+      required: true,
+      selectedSource: {
+        uuid: '01af8526-cea4-4175-aa90-340acb411771',
+        name: 'Generator 2 for SSN',
+        autoGenerationOption: {
+          manualEntryEnabled: true,
+          automaticGenerationEnabled: false,
+        },
+      } as IdentifierSource,
+    };
+
+    const mockSetFieldTouched = jest.fn();
+    const mockSetFieldValue = jest.fn();
+    const testContextValues = {
+      ...mockContextValues,
+      setFieldTouched: mockSetFieldTouched,
+      setFieldValue: mockSetFieldValue,
+      values: {
+        ...mockInitialFormValues,
+        identifiers: {
+          [fieldName]: ssnIdentifier,
+        },
+      },
+    };
+
+    const initialValues = {
+      identifiers: {
+        [fieldName]: {
+          identifierValue: '',
+        },
+      },
+    };
+
+    renderWithContext(
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+        <Form>
+          <PatientRegistrationContextProvider value={testContextValues}>
+            <IdentifierInput patientIdentifier={ssnIdentifier} fieldName={fieldName} />
+          </PatientRegistrationContextProvider>
+        </Form>
+      </Formik>,
+      ResourcesContextProvider,
+      mockResourcesContextValue,
+    );
+
+    const input = screen.getByRole('textbox', {
+      name: /ssn/i,
+    });
+
+    // Valid cases
+    await user.type(input, 'A-1234567');
+    await user.tab();
+    expect(input).toHaveValue('A-1234567');
+    expect(input).not.toHaveClass('cds--text-input--invalid');
+    expect(screen.queryByText(/identifier should be/i)).not.toBeInTheDocument();
+
+    // Invalid cases
+    await user.clear(input);
+    await user.type(input, 'A-0010902aaa'); // Extra characters
+    await user.tab();
+    expect(input).toHaveClass('cds--text-input--invalid');
+    expect(screen.getByText(/identifier should be/i)).toBeInTheDocument();
+
+    await user.clear(input);
+    await user.type(input, 'a-1234567'); // Lowercase letter
+    await user.tab();
+    expect(input).toHaveClass('cds--text-input--invalid');
+    expect(screen.getByText(/identifier should be/i)).toBeInTheDocument();
+
+    await user.clear(input);
+    await user.type(input, 'AB-1234567'); // Two letters
+    await user.tab();
+    expect(input).toHaveClass('cds--text-input--invalid');
+    expect(screen.getByText(/identifier should be/i)).toBeInTheDocument();
+
+    await user.clear(input);
+    await user.type(input, 'A-123456'); // Only 6 digits
+    await user.tab();
+    expect(input).toHaveClass('cds--text-input--invalid');
+    expect(screen.getByText(/identifier should be/i)).toBeInTheDocument();
   });
 });

--- a/packages/esm-patient-registration-app/src/patient-registration/input/input.scss
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/input.scss
@@ -89,7 +89,7 @@
 .IDInput {
   display: grid;
   grid-template-columns: 1fr auto;
-  align-items: end;
+  align-items: center;
 }
 
 .trashCan {
@@ -119,5 +119,4 @@
 
 .actionButtonContainer {
   margin-left: layout.$spacing-05;
-  margin-bottom: layout.$spacing-05;
 }

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.types.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.types.ts
@@ -24,6 +24,7 @@ export interface FetchedPatientIdentifierType {
   uuid: string;
   fieldName: string;
   format: string;
+  formatDescription?: string;
   isPrimary: boolean;
   /** See: https://github.com/openmrs/openmrs-core/blob/e3fb1ac0a052aeff0f957a150731757dd319693b/api/src/main/java/org/openmrs/PatientIdentifierType.java#L41 */
   uniquenessBehavior: undefined | null | 'UNIQUE' | 'NON_UNIQUE' | 'LOCATION';

--- a/packages/esm-patient-registration-app/src/resources-context.ts
+++ b/packages/esm-patient-registration-app/src/resources-context.ts
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 import { type Resources } from './offline.resources';
 
 export const ResourcesContext = createContext<Resources>(null);

--- a/packages/esm-patient-registration-app/translations/en.json
+++ b/packages/esm-patient-registration-app/translations/en.json
@@ -64,7 +64,6 @@
   "idFieldLabelText": "Identifiers",
   "IDInstructions": "Select the identifiers you'd like to add for this patient:",
   "invalidEmail": "Invalid email",
-  "invalidIdentifierFormat": "{{description}}",
   "invalidInput": "Invalid Input",
   "isDeadInputLabel": "Is dead",
   "jumpTo": "Jump to",

--- a/packages/esm-patient-registration-app/translations/en.json
+++ b/packages/esm-patient-registration-app/translations/en.json
@@ -64,6 +64,7 @@
   "idFieldLabelText": "Identifiers",
   "IDInstructions": "Select the identifiers you'd like to add for this patient:",
   "invalidEmail": "Invalid email",
+  "invalidIdentifierFormat": "{{description}}",
   "invalidInput": "Invalid Input",
   "isDeadInputLabel": "Is dead",
   "jumpTo": "Jump to",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

The [IdentifierInput component](https://github.com/openmrs/openmrs-esm-patient-management/blob/main/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.component.tsx) in the Registration form should validate identifier values against their defined regex patterns as the user types.

The component should use the [format and formatDescription](https://rest.openmrs.org/#list-patientidentifiertype-resource) properties (when available) to perform real-time validation and provide immediate feedback to users. Currently, when a user enters an invalid identifier value, the UI only shows validation errors after form submission, displaying the backend error message.

This change will improve the user experience by providing immediate visual feedback and clear error messages about format requirements after typing into the identifier field.

## Screenshots

### Before

![CleanShot 2025-04-15 at 10  03 38@2x](https://github.com/user-attachments/assets/0323fa1c-cac3-4d12-ac7b-de709aa152fa)

### After

![CleanShot 2025-04-15 at 2  30 44@2x](https://github.com/user-attachments/assets/33e9af7a-c844-4ee4-bf86-d8d13eef3192)

## Related Issue
https://openmrs.atlassian.net/browse/O3-4644
https://openmrs.atlassian.net/browse/O3-3580

## Other
<!-- Anything not covered above -->
