### PR TITLE
(feat) O3-4277: Set 60-second SWR refresh interval for service queues and ward views

### DIFF
--- a/packages/esm-service-queues-app/src/index.ts
+++ b/packages/esm-service-queues-app/src/index.ts
@@ -6,7 +6,7 @@ import { dashboardMeta } from './dashboard.meta';
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
 const moduleName = '@openmrs/esm-service-queues-app';
-const swrRefreshInternalMs = 60000; // milliseconds
+const swrRefreshIntervalInMs = 60000;
 
 const options = {
   featureName: 'service-queues',
@@ -17,7 +17,7 @@ export const root = getAsyncLifecycle(() => import('./root.component'), {
   featureName: 'service-queues-app-root',
   moduleName,
   swrConfig: {
-    refreshInterval: swrRefreshInternalMs,
+    refreshInterval: swrRefreshIntervalInMs,
   },
 });
 
@@ -29,7 +29,7 @@ export const queueTableByStatusView = getAsyncLifecycle(() => import('./views/qu
   featureName: 'queue-table-by-status-view',
   moduleName,
   swrConfig: {
-    refreshInterval: swrRefreshInternalMs,
+    refreshInterval: swrRefreshIntervalInMs,
   },
 });
 

--- a/packages/esm-service-queues-app/src/index.ts
+++ b/packages/esm-service-queues-app/src/index.ts
@@ -6,22 +6,32 @@ import { dashboardMeta } from './dashboard.meta';
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
 const moduleName = '@openmrs/esm-service-queues-app';
+const swrRefreshInternalMs = 60000; // milliseconds
 
 const options = {
-  featureName: 'outpatient',
+  featureName: 'service-queues',
   moduleName,
 };
 
-export const root = getAsyncLifecycle(() => import('./root.component'), options);
+export const root = getAsyncLifecycle(() => import('./root.component'), {
+  featureName: 'service-queues-app-root',
+  moduleName,
+  swrConfig: {
+    refreshInterval: swrRefreshInternalMs,
+  },
+});
 
 export const queueTableByStatusMenu = getAsyncLifecycle(
   () => import('./queue-table/queue-table-by-status-menu.component'),
   options,
 );
-export const queueTableByStatusView = getAsyncLifecycle(
-  () => import('./views/queue-table-by-status-view.component'),
-  options,
-);
+export const queueTableByStatusView = getAsyncLifecycle(() => import('./views/queue-table-by-status-view.component'), {
+  featureName: 'queue-table-by-status-view',
+  moduleName,
+  swrConfig: {
+    refreshInterval: swrRefreshInternalMs,
+  },
+});
 
 export const queueList = getAsyncLifecycle(
   () => import('./queue-patient-linelists/queue-services-table.component'),

--- a/packages/esm-ward-app/src/index.ts
+++ b/packages/esm-ward-app/src/index.ts
@@ -15,6 +15,7 @@ const options = {
   featureName: 'ward',
   moduleName,
 };
+const swrRefreshInternalMs = 60000; // milliseconds
 
 export const root = getAsyncLifecycle(() => import('./root.component'), options);
 
@@ -114,14 +115,23 @@ export const createAdmissionEncounterWorkspace = getAsyncLifecycle(
   options,
 );
 
-export const defaultWardView = getAsyncLifecycle(
-  () => import('./ward-view/default-ward/default-ward-view.component'),
-  options,
-);
+export const defaultWardView = getAsyncLifecycle(() => import('./ward-view/default-ward/default-ward-view.component'), {
+  featureName: 'default-ward-view',
+  moduleName,
+  swrConfig: {
+    refreshInterval: swrRefreshInternalMs,
+  },
+});
 
 export const maternalWardView = getAsyncLifecycle(
   () => import('./ward-view/materal-ward/maternal-ward-view.component'),
-  options,
+  {
+    featureName: 'maternal-ward-view',
+    moduleName,
+    swrConfig: {
+      refreshInterval: swrRefreshInternalMs,
+    },
+  },
 );
 
 export const wardPatientWorkspaceBanner = getAsyncLifecycle(

--- a/packages/esm-ward-app/src/index.ts
+++ b/packages/esm-ward-app/src/index.ts
@@ -15,7 +15,7 @@ const options = {
   featureName: 'ward',
   moduleName,
 };
-const swrRefreshInternalMs = 60000; // milliseconds
+const swrRefreshIntervalInMs = 60000;
 
 export const root = getAsyncLifecycle(() => import('./root.component'), options);
 
@@ -119,7 +119,7 @@ export const defaultWardView = getAsyncLifecycle(() => import('./ward-view/defau
   featureName: 'default-ward-view',
   moduleName,
   swrConfig: {
-    refreshInterval: swrRefreshInternalMs,
+    refreshInterval: swrRefreshIntervalInMs,
   },
 });
 
@@ -129,7 +129,7 @@ export const maternalWardView = getAsyncLifecycle(
     featureName: 'maternal-ward-view',
     moduleName,
     swrConfig: {
-      refreshInterval: swrRefreshInternalMs,
+      refreshInterval: swrRefreshIntervalInMs,
     },
   },
 );

--- a/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/ward-view.component.tsx
@@ -1,5 +1,5 @@
 import { InlineNotification } from '@carbon/react';
-import { ExtensionSlot, useFeatureFlag } from '@openmrs/esm-framework';
+import { ExtensionSlot } from '@openmrs/esm-framework';
 import classNames from 'classnames';
 import React from 'react';
 import { useTranslation } from 'react-i18next';


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds SWR configuration to the service queues app and the ward app so that data is refreshed every minute. This keeps the data displayed in those apps' dashboards near real-time.

Testing done:
Verify that data is re-fetched in the ward app and the service queues app every minute.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4277

## Other
<!-- Anything not covered above -->
