### PR TITLE
(fix) O3-4773: Introduce _elements property in pageSizes in activeVisits config schema

### DIFF
--- a/packages/esm-active-visits-app/src/config-schema.ts
+++ b/packages/esm-active-visits-app/src/config-schema.ts
@@ -42,7 +42,7 @@ export const configSchema = {
           _description: 'Name of the desired identifier to filter data returned from the visit resource.',
         },
       },
-      _default: null,
+      _default: [],
     },
     pageSize: {
       _type: Type.Number,
@@ -52,6 +52,10 @@ export const configSchema = {
     pageSizes: {
       _type: Type.Array,
       _description: 'Customizable page sizes that user can choose',
+      _elements: {
+        _type: Type.Number,
+        _description: 'Number of entries to be displayed on the active visits table.',
+      },
       _default: [10, 20, 50],
     },
     obs: {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an issue where the `pageSizes` array input in the `active-visits-app` was not allowing users to type or view the values properly. The input is now fully editable and displays the values as expected.

## Screen Recordings
### Before
https://github.com/user-attachments/assets/d5b300fa-1162-4da8-9fbb-7110a1d63344

### After
https://github.com/user-attachments/assets/a2c8c96d-c85b-48ef-858e-bdfd926bf28a

## Related Issue
[O3-4773](https://openmrs.atlassian.net/issues/O3-4773?jql=ORDER%20BY%20created%20DESC)


[O3-4773]: https://openmrs.atlassian.net/browse/O3-4773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ