### PR TITLE
(fix) Fix translation handling in registration form validation messages

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/input/input.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/basic-input/input/input.component.tsx
@@ -152,7 +152,7 @@ export const Input: React.FC<InputProps> = ({ checkWarning, ...props }) => {
   */
 
   const value = field.value || '';
-  const invalidText = meta.error && t(meta.error);
+  const invalidText = meta.error || '';
   const warnText = useMemo(() => {
     if (!invalidText && typeof checkWarning === 'function') {
       const warning = checkWarning(value);

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.component.tsx
@@ -63,7 +63,7 @@ export const PatientRegistration: React.FC<PatientRegistrationProps> = ({ savePa
   const showDummyData = useMemo(() => localStorage.getItem('openmrs:devtools') === 'true' && !inEditMode, [inEditMode]);
   const { data: photo } = usePatientPhoto(patientToEdit?.id);
   const savePatientTransactionManager = useRef(new SavePatientTransactionManager());
-  const validationSchema = getValidationSchema(config);
+  const validationSchema = getValidationSchema(config, t);
 
   useEffect(() => {
     exportedInitialFormValuesForTesting = initialFormValues;

--- a/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.test.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.test.ts
@@ -57,8 +57,9 @@ describe('Patient registration validation', () => {
 
   const validateFormValues = async (formValues) => {
     const config = (await getConfig('@openmrs/esm-patient-registration-app')) as unknown as RegistrationConfig;
+    const mockT = (key: string, defaultValue: string) => defaultValue;
 
-    const validationSchema = getValidationSchema(config);
+    const validationSchema = getValidationSchema(config, mockT);
     try {
       await validationSchema.validate(formValues, { abortEarly: false });
     } catch (err) {
@@ -77,7 +78,7 @@ describe('Patient registration validation', () => {
       givenName: '',
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('givenNameRequired');
+    expect(validationError.errors).toContain('Given name is required');
   });
 
   it('should require familyName', async () => {
@@ -86,7 +87,7 @@ describe('Patient registration validation', () => {
       familyName: '',
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('familyNameRequired');
+    expect(validationError.errors).toContain('Family name is required');
   });
 
   it('should require additionalGivenName when addNameInLocalLanguage is true', async () => {
@@ -96,7 +97,7 @@ describe('Patient registration validation', () => {
       additionalGivenName: '',
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('givenNameRequired');
+    expect(validationError.errors).toContain('Given name is required');
   });
 
   it('should require additionalFamilyName when addNameInLocalLanguage is true', async () => {
@@ -106,7 +107,7 @@ describe('Patient registration validation', () => {
       additionalFamilyName: '',
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('familyNameRequired');
+    expect(validationError.errors).toContain('Family name is required');
   });
 
   it('should require gender', async () => {
@@ -115,7 +116,7 @@ describe('Patient registration validation', () => {
       gender: '',
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('genderUnspecified');
+    expect(validationError.errors).toContain('Gender unspecified');
   });
 
   it('should allow female as a valid gender', async () => {
@@ -151,7 +152,7 @@ describe('Patient registration validation', () => {
       birthdate: new Date('2100-01-01'),
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('birthdayNotInTheFuture');
+    expect(validationError.errors).toContain('Birthday cannot be in future');
   });
 
   it('should throw an error when date of birth is more than 140 years ago', async () => {
@@ -160,7 +161,7 @@ describe('Patient registration validation', () => {
       birthdate: dayjs().subtract(141, 'years').toDate(),
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('birthdayNotOver140YearsAgo');
+    expect(validationError.errors).toContain('Birthday cannot be more than 140 years ago');
   });
 
   it('should require yearsEstimated when birthdateEstimated is true', async () => {
@@ -169,7 +170,7 @@ describe('Patient registration validation', () => {
       birthdateEstimated: true,
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('yearsEstimateRequired');
+    expect(validationError.errors).toContain('Estimated years required');
   });
 
   it('should throw an error when monthEstimated is negative', async () => {
@@ -180,7 +181,7 @@ describe('Patient registration validation', () => {
       monthsEstimated: -1,
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('negativeMonths');
+    expect(validationError.errors).toContain('Estimated months cannot be negative');
   });
 
   it('should throw an error when yearsEstimated is more than 140', async () => {
@@ -190,7 +191,7 @@ describe('Patient registration validation', () => {
       yearsEstimated: 141,
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('nonsensicalYears');
+    expect(validationError.errors).toContain('Estimated years cannot be more than 140');
   });
 
   it('should throw an error when deathDate is in future', async () => {
@@ -199,6 +200,6 @@ describe('Patient registration validation', () => {
       deathDate: new Date('2100-01-01'),
     };
     const validationError = await validateFormValues(invalidFormValues);
-    expect(validationError.errors).toContain('deathDateInFuture');
+    expect(validationError.errors).toContain('Death date cannot be in future');
   });
 });

--- a/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/validation/patient-registration-validation.ts
@@ -1,14 +1,11 @@
 import dayjs from 'dayjs';
 import * as Yup from 'yup';
 import mapValues from 'lodash/mapValues';
-import { translateFrom } from '@openmrs/esm-framework';
 import { type RegistrationConfig } from '../../config-schema';
 import { type FormValues } from '../patient-registration.types';
 import { getDatetime } from '../patient-registration.resource';
 
-const t = (key: string, value: string) => translateFrom('@openmrs/esm-framework', key, value);
-
-export function getValidationSchema(config: RegistrationConfig) {
+export function getValidationSchema(config: RegistrationConfig, t: (key: string, defaultValue: string) => string) {
   return Yup.object({
     givenName: Yup.string().required(t('givenNameRequired', 'Given name is required')),
     familyName: Yup.string().required(t('familyNameRequired', 'Family name is required')),
@@ -56,7 +53,7 @@ export function getValidationSchema(config: RegistrationConfig) {
         then: Yup.date().required(t('deathDateRequired', 'Death date is required')),
         otherwise: Yup.date().nullable(),
       })
-      .max(new Date(), 'deathDateInFuture')
+      .max(new Date(), t('deathDateInFuture', 'Death date cannot be in future'))
       .test(
         'deathDate-after-birthdate',
         t('deathdayInvalidDate', 'Death date and time cannot be before the birthday'),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This commit fixes how validation error messages are translated in the patient registration form. The main changes include:

- Fixing the validation schema to properly handle translated error messages by passing the `t` function from `react-i18next` as a parameter to `getValidationSchema`.
- Updating the Input component to use pre-translated error messages directly instead of attempting to translate them again.
- Adding a mock translation function for validation tests to ensure proper test coverage.
- Fixing test assertions to properly match error messages.

The changes resolve an issue where validation error messages were being translated twice - once in the validation schema and again in the  `Input` component. This fix ensures messages are translated only once at the validation level, improving both performance and translation accuracy.

## Screenshots

https://github.com/user-attachments/assets/4e573d87-d8e9-426d-80cb-382f88c9817e

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
