### PR TITLE
(feat) O3-4934: Add data-tutorial-target custom attribute to close icon in search app

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -103,6 +103,7 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
               aria-label={t('closeSearch', 'Close Search Panel')}
               className={styles.activeSearchIconButton}
               data-testid="closeSearchIcon"
+              data-tutorial-target="close-search-icon"
               enterDelayMs={500}
               name="CloseSearchIcon"
               onClick={closePatientSearch}>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

---

## Summary

This PR adds a `data-tutorial-target="close-search-icon"` attribute to the **close icon** in the "Find Patient" workflow. This change supports the onboarding tutorial overlay system by allowing the tutorial configuration to properly highlight and guide users through closing the search panel.

This does **not** interfere with the existing `data-testid` attributes used for testing purposes.

---

## Screenshots

<!-- Add screenshots here if the UI changed visually -->
<!-- Example:
Before: ![Before](url)
After: ![After](url)
-->

---

## Related Issue

[Jira Ticket: O3-4934](https://openmrs.atlassian.net/browse/O3-4934)

---

