### PR TITLE
fix: Temporarily remove the patient list links from service-queues-app

### DIFF
--- a/packages/esm-service-queues-app/src/metrics/metrics-cards/metrics-card.component.tsx
+++ b/packages/esm-service-queues-app/src/metrics/metrics-cards/metrics-card.component.tsx
@@ -44,7 +44,8 @@ const MetricsCard: React.FC<MetricsCardProps> = ({
             <label className={styles.headerLabel}>{headerLabel}</label>
             {children}
           </div>
-          {service == 'scheduled' ? (
+          {/* TODO: Uncomment this when functionality of the patient list works.*/}
+          {/* {service == 'scheduled' ? (
             <div className={styles.link}>
               <ConfigurableLink className={styles.link} to={`\${openmrsSpaBase}/home`}>
                 {t('patientList', 'Patient list')}
@@ -58,7 +59,7 @@ const MetricsCard: React.FC<MetricsCardProps> = ({
               </ConfigurableLink>
               <ArrowRight size={16} />
             </div>
-          )}
+          )} */}
         </div>
         <div className={styles.metricsContainer}>
           <div className={styles.metricItem}>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

We have two links on the metrics cards of the`service-queues-app`  that can be confusing since when clicking them, the assumption is the user will get a line list for the counts on the cards; however, in this case, functionality is broken, so this PR removes the link until the line lists are fixed.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1512" height="903" alt="image" src="https://github.com/user-attachments/assets/11fde063-fd30-4869-b2a3-5ea5fee7d889" />
The highlighted links don't really work. The link for  *Checked in patients* does nothing, and the link on  *Waiting for:*  opens a broken UI
<img width="1512" height="909" alt="image" src="https://github.com/user-attachments/assets/16bbcacb-ca61-4ea0-abbd-909dddb31308" />

<img width="1512" height="903" alt="image" src="https://github.com/user-attachments/assets/b718b1a0-0347-459f-9726-0728e9ca6015" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
