### PR TITLE
(fix)  O3-4848 Service Queues: Remove "Delete" from action menu.

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
@@ -49,37 +49,21 @@ export function QueueTableActionCell({ queueEntry }: QueueTableCellComponentProp
           }}
           itemText={t('removePatient', 'Remove patient')}
         />
-        {queueEntry.previousQueueEntry == null ? (
-          <OverflowMenuItem
-            className={styles.menuItem}
-            aria-label={t('delete', 'Delete')}
-            hasDivider
-            isDelete
-            onClick={() => {
-              const dispose = showModal('void-queue-entry-modal', {
-                closeModal: () => dispose(),
-                queueEntry,
-                size: 'sm',
-              });
-            }}
-            itemText={t('delete', 'Delete')}
-          />
-        ) : (
-          <OverflowMenuItem
-            className={styles.menuItem}
-            aria-label={t('undoTransition', 'Undo transition')}
-            hasDivider
-            isDelete
-            onClick={() => {
-              const dispose = showModal('undo-transition-queue-entry-modal', {
-                closeModal: () => dispose(),
-                queueEntry,
-                size: 'sm',
-              });
-            }}
-            itemText={t('undoTransition', 'Undo transition')}
-          />
-        )}
+
+        <OverflowMenuItem
+          className={styles.menuItem}
+          aria-label={t('undoTransition', 'Undo transition')}
+          hasDivider
+          isDelete
+          onClick={() => {
+            const dispose = showModal('undo-transition-queue-entry-modal', {
+              closeModal: () => dispose(),
+              queueEntry,
+              size: 'sm',
+            });
+          }}
+          itemText={t('undoTransition', 'Undo transition')}
+        />
       </OverflowMenu>
     </div>
   );

--- a/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.component.tsx
@@ -49,21 +49,22 @@ export function QueueTableActionCell({ queueEntry }: QueueTableCellComponentProp
           }}
           itemText={t('removePatient', 'Remove patient')}
         />
-
-        <OverflowMenuItem
-          className={styles.menuItem}
-          aria-label={t('undoTransition', 'Undo transition')}
-          hasDivider
-          isDelete
-          onClick={() => {
-            const dispose = showModal('undo-transition-queue-entry-modal', {
-              closeModal: () => dispose(),
-              queueEntry,
-              size: 'sm',
-            });
-          }}
-          itemText={t('undoTransition', 'Undo transition')}
-        />
+        {queueEntry.previousQueueEntry != null && (
+          <OverflowMenuItem
+            className={styles.menuItem}
+            aria-label={t('undoTransition', 'Undo transition')}
+            hasDivider
+            isDelete
+            onClick={() => {
+              const dispose = showModal('undo-transition-queue-entry-modal', {
+                closeModal: () => dispose(),
+                queueEntry,
+                size: 'sm',
+              });
+            }}
+            itemText={t('undoTransition', 'Undo transition')}
+          />
+        )}
       </OverflowMenu>
     </div>
   );


### PR DESCRIPTION

## Requirements
- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Removed the "Delete" action from the service queue entry action menu as per the requirements of the Ticket.
The "Undo transition" action is now  available in the action menu,  only when  there has been a transition made  on the Patient.  
If the patient has no Transition, the Button wont appear.  

## Screenshots
Before Fix:
![Before Fix](https://github.com/user-attachments/assets/1106ac97-a843-45da-bc4f-1a4824c7f5d7)

The After Fix:
![After](https://github.com/user-attachments/assets/e0ad1443-686b-420d-b326-13f6c1636543)

## Related Issue:
LINK: [https://openmrs.atlassian.net/issues/O3-4848?filter=-4]
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

