### PR TITLE
(fix) Use activeVisit instead of currentVisit in patient banner

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -33,7 +33,7 @@ interface PatientBannerProps {
 const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hideActionsOverflow }) => {
   const layout = useLayoutType();
   const isTablet = layout === 'tablet';
-  const { currentVisit } = useVisit(patientUuid);
+  const { activeVisit } = useVisit(patientUuid);
   const { nonNavigationSelectPatientAction, showPatientSearch, hidePatientSearch, handleReturnToSearchList } =
     usePatientSearchContext();
 
@@ -80,7 +80,7 @@ const PatientBanner: React.FC<PatientBannerProps> = ({ patient, patientUuid, hid
                 patientUuid={patientUuid}
               />
             ) : null}
-            {!isDeceased && !currentVisit && (
+            {!isDeceased && !activeVisit && (
               <ExtensionSlot
                 name="start-visit-button-slot"
                 state={{


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Replaces `currentVisit` with `activeVisit` in the patient banner component. The `activeVisit` represents the ongoing visit (without an end date), while `currentVisit` could point to a retrospective visit. This ensures the "Start visit" button is only hidden when there's actually an ongoing visit, not when a retrospective visit is selected. 

## Screenshots

### Before

Note how the `Start visit` button is shown despite there being an active visit:

![CleanShot 2025-07-01 at 15 44 06@2x](https://github.com/user-attachments/assets/30b77ac5-7f98-49bc-9ac9-056d0fd6eb5f)

### After

`Start visit` button is hidden when the patient has an active visit:

![CleanShot 2025-07-01 at 15 45 55@2x](https://github.com/user-attachments/assets/406bac5d-a339-4577-a627-0ed97fe4fd26)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
