### PR TITLE
(fix) Remove space before colon in serve modal patient info display

### DIFF
--- a/packages/esm-service-queues-app/src/modals/call-modal/call-queue-entry.modal.tsx
+++ b/packages/esm-service-queues-app/src/modals/call-modal/call-queue-entry.modal.tsx
@@ -6,8 +6,8 @@ import { type ConfigObject } from '../../config-schema';
 import { mapVisitQueueEntryProperties, serveQueueEntry, updateQueueEntry } from '../../service-queues.resource';
 import { requeueQueueEntry } from './call-queue-entry.resource';
 import { useMutateQueueEntries } from '../../hooks/useQueueEntries';
-import styles from './call-queue-entry.scss';
 import { type QueueEntry } from '../../types';
+import styles from './call-queue-entry.scss';
 
 interface CallQueueEntryModalProps {
   closeModal: () => void;
@@ -113,7 +113,7 @@ const CallQueueEntryModal: React.FC<CallQueueEntryModalProps> = ({ closeModal, q
         <div>
           <section className={styles.modalBody}>
             <p className={styles.p}>
-              {t('patientName', 'Patient name')} : &nbsp; {mappedQueueEntry.name}
+              {t('patientName', 'Patient name')}: &nbsp; {mappedQueueEntry.name}
             </p>
             {preferredIdentifiers?.length
               ? preferredIdentifiers.map((identifier) => (
@@ -123,10 +123,12 @@ const CallQueueEntryModal: React.FC<CallQueueEntryModalProps> = ({ closeModal, q
                 ))
               : ''}
             <p className={styles.p}>
-              {t('patientAge', 'Age')} : &nbsp; {mappedQueueEntry.patientAge}
+              {t('patientAge', 'Age')}: &nbsp; {mappedQueueEntry.patientAge}
             </p>
             <div>
-              {mappedQueueEntry.identifiers?.map((identifier) => <Tag key={identifier.uuid}>{identifier.display}</Tag>)}
+              {mappedQueueEntry.identifiers?.map((identifier) => (
+                <Tag key={identifier.uuid}>{identifier.display}</Tag>
+              ))}
             </div>
           </section>
         </div>

--- a/packages/esm-service-queues-app/src/modals/call-modal/call-queue-entry.test.tsx
+++ b/packages/esm-service-queues-app/src/modals/call-modal/call-queue-entry.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { getDefaultsFromConfigSchema, navigate, useConfig } from '@openmrs/esm-framework';
+import { mockQueueEntryAlice } from '__mocks__';
 import { configSchema, type ConfigObject } from '../../config-schema';
 import { serveQueueEntry, updateQueueEntry } from '../../service-queues.resource';
 import { requeueQueueEntry } from './call-queue-entry.resource';
 import CallQueueEntryModal from './call-queue-entry.modal';
-import { mockQueueEntryAlice } from '__mocks__';
 
 const mockNavigate = jest.mocked(navigate);
 const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
@@ -41,7 +41,7 @@ describe('MoveQueueEntryModal', () => {
     render(<CallQueueEntryModal queueEntry={mockQueueEntryAlice} closeModal={closeModal} />);
 
     expect(screen.getByText(/Serve patient/i)).toBeInTheDocument();
-    expect(screen.getByText(/Patient name :/i)).toBeInTheDocument();
+    expect(screen.getByText(/Patient name:/i)).toBeInTheDocument();
   });
 
   it('handles requeueing patient', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes punctuation in the Service Queues' Serve patient modal by making the following changes:

- Remove space before colon in "Patient name:" and "Age:" labels
- Update test expectations to match new formatting

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
