### PR TITLE
(fix) O3-4516 Ward App - Make admission request workspace wider

### DIFF
--- a/packages/esm-ward-app/src/routes.json
+++ b/packages/esm-ward-app/src/routes.json
@@ -92,7 +92,7 @@
       "component": "admissionRequestWorkspace",
       "title": "admissionRequests",
       "type": "pending-admission-requests",
-      "width": "narrow"
+      "width": "wider"
     },{
       "name": "create-admission-encounter-workspace",
       "component": "createAdmissionEncounterWorkspace",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
A [previous commit](https://github.com/openmrs/openmrs-esm-patient-management/pull/1540) changed the patient-search workspace's and the admission request workspace's widths to be standard (narrow). However. per the [mockup](https://app.zeplin.io/project/65f454477b16814668c38d02/screen/65fda236f0ad0df6e5d786ec), the admission request workspace should be wider than the standard workspace width in order to display the buttons in the pending admission patient cards in one row.

 In the mockup, the workspace is 420px wide. We don’t actually have that exact size, but it’s pretty close to the “wider” workspace size.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://github.com/user-attachments/assets/55f22648-8470-440e-9e6c-f3cf2c31452b)


After:
![image](https://github.com/user-attachments/assets/167edb6a-d133-4f83-8e98-f822dd2967ae)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4516

## Other
<!-- Anything not covered above -->
