### PR TITLE
(fix) Add null type to date arg

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/date-util.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/date-util.ts
@@ -19,7 +19,7 @@ export const generateFormatting = (order: Array<string>, separator: string) => {
     return date;
   };
 
-  const format = (date: Date) => {
+  const format = (date: Date | null) => {
     if (date === null) {
       return '';
     } else if (!(date instanceof Date)) {


### PR DESCRIPTION
As the received date can be `null`, the corresponding `null` type is added to the parameter.
