### PR TITLE
(feat) O3-4923: Add custom data attributes for targeting elements for onboarding app 

### DIFF
--- a/packages/esm-patient-list-management-app/src/lists-table/lists-table.component.tsx
+++ b/packages/esm-patient-list-management-app/src/lists-table/lists-table.component.tsx
@@ -154,10 +154,12 @@ const ListsTable: React.FC<PatientListTableProps> = ({
       <DataTable rows={tableRows} headers={headers} size={responsiveSize} sortRow={customSortRow}>
         {({ rows, headers, getTableProps, getHeaderProps, getRowProps, getTableContainerProps }) => (
           <TableContainer {...getTableContainerProps()} className={styles.tableContainer}>
+            {/* data-tutorial-target attribute is essential for joyride in onboarding app ! */}
+
             <Table
               {...getTableProps()}
               className={styles.table}
-              data-testid="patientListsTable"
+              data-tutorial-target="patient-lists-table"
               isSortable
               useZebraStyles>
               <TableHead>

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -99,7 +99,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
     [addViewedPatientAndCloseSearchResults, config.search.patientChartUrl],
   );
   const focusedResult = useArrowNavigation(
-    !recentPatients ? searchedPatients?.length ?? 0 : recentPatients?.length ?? 0,
+    !recentPatients ? (searchedPatients?.length ?? 0) : (recentPatients?.length ?? 0),
     handlePatientSelection,
     handleFocusToInput,
     -1,
@@ -171,14 +171,22 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
           ref={searchInputRef}
         />
 
+        {/* data-tutorial-target attribute is essential for joyride in onboarding app ! */}
+
         {!isSearchPage && hasSearchTerm && (
-          <div className={styles.floatingSearchResultsContainer} data-testid="floatingSearchResultsContainer">
+          <div
+            className={styles.floatingSearchResultsContainer}
+            data-testid="floatingSearchResultsContainer"
+            data-tutorial-target="floating-search-results-container">
             <PatientSearch query={debouncedSearchTerm} ref={bannerContainerRef} {...patientSearchResponse} />
           </div>
         )}
 
         {!isSearchPage && !hasSearchTerm && showRecentlySearchedPatients && (
-          <div className={styles.floatingSearchResultsContainer} data-testid="floatingSearchResultsContainer">
+          <div
+            className={styles.floatingSearchResultsContainer}
+            data-testid="floatingSearchResultsContainer"
+            data-tutorial-target="floating-search-results-container">
             <RecentlySearchedPatients ref={bannerContainerRef} {...recentPatientSearchResponse} />
           </div>
         )}

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -44,7 +44,7 @@ const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChild
           className={styles.patientSearchInput}
           closeButtonLabelText={t('clearSearch', 'Clear')}
           data-testid="patientSearchBar"
-          data-tutorial-target="paitent-search-bar"
+          data-tutorial-target="patient-search-bar"
           labelText={t('searchForPatient', 'Search for a patient by name or identifier number')}
           onChange={(event) => handleChange(event.target.value)}
           onClear={onClear}

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -38,11 +38,13 @@ const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChild
 
     return (
       <form onSubmit={handleSubmit} className={styles.searchArea}>
+        {/* data-tutorial-target attribute is essential for joyride in onboarding app ! */}
         <Search
           autoFocus
           className={styles.patientSearchInput}
           closeButtonLabelText={t('clearSearch', 'Clear')}
           data-testid="patientSearchBar"
+          data-tutorial-target="paitent-search-bar"
           labelText={t('searchForPatient', 'Search for a patient by name or identifier number')}
           onChange={(event) => handleChange(event.target.value)}
           onClear={onClear}

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -98,13 +98,11 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
             />
           )}
 
-          {/* data-tutorial-target attribute is essential for joyride in onboarding app ! */}
           <div className={styles.closeButton}>
             <HeaderGlobalAction
               aria-label={t('closeSearch', 'Close Search Panel')}
               className={styles.activeSearchIconButton}
-              data-testid="searchPatientIcon"
-              data-tutorial-target="search-patient-icon"
+              data-testid="closeSearchIcon"
               enterDelayMs={500}
               name="CloseSearchIcon"
               onClick={closePatientSearch}>
@@ -114,6 +112,7 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
         </>
       ) : (
         <div>
+          {/* data-tutorial-target attribute is essential for joyride in onboarding app ! */}
           <HeaderGlobalAction
             aria-label={t('searchPatient', 'Search patient')}
             className={styles.searchIconButton}

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -97,11 +97,14 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
               patientClickSideEffect={closePatientSearch}
             />
           )}
+
+          {/* data-tutorial-target attribute is essential for joyride in onboarding app ! */}
           <div className={styles.closeButton}>
             <HeaderGlobalAction
               aria-label={t('closeSearch', 'Close Search Panel')}
               className={styles.activeSearchIconButton}
-              data-testid="closeSearchIcon"
+              data-testid="searchPatientIcon"
+              data-tutorial-target="search-patient-icon"
               enterDelayMs={500}
               name="CloseSearchIcon"
               onClick={closePatientSearch}>
@@ -115,6 +118,7 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
             aria-label={t('searchPatient', 'Search patient')}
             className={styles.searchIconButton}
             data-testid="searchPatientIcon"
+            data-tutorial-target="search-patient-icon"
             enterDelayMs={500}
             name="SearchPatientIcon"
             onClick={handleShowSearchInput}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR adds `tutorial` target attributes to specific UI components as part of the improvements requested in [O3-4923](https://openmrs.atlassian.net/browse/O3-4923). These attributes will help support user onboarding flows by enabling components to be targeted during tutorials.

## Screenshots

<!-- Add screenshots here if the UI was changed -->

## Related Issue

https://openmrs.atlassian.net/browse/O3-4923

## Other

This update improves compatibility with onboarding tools and supports the implementation of guided user flows as outlined in the Jira ticket.


[O3-4923]: https://openmrs.atlassian.net/browse/O3-4923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ