### PR TITLE
(fix): Fix privileges for patient identifier

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.component.tsx
@@ -120,7 +120,7 @@ export const Identifiers: React.FC = () => {
 
   return (
     <div className={styles.halfWidthInDesktopView}>
-      <UserHasAccess privilege={['Get Identifier Types', 'Add patient identifiers']}>
+      <UserHasAccess privilege={['Get Identifier Types', 'Add Patient Identifiers']}>
         <div className={styles.identifierLabelText}>
           <h4 className={styles.productiveHeading02Light}>{t('idFieldLabelText', 'Identifiers')}</h4>
           <Button


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes a typo in the permissions where the `Add Patient Identifiers` was written down as `Add patient identifiers` which caused a user with the correct privilege to not have access. The correct case is capital case as we have it here - https://github.com/openmrs/openmrs-core/blob/2.7.4/api/src/main/java/org/openmrs/util/PrivilegeConstants.java#L259

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
