### PR TITLE
(fix) Dedupe drug orders in expanded queue table current visit view

### DIFF
--- a/packages/esm-service-queues-app/src/current-visit/current-visit-summary.component.tsx
+++ b/packages/esm-service-queues-app/src/current-visit/current-visit-summary.component.tsx
@@ -27,7 +27,6 @@ const CurrentVisit: React.FC<CurrentVisitProps> = ({ patientUuid, visitUuid }) =
             {t('scheduledToday', 'Scheduled for today')} <Tag type="blue"> {t('onTime', 'On time')}</Tag>
           </div>
         </div>
-
         <div className={styles.visitContainer}>
           <CurrentVisitDetails encounters={visit.encounters} patientUuid={patientUuid} />
         </div>

--- a/packages/esm-service-queues-app/src/current-visit/current-visit.resource.ts
+++ b/packages/esm-service-queues-app/src/current-visit/current-visit.resource.ts
@@ -6,11 +6,9 @@ import { type ObsMetaInfo } from '../types/index';
 export function useVisit(visitUuid: string) {
   const customRepresentation =
     'custom:(uuid,encounters:(uuid,encounterDatetime,' +
-    'orders:(uuid,dateActivated,' +
-    'drug:(uuid,name,strength),doseUnits:(uuid,display),' +
-    'dose,route:(uuid,display),frequency:(uuid,display),' +
-    'duration,durationUnits:(uuid,display),numRefills,' +
-    'orderType:(uuid,display),orderer:(uuid,person:(uuid,display))),' +
+    // Use default representation for orders to safely include subclass-specific fields (e.g., DrugOrder)
+    // without requesting properties that are not present on other subclasses (e.g., TestOrder).
+    'orders,' +
     'obs:(uuid,concept:(uuid,display,conceptClass:(uuid,display)),' +
     'display,groupMembers:(uuid,concept:(uuid,display),' +
     'value:(uuid,display)),value),encounterType:(uuid,display),' +
@@ -42,29 +40,23 @@ export function calculateBMI(weight: number, height: number): number {
   }
 }
 
-export function assessValue(value: number, range: ObsMetaInfo): ObservationInterpretation {
-  if (range?.hiCritical && value >= range.hiCritical) {
-    return 'critically_high';
-  }
+export function assessValue(value: number | undefined, range?: ObsMetaInfo): ObservationInterpretation {
+  if (range && value) {
+    if (range.hiCritical && value >= range.hiCritical) {
+      return 'critically_high';
+    }
 
-  if (range?.hiAbsolute && value >= range.hiAbsolute) {
-    return 'critically_high';
-  }
+    if (range.hiNormal && value > range.hiNormal) {
+      return 'high';
+    }
 
-  if (range?.hiNormal && value > range.hiNormal) {
-    return 'high';
-  }
+    if (range.lowCritical && value <= range.lowCritical) {
+      return 'critically_low';
+    }
 
-  if (range?.lowCritical && value <= range.lowCritical) {
-    return 'critically_low';
-  }
-
-  if (range?.lowAbsolute && value <= range.lowAbsolute) {
-    return 'critically_low';
-  }
-
-  if (range?.lowNormal && value < range.lowNormal) {
-    return 'low';
+    if (range.lowNormal && value < range.lowNormal) {
+      return 'low';
+    }
   }
 
   return 'normal';

--- a/packages/esm-service-queues-app/src/past-visit/past-visit-details/medications-list.component.tsx
+++ b/packages/esm-service-queues-app/src/past-visit/past-visit-details/medications-list.component.tsx
@@ -19,9 +19,18 @@ const Medications: React.FC<MedicationProps> = ({ medications }) => {
     );
   }
 
+  const drugOrders = medications.filter(
+    (m) => m.order?.orderType?.display === 'Drug Order' && m.order?.action !== 'DISCONTINUE',
+  );
+
+  // Only keep leaf orders (those not referenced by another order's previousOrder)
+  const medicationsToDisplay = drugOrders.filter(
+    (m) => !drugOrders.some((o2) => o2.order?.previousOrder?.uuid === m.order?.uuid),
+  );
+
   return (
     <div className={styles.medicationRecord}>
-      {medications.map(
+      {medicationsToDisplay.map(
         (medication) =>
           medication?.order?.dose && (
             <React.Fragment key={medication.order.uuid}>

--- a/packages/esm-service-queues-app/src/types/index.ts
+++ b/packages/esm-service-queues-app/src/types/index.ts
@@ -73,6 +73,10 @@ export interface Order {
   uuid: string;
   dateActivated: string;
   dateStopped?: Date | null;
+  action?: 'NEW' | 'REVISE' | 'DISCONTINUE' | 'RENEW' | string;
+  previousOrder?: {
+    uuid: string;
+  } | null;
   dose: number;
   dosingInstructions: string | null;
   dosingType?: 'org.openmrs.FreeTextDosingInstructions' | 'org.openmrs.SimpleDosingInstructions';


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Makes the following fixes to the expanded Queue table's current visit view:

- Show only Drug orders and exclude DISCONTINUE orders
- Keep only leaf orders (those not referenced by another order's previousOrder) to avoid showing duplicate orders
- Use the default orders representation to avoid requesting properties in the visit resource to avoid this error:

		```
		{
			"error": { "message": "[converting class org.openmrs.Encounter to org.openmrs.module.webservices.rest.web.representation.CustomRepresentation@422aa88 => converting class org.openmrs.TestOrder to org.openmrs.module.webservices.rest.web.representation.CustomRepresentation@1da2e2aa => drug on class org.openmrs.TestOrder => Unknown property 'drug' on class 'class org.openmrs.TestOrder']", "code": "org.openmrs.module.webservices.rest.web.ConversionUtil:419", "detail": "org.openmrs.module.webservices.rest.web.response.ConversionException: converting class org.openmrs.Encounter to org.openmrs.module.webservices.rest.web.representation.CustomRepresentation@422aa88\n\tat org.openmrs.module.webservices.rest.web.ConversionUtil.convertToRepresentation(ConversionUtil.java:419)\n\tat org.openmrs.module.webservices.rest.web.ConversionUtil.convertToRepresentation(ConversionUtil.java:380)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription$Property.evaluate(DelegatingResourceDescription.java:249)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingConverter.convertDelegateToRepresentation(BaseDelegatingConverter.java:143)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource.asRepresentation(BaseDelegatingResource.java:414)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource.retrieve(DelegatingCrudResource.java:56)\n\tat org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceController.retrieve(MainResourceController.java:74)\n\tat jdk.internal.reflect.GeneratedMethodAccessor914.invoke(Unknown Source)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:569)\n\tat org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)\n\tat org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150)\n\tat org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)\n\tat org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895)\n\tat org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)\n\tat org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)\n\tat org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1072)\n\tat org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:965)\n\tat org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)\n\tat org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:529)\n\tat org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:623)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:199)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.openmrs.module.web.filter.ForcePasswordChangeFilter.doFilter(ForcePasswordChangeFilter.java:61)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.openmrs.module.web.filter.ModuleFilterChain.doFilter(ModuleFilterChain.java:73)\n\tat org.openmrs.web.xss.XSSFilter.doFilter(XSSFilter.java:39)\n\tat org.openmrs.module.web.filter.ModuleFilterChain.doFilter(ModuleFilterChain.java:71)\n\tat org.openmrs.web.filter.GZIPFilter.doFilterInternal(GZIPFilter.java:66)\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)\n\tat org.openmrs.module.web.filter.ModuleFilterChain.doFilter(ModuleFilterChain.java:71)\n\tat org.openmrs.module.webservices.rest.web.filter.AuthorizationFilter.doFilter(AuthorizationFilter.java:121)\n\tat org.openmrs.module.web.filter.ModuleFilterChain.doFilter(ModuleFilterChain.java:71)\n\tat org.openmrs.module.webservices.rest.web.filter.ContentTypeFilter.doFilter(ContentTypeFilter.java:64)\n\tat org.openmrs.module.web.filter.ModuleFilterChain.doFilter(ModuleFilterChain.java:71)\n\tat org.springframework.web.filter.ShallowEtagHeaderFilter.doFilterInternal(ShallowEtagHeaderFilter.java:106)\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)\n\tat org.openmrs.module.web.filter.ModuleFilterChain.doFilter(ModuleFilterChain.java:71)\n\tat org.openmrs.module.authentication.web.ForcePasswordChangeFilter.doFilter(ForcePasswordChangeFilter.java:68)\n\tat org.openmrs.module.web.filter.ModuleFilterChain.doFilter(ModuleFilterChain.java:71)\n\tat org.openmrs.module.authentication.web.AuthenticationFilter.doFilter(AuthenticationFilter.java:165)\n\tat org.openmrs.module.web.filter.ModuleFilterChain.doFilter(ModuleFilterChain.java:71)\n\tat org.openmrs.module.web.filter.ModuleFilter.doFilter(ModuleFilter.java:57)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.owasp.csrfguard.CsrfGuardFilter.handleSession(CsrfGuardFilter.java:107)\n\tat org.owasp.csrfguard.CsrfGuardFilter.doFilter(CsrfGuardFilter.java:97)\n\tat org.owasp.csrfguard.CsrfGuardFilter.doFilter(CsrfGuardFilter.java:68)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.openmrs.web.filter.OpenmrsFilter.doFilterInternal(OpenmrsFilter.java:114)\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.openmrs.web.filter.CookieClearingFilter.doFilterInternal(CookieClearingFilter.java:77)\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.springframework.orm.hibernate5.support.OpenSessionInViewFilter.doFilterInternal(OpenSessionInViewFilter.java:156)\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.springframework.web.multipart.support.MultipartFilter.doFilterInternal(MultipartFilter.java:125)\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.openmrs.web.filter.StartupFilter.doFilter(StartupFilter.java:117)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.openmrs.web.filter.StartupFilter.doFilter(StartupFilter.java:117)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.openmrs.web.filter.StartupFilter.doFilter(StartupFilter.java:117)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)\n\tat org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)\n\tat org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:168)\n\tat org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)\n\tat org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:168)\n\tat org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)\n\tat org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482)\n\tat org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:130)\n\tat org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)\n\tat org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:656)\n\tat org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)\n\tat org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:346)\n\tat org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:397)\n\tat org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)\n\tat org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:935)\n\tat org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1826)\n\tat org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)\n\tat org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1189)\n\tat org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:658)\n\tat org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)\n\tat java.base/java.lang.Thread.run(Thread.java:840)\nCaused by: org.openmrs.module.webservices.rest.web.response.ConversionException: converting class org.openmrs.TestOrder to org.openmrs.module.webservices.rest.web.representation.CustomRepresentation@1da2e2aa\n\tat org.openmrs.module.webservices.rest.web.ConversionUtil.convertToRepresentation(ConversionUtil.java:419)\n\tat org.openmrs.module.webservices.rest.web.ConversionUtil.convertToRepresentation(ConversionUtil.java:380)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription$Property.evaluate(DelegatingResourceDescription.java:249)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingConverter.convertDelegateToRepresentation(BaseDelegatingConverter.java:143)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource.asRepresentation(BaseDelegatingResource.java:414)\n\tat org.openmrs.module.webservices.rest.web.ConversionUtil.convertToRepresentation(ConversionUtil.java:416)\n\t... 101 more\nCaused by: org.openmrs.module.webservices.rest.web.response.ConversionException: drug on class org.openmrs.TestOrder\n\tat org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource.getProperty(BaseDelegatingResource.java:689)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription$Property.evaluate(DelegatingResourceDescription.java:245)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingConverter.convertDelegateToRepresentation(BaseDelegatingConverter.java:143)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource.asRepresentation(BaseDelegatingResource.java:414)\n\tat org.openmrs.module.webservices.rest.web.ConversionUtil.convertToRepresentation(ConversionUtil.java:416)\n\t... 106 more\nCaused by: java.lang.NoSuchMethodException: Unknown property 'drug' on class 'class org.openmrs.TestOrder'\n\tat org.apache.commons.beanutils.PropertyUtilsBean.getSimpleProperty(PropertyUtilsBean.java:1270)\n\tat org.apache.commons.beanutils.PropertyUtilsBean.getNestedProperty(PropertyUtilsBean.java:809)\n\tat org.apache.commons.beanutils.PropertyUtilsBean.getProperty(PropertyUtilsBean.java:885)\n\tat org.apache.commons.beanutils.PropertyUtils.getProperty(PropertyUtils.java:464)\n\tat org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource.getProperty(BaseDelegatingResource.java:683)\n\t... 110 more\n" } } 
		```

## Screenshots

### Before

https://github.com/user-attachments/assets/a8980bd1-fc13-4a28-bfb7-2eb789e8fa10

### After

https://github.com/user-attachments/assets/22674322-51fa-4c23-ab43-12156d410270

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
