### PR TITLE
(feat) Handle duplicate patient queue entries in the Add patient to queue form

### DIFF
--- a/packages/esm-service-queues-app/src/constants.ts
+++ b/packages/esm-service-queues-app/src/constants.ts
@@ -10,3 +10,6 @@ export const datePickerFormat = 'd/m/Y';
 export const time12HourFormatRegexPattern = '^(1[0-2]|0?[1-9]):[0-5][0-9]$';
 
 export const serviceQueuesPatientSearchWorkspace = 'create-queue-entry-workspace';
+
+// Error codes
+export const DUPLICATE_QUEUE_ENTRY_ERROR_CODE = '[queue.entry.duplicate.patient]';

--- a/packages/esm-service-queues-app/src/create-queue-entry/existing-visit-form/existing-visit-form.component.tsx
+++ b/packages/esm-service-queues-app/src/create-queue-entry/existing-visit-form/existing-visit-form.component.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useState } from 'react';
-import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonSet, Form, Row } from '@carbon/react';
 import { ExtensionSlot, useLayoutType, type Visit } from '@openmrs/esm-framework';

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -118,6 +118,8 @@
   "queueEntryAddedSuccessfully": "Queue entry added successfully",
   "queueEntryDeleteFailed": "Error deleting queue entry",
   "queueEntryDeleteSuccessful": "Queue entry deleted successfully",
+  "queueEntryDuplicateError": "Patient already in queue",
+  "queueEntryDuplicateMessage": "A queue entry for this patient already exists",
   "queueEntryEdited": "Queue entry edited",
   "queueEntryEditedSuccessfully": "Queue entry edited successfully",
   "queueEntryEditingFailed": "Error editing queue entry",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds specific error handling for duplicate patient queue entry errors. It does so by checking for the `[queue.entry.duplicate.patient]` code in the error response from the backend. If the error code is found, a snackbar notification is shown to alert the user that the patient is already in the queue.

## Screenshots

### Current behaviour

https://github.com/user-attachments/assets/5ec6b4e8-7d47-4a38-9efc-8dcaef7998b4

### New behaviour

https://github.com/user-attachments/assets/9eba3e8e-3a01-413d-bfbd-0735be60cee7

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
