### PR TITLE
(fix): Fetch all queue locations using fhirFetchAll

### DIFF
--- a/packages/esm-service-queues-app/src/create-queue-entry/hooks/useQueueLocations.ts
+++ b/packages/esm-service-queues-app/src/create-queue-entry/hooks/useQueueLocations.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { fhirBaseUrl, getLocale, openmrsFetch } from '@openmrs/esm-framework';
+import { fhirBaseUrl, getLocale, openmrsFetch, useFhirFetchAll } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
 
 interface FHIRResponse {
@@ -11,14 +11,12 @@ interface FHIRResponse {
 
 export function useQueueLocations() {
   const apiUrl = `${fhirBaseUrl}/Location?_summary=data&_tag=queue location`;
-  const { data, error, isLoading } = useSWRImmutable<{ data: FHIRResponse }>(apiUrl, openmrsFetch);
+  const { data, error, isLoading } = useFhirFetchAll<fhir.Location>(apiUrl);
 
   const queueLocations = useMemo(
-    () =>
-      data?.data?.entry
-        ?.map((response) => response.resource)
-        .sort((a, b) => a.name.localeCompare(b.name, getLocale())) ?? [],
-    [data?.data?.entry],
+    () => data?.map((response) => response).sort((a, b) => a.name.localeCompare(b.name, getLocale())) ?? [],
+    [data],
   );
+
   return { queueLocations, isLoading, error };
 }

--- a/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
+++ b/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.component.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Dropdown } from '@carbon/react';
+import { Dropdown, DropdownSkeleton } from '@carbon/react';
 import { useConfig, useSession, PageHeader, PageHeaderContent, ServiceQueuesPictogram } from '@openmrs/esm-framework';
 import { useQueueLocations } from '../create-queue-entry/hooks/useQueueLocations';
 import {
@@ -76,20 +76,27 @@ const PatientQueueHeader: React.FC<PatientQueueHeaderProps> = ({ title, showLoca
         illustration={<ServiceQueuesPictogram />}
       />
       <div className={styles.dropdownContainer}>
-        {showLocationDropdown && (
-          <Dropdown
-            aria-label={t('selectQueueLocation', 'Select a queue location')}
-            className={styles.dropdown}
-            id="queueLocationDropdown"
-            label={currentQueueLocationName ?? t('all', 'All')}
-            items={
-              queueLocations.length !== 1 ? [{ id: 'all', name: t('all', 'All') }, ...queueLocations] : queueLocations
-            }
-            itemToString={(item) => (item ? item.name : '')}
-            titleText={t('location', 'Location')}
-            type="inline"
-            onChange={handleQueueLocationChange}
-          />
+        {isLoading ? (
+          <div className={styles.dropdownSkeletonContainer}>
+            <DropdownSkeleton />
+          </div>
+        ) : (
+          showLocationDropdown &&
+          !error && (
+            <Dropdown
+              aria-label={t('selectQueueLocation', 'Select a queue location')}
+              className={styles.dropdown}
+              id="queueLocationDropdown"
+              label={currentQueueLocationName ?? t('all', 'All')}
+              items={
+                queueLocations.length !== 1 ? [{ id: 'all', name: t('all', 'All') }, ...queueLocations] : queueLocations
+              }
+              itemToString={(item) => (item ? item.name : '')}
+              titleText={t('location', 'Location')}
+              type="inline"
+              onChange={handleQueueLocationChange}
+            />
+          )
         )}
         {actions}
       </div>

--- a/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.scss
+++ b/packages/esm-service-queues-app/src/patient-queue-header/patient-queue-header.scss
@@ -11,6 +11,10 @@
   padding-right: layout.$spacing-03;
 }
 
+.dropdownSkeletonContainer {
+  width: 300px;
+}
+
 .dropdownContainer {
   display: flex;
   align-items: center;

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -96,7 +96,6 @@
   "orderIndefiniteDuration": "Indefinite duration",
   "patientAge": "Age",
   "patientAttendingService": "Patient attending service",
-  "patientList": "Patient list",
   "patientName": "Patient name",
   "patientRemoved": "Patient removed",
   "patientRemovedFailed": "Error removing patient from queue",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates the `useQueueLocations` hook to use `useFhirFetchAll` to fetch all queue locations. Previously this only returned 10. This also adds a loading indicator to render until the queue locations are loaded.

## Screenshots
<!-- Required if you are making UI changes. -->
Loading indicator:
<img width="1710" height="197" alt="Screenshot 2025-07-25 at 3 44 16 PM" src="https://github.com/user-attachments/assets/9c4b11b6-381c-4f04-a32d-d18eaf90bbb2" />

Queue locations is now no longer limited to only 10 locations:
https://github.com/user-attachments/assets/1d656685-7802-4854-bd3b-8900c9eaafff


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
Related slack thread - https://openmrs.slack.com/archives/C039BLMGMMX/p1752498396351849
