### PR TITLE
(fix) O3-4895: Fix queue table action cell height

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.scss
+++ b/packages/esm-service-queues-app/src/queue-table/cells/queue-table-action-cell.scss
@@ -1,3 +1,5 @@
+@use '@carbon/layout';
+
 .actionCellContainer {
   white-space: nowrap;
 }
@@ -9,6 +11,6 @@
 .actionsCell {
   display: flex;
   justify-content: flex-end;
-  height: 100%;
+  height: layout.$spacing-09;
   align-items: center;
 }

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -200,7 +200,6 @@
   "undoTransition": "Undo transition",
   "unexpectedError": "An unexpected error occurred",
   "unexpectedServerResponse": "Unexpected Server Response",
-  "updateEntry": "Update entry",
   "urgent": "Urgent",
   "useTodaysDate": "Use today's date",
   "visitTabs": "Visit tabs",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Replaces the percentage-based height value of the Queue Table actions cell with a fixed height corresponding to the default table row height (`3rem`). This fixes an issue in Firefox where the action buttons are not properly centered vertically. This snippet from the `Table height algorithms` section of the [CSS 2.2 Official spec](https://www.w3.org/TR/CSS22/tables.html#height-layout) is the closest to an official source I've found for why Firefox has trouble interpreting `height: 100%` in table cells:

> CSS 2.2 does not define how the height of table cells and table rows is calculated when their height is specified using percentage values. CSS 2.2 does not define the meaning of 'height' on row groups.

## Screenshots

### Issue on Firefox (note the positioning of the `Move` button in the `Actions` column

<img width="2274" height="498" alt="CleanShot 2025-07-22 at 20 56 11@2x" src="https://github.com/user-attachments/assets/9e421a81-2744-433a-bb5b-b1a7894f8a49" />

### Fix  (the first browser is Firefox followed by a Chromium-based browser)

https://github.com/user-attachments/assets/657425f8-5952-4202-af67-7acd3888898b

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
