### PR TITLE
(chore) Pin peerDependencies to latest tooling and framework version

### DIFF
--- a/packages/esm-active-visits-app/package.json
+++ b/packages/esm-active-visits-app/package.json
@@ -42,7 +42,7 @@
     "lodash-es": "^4.17.15"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "dayjs": "1.x",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/packages/esm-appointments-app/package.json
+++ b/packages/esm-appointments-app/package.json
@@ -48,8 +48,8 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
-    "@openmrs/esm-patient-common-lib": "10.x",
+    "@openmrs/esm-framework": "7.x",
+    "@openmrs/esm-patient-common-lib": "11.x",
     "react": "18.x",
     "react-dom": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-bed-management-app/package.json
+++ b/packages/esm-bed-management-app/package.json
@@ -45,7 +45,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-home-app/package.json
+++ b/packages/esm-home-app/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/openmrs/openmrs-esm-home/issues"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "react": "18.x",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/packages/esm-patient-list-management-app/package.json
+++ b/packages/esm-patient-list-management-app/package.json
@@ -45,7 +45,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "react": "18.x",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/packages/esm-patient-registration-app/package.json
+++ b/packages/esm-patient-registration-app/package.json
@@ -45,7 +45,7 @@
     "yup": "^0.29.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-i18next": "11.x",

--- a/packages/esm-patient-search-app/package.json
+++ b/packages/esm-patient-search-app/package.json
@@ -43,7 +43,7 @@
     "react-hook-form": "^7.54.0"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/packages/esm-service-queues-app/package.json
+++ b/packages/esm-service-queues-app/package.json
@@ -45,7 +45,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/packages/esm-ward-app/package.json
+++ b/packages/esm-ward-app/package.json
@@ -44,7 +44,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3132,7 +3132,7 @@ __metadata:
     lodash-es: "npm:^4.17.15"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     dayjs: 1.x
     react: ^18.1.0
     react-dom: ^18.1.0
@@ -3207,8 +3207,8 @@ __metadata:
     yup: "npm:^0.32.11"
     zod: "npm:^3.24.1"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
-    "@openmrs/esm-patient-common-lib": 10.x
+    "@openmrs/esm-framework": 7.x
+    "@openmrs/esm-patient-common-lib": 11.x
     react: 18.x
     react-dom: 18.x
     react-i18next: 11.x
@@ -3229,7 +3229,7 @@ __metadata:
     webpack: "npm:^5.99.9"
     zod: "npm:^3.24.1"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -3390,7 +3390,7 @@ __metadata:
   dependencies:
     webpack: "npm:^5.74.0"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     react: 18.x
     react-i18next: 11.x
     react-router-dom: 6.x
@@ -3453,7 +3453,7 @@ __metadata:
     webpack: "npm:^5.99.9"
     zod: "npm:^3.24.1"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     react: 18.x
     react-i18next: 11.x
     react-router-dom: 6.x
@@ -3536,7 +3536,7 @@ __metadata:
     webpack: "npm:^5.99.9"
     yup: "npm:^0.29.1"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     dayjs: 1.x
     react: 18.x
     react-i18next: 11.x
@@ -3555,7 +3555,7 @@ __metadata:
     react-hook-form: "npm:^7.54.0"
     webpack: "npm:^5.99.9"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     react: ^18.1.0
     react-i18next: 11.x
     react-router-dom: 6.x
@@ -3619,7 +3619,7 @@ __metadata:
     webpack: "npm:^5.99.9"
     zod: "npm:^3.24.1"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     react: ^18.1.0
     react-i18next: 11.x
     react-router-dom: 6.x
@@ -3715,7 +3715,7 @@ __metadata:
     webpack: "npm:^5.99.9"
     zod: "npm:^3.24.1"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     react: ^18.1.0
     react-i18next: 11.x
     react-router-dom: 6.x


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This fix ensures that the common lib, framework and core tooling versions referenced in peerDependencies is always up-to-date, reducing the likelihood of unusual behaviour in the app due to package version mismatches.

## Screenshots

### Console logs from test3.openmrs.org

<img width="1082" height="1276" alt="CleanShot 2025-08-13 at 14 58 18@2x" src="https://github.com/user-attachments/assets/217d47ad-0d1f-4045-bee6-d08a6bf99f99" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
