### PR TITLE
(feat) O3-4734 Make Ward / Queues / Appointments apps available as extensions

### DIFF
--- a/packages/esm-appointments-app/src/routes.json
+++ b/packages/esm-appointments-app/src/routes.json
@@ -26,6 +26,11 @@
       "slot": "clinical-appointments-dashboard-slot"
     },
     {
+      "name": "appointments-dashboard",
+      "slot": "appointments-dashboard-slot",
+      "component": "appointmentsDashboard"
+    },
+    {
       "name": "appointments-calendar-dashboard-link",
       "slot": "calendar-dashboard-slot",
       "component": "appointmentsCalendarDashboardLink"

--- a/packages/esm-service-queues-app/src/index.ts
+++ b/packages/esm-service-queues-app/src/index.ts
@@ -18,6 +18,10 @@ export const queueTableByStatusMenu = getAsyncLifecycle(
   () => import('./queue-table/queue-table-by-status-menu.component'),
   options,
 );
+export const queueTableByStatusView = getAsyncLifecycle(
+  () => import('./views/queue-table-by-status-view.component'),
+  options,
+);
 
 export const appointmentsList = getAsyncLifecycle(
   () => import('./queue-patient-linelists/scheduled-appointments-table.component'),

--- a/packages/esm-service-queues-app/src/root.component.tsx
+++ b/packages/esm-service-queues-app/src/root.component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes, useParams } from 'react-router-dom';
 import AppointmentsTable from './queue-patient-linelists/scheduled-appointments-table.component';
 import Home from './home.component';
 import ServicesTable from './queue-patient-linelists/queue-services-table.component';
@@ -14,8 +14,7 @@ const Root: React.FC = () => {
       <BrowserRouter basename={serviceQueuesBasename}>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/queue-table-by-status/:queueUuid" element={<QueueTableByStatusView />} />
-          <Route path="/queue-table-by-status/:queueUuid/:statusUuid" element={<QueueTableByStatusView />} />
+          <Route path="/queue-table-by-status/:queueUuid" element={<QueueTableByStatusViewWrapper />} />
           <Route path="/screen" element={<QueueScreen />} />
           <Route path="/appointments-list/:value/" element={<AppointmentsTable />} />
           <Route path="/queue-list/:service/:serviceUuid/:locationUuid" element={<ServicesTable />} />
@@ -24,5 +23,10 @@ const Root: React.FC = () => {
     </main>
   );
 };
+
+function QueueTableByStatusViewWrapper() {
+  const { queueUuid } = useParams();
+  return <QueueTableByStatusView queueUuid={queueUuid} />;
+}
 
 export default Root;

--- a/packages/esm-service-queues-app/src/routes.json
+++ b/packages/esm-service-queues-app/src/routes.json
@@ -41,6 +41,11 @@
       "slot": "service-queues-dashboard-slot"
     },
     {
+      "name": "queue-table-by-status-view",
+      "component": "queueTableByStatusView",
+      "slot": "queue-table-by-status-view-slot"
+    },
+    {
       "name": "remove-queue-entry",
       "component": "removeQueueEntry"
     },

--- a/packages/esm-service-queues-app/src/views/queue-table-by-status-view.component.tsx
+++ b/packages/esm-service-queues-app/src/views/queue-table-by-status-view.component.tsx
@@ -1,19 +1,16 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { useQueue } from '../hooks/useQueue';
 import QueueTablesForAllStatuses from './queue-tables-for-all-statuses.component';
 
 interface QueueTableByStatusViewProps {
-  /**
-   * If provided, this will be used to fetch the queue instead of the one in the URL.
-   * This is useful for when this component is used as an extension.
-   */
-  customQueueUuid?: string;
+  queueUuid: string;
 }
 
-const QueueTableByStatusView: React.FC<QueueTableByStatusViewProps> = ({ customQueueUuid }) => {
-  const { queueUuid } = useParams();
-  const { queue, isLoading: isLoadingQueue, error } = useQueue(customQueueUuid ?? queueUuid);
+/**
+ * This component renders the several tables, one for each status, for a given queue.
+ */
+const QueueTableByStatusView: React.FC<QueueTableByStatusViewProps> = ({ queueUuid }) => {
+  const { queue, isLoading: isLoadingQueue, error } = useQueue(queueUuid);
 
   return <QueueTablesForAllStatuses selectedQueue={queue} isLoadingQueue={isLoadingQueue} errorFetchingQueue={error} />;
 };

--- a/packages/esm-service-queues-app/src/views/queue-table-by-status-view.component.tsx
+++ b/packages/esm-service-queues-app/src/views/queue-table-by-status-view.component.tsx
@@ -3,9 +3,17 @@ import { useParams } from 'react-router-dom';
 import { useQueue } from '../hooks/useQueue';
 import QueueTablesForAllStatuses from './queue-tables-for-all-statuses.component';
 
-const QueueTableByStatusView: React.FC = () => {
+interface QueueTableByStatusViewProps {
+  /**
+   * If provided, this will be used to fetch the queue instead of the one in the URL.
+   * This is useful for when this component is used as an extension.
+   */
+  customQueueUuid?: string;
+}
+
+const QueueTableByStatusView: React.FC<QueueTableByStatusViewProps> = ({ customQueueUuid }) => {
   const { queueUuid } = useParams();
-  const { queue, isLoading: isLoadingQueue, error } = useQueue(queueUuid);
+  const { queue, isLoading: isLoadingQueue, error } = useQueue(customQueueUuid ?? queueUuid);
 
   return <QueueTablesForAllStatuses selectedQueue={queue} isLoadingQueue={isLoadingQueue} errorFetchingQueue={error} />;
 };

--- a/packages/esm-ward-app/src/index.ts
+++ b/packages/esm-ward-app/src/index.ts
@@ -20,6 +20,8 @@ export const root = getAsyncLifecycle(() => import('./root.component'), options)
 
 export const wardDashboardLink = getSyncLifecycle(createDashboardLink({ name: 'ward', title: 'wards' }), options);
 
+export const wardView = getAsyncLifecycle(() => import('./ward-view/ward-view.component'), options);
+
 // t('admissionRequests', 'Admission Requests')
 export const admissionRequestWorkspace = getAsyncLifecycle(
   () => import('./ward-workspace/admission-request-workspace/admission-requests.workspace'),

--- a/packages/esm-ward-app/src/routes.json
+++ b/packages/esm-ward-app/src/routes.json
@@ -31,6 +31,11 @@
       "slot": "ward-dashboard-slot"
     },
     {
+      "component": "wardView",
+      "name": "ward-view",
+      "slot": "ward-view-slot"
+    },
+    {
       "component": "wardPatientActionButtonExtension",
       "name": "ward-patient-action-button",
       "slot": "action-menu-ward-patient-items-slot"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently in the refapp, the Ward / Queues / Appointments apps are not standalone apps, Rather, they are mounted inside the home app. For distributions (like PIH’s) that want to have these apps mounted standalone, we need to make those apps, at the top level, be extensions.

Annoyingly, while each of those apps already has a `root` component as an extension, we cannot use it as it includes its own `<BrowserRouter>`. This PR exposes the (almost) top-level components that those `BrowserRouters` route to.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
