### PR TITLE
(FIXED ) Service Queues: Remove "Delete" from action menu  #[03-4848]

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
@@ -49,37 +49,21 @@ export function QueueTableActionCell({ queueEntry }: QueueTableCellComponentProp
           }}
           itemText={t('removePatient', 'Remove patient')}
         />
-        {queueEntry.previousQueueEntry == null ? (
-          <OverflowMenuItem
-            className={styles.menuItem}
-            aria-label={t('delete', 'Delete')}
-            hasDivider
-            isDelete
-            onClick={() => {
-              const dispose = showModal('void-queue-entry-modal', {
-                closeModal: () => dispose(),
-                queueEntry,
-                size: 'sm',
-              });
-            }}
-            itemText={t('delete', 'Delete')}
-          />
-        ) : (
-          <OverflowMenuItem
-            className={styles.menuItem}
-            aria-label={t('undoTransition', 'Undo transition')}
-            hasDivider
-            isDelete
-            onClick={() => {
-              const dispose = showModal('undo-transition-queue-entry-modal', {
-                closeModal: () => dispose(),
-                queueEntry,
-                size: 'sm',
-              });
-            }}
-            itemText={t('undoTransition', 'Undo transition')}
-          />
-        )}
+
+        <OverflowMenuItem
+          className={styles.menuItem}
+          aria-label={t('undoTransition', 'Undo transition')}
+          hasDivider
+          isDelete
+          onClick={() => {
+            const dispose = showModal('undo-transition-queue-entry-modal', {
+              closeModal: () => dispose(),
+              queueEntry,
+              size: 'sm',
+            });
+          }}
+          itemText={t('undoTransition', 'Undo transition')}
+        />
       </OverflowMenu>
     </div>
   );


### PR DESCRIPTION
Removed the "Delete" action from the service queue entry action menu as per the requirements.
The "Undo transition" action is now always available in the action menu, regardless of the queue entry state.
Cleaned up the conditional rendering logic to ensure only the relevant actions (Edit, Remove patient, and Undo transition) are shown.


This is how originally it was:
![Before Fix](https://github.com/user-attachments/assets/b29e98a5-7aca-4893-929e-ac9865d03263)

Then After :
![After Fix](https://github.com/user-attachments/assets/c021cb3d-c57c-4706-a41a-025a856cb7f7)

Jira Ticket Link: [https://openmrs.atlassian.net/issues/O3-4848?filter=-4]

