### PR TITLE
(feat) O3-4882: Service Queues: defaultInitialServiceQueue config should live in Service Queues app and be used for Add Patient

### DIFF
--- a/packages/esm-service-queues-app/src/config-schema.ts
+++ b/packages/esm-service-queues-app/src/config-schema.ts
@@ -195,6 +195,11 @@ export const configSchema = {
     _description: 'The identifier types to be display on all patient search result page',
     _default: ['05ee9cf4-7242-4a17-b4d4-00f707265c8a', 'f85081e2-b4be-4e48-b3a4-7994b69bb101'],
   },
+  defaultInitialServiceQueue: {
+    _type: Type.String,
+    _description: 'The name of the default service queue to be selected when the start visit form is opened',
+    _default: 'Outpatient Triage',
+  },
   queueTables: {
     columnDefinitions: {
       _type: Type.Array,
@@ -456,6 +461,7 @@ export interface ConfigObject {
     temperatureUuid: string;
     weightUuid: string;
   };
+  defaultInitialServiceQueue: string;
   contactAttributeType: Array<string>;
   customPatientChartUrl: string;
   defaultIdentifierTypes: Array<string>;

--- a/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/visit-form-queue-fields.extension.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/queue-fields/visit-form-queue-fields.extension.tsx
@@ -1,6 +1,7 @@
-import { type Visit } from '@openmrs/esm-framework';
+import { useConfig, type Visit } from '@openmrs/esm-framework';
 import React from 'react';
 import QueueFields from './queue-fields.component';
+import { type ConfigObject } from '../../config-schema';
 
 interface VisitFormCallbacks {
   onVisitCreatedOrUpdated: (visit: Visit) => Promise<any>;
@@ -11,7 +12,6 @@ export interface VisitFormQueueFieldsProps {
   visitFormOpenedFrom: string;
   patientChartConfig?: {
     showServiceQueueFields: boolean;
-    defaultInitialServiceQueue: string;
   };
   patientUuid: string;
 }
@@ -21,12 +21,13 @@ export interface VisitFormQueueFieldsProps {
  * It is used slotted into the patient-chart's start visit form
  */
 const VisitFormQueueFields: React.FC<VisitFormQueueFieldsProps> = (props) => {
+  const config = useConfig<ConfigObject>();
   const { setVisitFormCallbacks, visitFormOpenedFrom, patientChartConfig } = props;
   if (patientChartConfig.showServiceQueueFields || visitFormOpenedFrom == 'service-queues-add-patient') {
     return (
       <QueueFields
         setOnSubmit={(onSubmit) => setVisitFormCallbacks({ onVisitCreatedOrUpdated: onSubmit })}
-        defaultInitialServiceQueue={patientChartConfig.defaultInitialServiceQueue}
+        defaultInitialServiceQueue={config.defaultInitialServiceQueue}
       />
     );
   } else {

--- a/packages/esm-service-queues-app/src/modals/add-or-move-modal/add-patient-to-queue.component.tsx
+++ b/packages/esm-service-queues-app/src/modals/add-or-move-modal/add-patient-to-queue.component.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Form, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
-import { showSnackbar, type Visit } from '@openmrs/esm-framework';
+import { showSnackbar, useConfig, type Visit } from '@openmrs/esm-framework';
 import { useMutateQueueEntries } from '../../hooks/useQueueEntries';
 import QueueFields from '../../create-queue-entry/queue-fields/queue-fields.component';
+import { type ConfigObject } from '../../config-schema';
 
 interface AddPatientToQueueModalProps {
   modalTitle: string;
@@ -14,6 +15,7 @@ interface AddPatientToQueueModalProps {
 const AddPatientToQueueModal: React.FC<AddPatientToQueueModalProps> = ({ modalTitle, activeVisit, closeModal }) => {
   const { t } = useTranslation();
   const { mutateQueueEntries } = useMutateQueueEntries();
+  const config = useConfig<ConfigObject>();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [callback, setCallback] = useState<{
@@ -50,7 +52,10 @@ const AddPatientToQueueModal: React.FC<AddPatientToQueueModalProps> = ({ modalTi
     <Form onSubmit={handleSubmit}>
       <ModalHeader closeModal={closeModal} title={modalTitle} />
       <ModalBody>
-        <QueueFields setOnSubmit={(onSubmit) => setCallback({ submitQueueEntry: onSubmit })} />
+        <QueueFields
+          setOnSubmit={(onSubmit) => setCallback({ submitQueueEntry: onSubmit })}
+          defaultInitialServiceQueue={config.defaultInitialServiceQueue}
+        />
       </ModalBody>
       <ModalFooter>
         <Button kind="secondary" onClick={closeModal}>


### PR DESCRIPTION
…

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Added `defaultInitialServiceQueue` config element from the patient chart. The “Add patient to queue” form should use that as the default service option.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-4882

## Other
<!-- Anything not covered above -->
