### PR TITLE
(refactor) Replace launchPatientWorkspace with launchWorkspace

### DIFF
--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-action-menu.component.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-action-menu.component.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Layer, OverflowMenu, OverflowMenuItem } from '@carbon/react';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { showModal, useLayoutType } from '@openmrs/esm-framework';
+import { launchWorkspace, showModal, useLayoutType } from '@openmrs/esm-framework';
 import type { Appointment } from '../types';
 import styles from './patient-appointments-action-menu.scss';
 
@@ -16,7 +15,7 @@ export const PatientAppointmentsActionMenu = ({ appointment, patientUuid }: appo
   const isTablet = useLayoutType() === 'tablet';
 
   const handleLaunchEditAppointmentForm = () => {
-    launchPatientWorkspace('appointments-form-workspace', {
+    launchWorkspace('appointments-form-workspace', {
       appointment,
       context: 'editing',
       workspaceTitle: t('editAppointment', 'Edit appointment'),

--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-base.component.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-base.component.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ContentSwitcher, DataTableSkeleton, InlineLoading, Layer, Switch, Tile } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
 import { launchWorkspace, useLayoutType } from '@openmrs/esm-framework';
-import { CardHeader, EmptyDataIllustration, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyDataIllustration, ErrorState } from '@openmrs/esm-patient-common-lib';
 import { usePatientAppointments } from './patient-appointments.resource';
 import { PatientAppointmentContextTypes, usePatientAppointmentContext } from '../hooks/patient-appointment-context';
 import PatientAppointmentsTable from './patient-appointments-table.component';
@@ -40,7 +40,7 @@ const PatientAppointmentsBase: React.FC<PatientAppointmentsBaseProps> = ({ patie
     if (
       (patientAppointmentContext as PatientAppointmentContextTypes) === PatientAppointmentContextTypes.PATIENT_CHART
     ) {
-      launchPatientWorkspace('appointments-form-workspace');
+      launchWorkspace('appointments-form-workspace');
     } else {
       launchWorkspace('appointments-form-workspace', {
         context: 'creating',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR replaces the use of `launchPatientWorkspace` with `launchWorkspace`. This is following the removal of the `launchPatientWorkspace` function from the `openmrs/esm-patient-common-lib` package in https://github.com/openmrs/openmrs-esm-patient-chart/pull/2444.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
