### PR TITLE
(feat) O3-4985: Handle duplicate queue entries when transitioning patients between queues

### DIFF
--- a/packages/esm-service-queues-app/src/modals/queue-entry-actions-modal.component.tsx
+++ b/packages/esm-service-queues-app/src/modals/queue-entry-actions-modal.component.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo, useState } from 'react';
+import classNames from 'classnames';
 import dayjs from 'dayjs';
 import {
   Button,
   Checkbox,
+  Dropdown,
   InlineNotification,
   ModalBody,
   ModalFooter,
@@ -14,20 +16,17 @@ import {
   TextArea,
   TimePicker,
   TimePickerSelect,
-  Dropdown,
-  Tag,
 } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { OpenmrsDatePicker, showSnackbar, type FetchResponse, useConfig } from '@openmrs/esm-framework';
-import { time12HourFormatRegexPattern } from '../constants';
 import { convertTime12to24, type amPm } from '../helpers/time-helpers';
-import { useMutateQueueEntries } from '../hooks/useQueueEntries';
-import { useQueues } from '../hooks/useQueues';
+import { DUPLICATE_QUEUE_ENTRY_ERROR_CODE, time12HourFormatRegexPattern } from '../constants';
 import { type ConfigObject } from '../config-schema';
 import { type QueueEntry } from '../types';
-import styles from './queue-entry-actions.scss';
-import classNames from 'classnames';
+import { useMutateQueueEntries } from '../hooks/useQueueEntries';
+import { useQueues } from '../hooks/useQueues';
 import QueuePriority from '../queue-table/components/queue-priority.component';
+import styles from './queue-entry-actions.scss';
 
 interface QueueEntryActionModalProps {
   queueEntry: QueueEntry;
@@ -103,8 +102,15 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({
   });
   const { queues } = useQueues();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submissionError, setSubmissionError] = useState<{
+    type: 'duplicate' | 'error';
+    message: string;
+    title?: string;
+  } | null>(null);
 
   const selectedQueue = queues.find((q) => q.uuid == formState.selectedQueue);
+
+  const clearSubmissionError = () => setSubmissionError(null);
 
   const statuses = selectedQueue?.allowedStatuses;
   const hasNoStatusesConfigured = selectedQueue && statuses.length == 0;
@@ -112,6 +118,7 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({
   const hasNoPrioritiesConfigured = selectedQueue && priorities.length == 0;
 
   const setSelectedQueueUuid = (selectedQueueUuid: string) => {
+    clearSubmissionError();
     const newSelectedQueue = queues.find((q) => q.uuid == selectedQueueUuid);
     const { allowedStatuses, allowedPriorities } = newSelectedQueue;
     const newQueueHasCurrentPriority = allowedPriorities.find((s) => s.uuid == formState.selectedPriority);
@@ -128,10 +135,12 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({
   };
 
   const setSelectedPriorityUuid = (selectedPriorityUuid: string) => {
+    clearSubmissionError();
     setFormState({ ...formState, selectedPriority: selectedPriorityUuid });
   };
 
   const setSelectedStatusUuid = (selectedStatusUuid: string) => {
+    clearSubmissionError();
     setFormState({ ...formState, selectedStatus: selectedStatusUuid });
   };
 
@@ -155,10 +164,6 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({
     setFormState({ ...formState, modifyDefaultTransitionDateTime });
   };
 
-  const findPriorityIndex = (uuid: string) => {
-    return priorities.findIndex((p) => p.uuid === uuid);
-  };
-
   const submitForm = (e) => {
     e.preventDefault();
     setIsSubmitting(true);
@@ -179,11 +184,22 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({
         }
       })
       .catch((error) => {
-        showSnackbar({
-          title: submitFailureTitle,
-          kind: 'error',
-          subtitle: error?.message,
-        });
+        const errorMessage = error?.responseBody?.error?.message || error?.message || '';
+        const isDuplicateQueueEntryError = errorMessage.includes(DUPLICATE_QUEUE_ENTRY_ERROR_CODE);
+
+        if (isDuplicateQueueEntryError) {
+          setSubmissionError({
+            type: 'duplicate',
+            message: t('duplicateQueueEntry', 'This patient is already in the selected queue.'),
+            title: t('patientAlreadyInQueue', 'Patient already in queue'),
+          });
+        } else {
+          setSubmissionError({
+            type: 'error',
+            message: error?.message || t('unknownError', 'An unknown error occurred'),
+            title: submitFailureTitle,
+          });
+        }
       })
       .finally(() => {
         setIsSubmitting(false);
@@ -397,6 +413,16 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({
                 </div>
               )}
             </section>
+
+            {submissionError && (
+              <InlineNotification
+                kind="error"
+                lowContrast={false}
+                title={submissionError.title || t('queueEntryError', 'Error updating queue entry')}
+                subtitle={submissionError.message}
+                onClose={() => setSubmissionError(null)}
+              />
+            )}
           </Stack>
         </div>
       </ModalBody>

--- a/packages/esm-service-queues-app/src/modals/queue-entry-actions.test.tsx
+++ b/packages/esm-service-queues-app/src/modals/queue-entry-actions.test.tsx
@@ -4,8 +4,9 @@ import { type FetchResponse, openmrsFetch, showSnackbar } from '@openmrs/esm-fra
 import { screen } from '@testing-library/react';
 import { mockQueues, mockQueueEntryAlice } from '__mocks__';
 import { renderWithSwr } from 'tools';
-import UndoTransitionQueueEntryModal from './undo-transition-queue-entry.modal';
 import DeleteQueueEntryModal from './delete-queue-entry.modal';
+import QueueEntryActionModal from './queue-entry-actions-modal.component';
+import UndoTransitionQueueEntryModal from './undo-transition-queue-entry.modal';
 
 const mockOpenmrsFetch = jest.mocked(openmrsFetch);
 
@@ -13,6 +14,43 @@ jest.mock('../hooks/useQueues', () => {
   return {
     useQueues: jest.fn().mockReturnValue({
       queues: mockQueues,
+    }),
+  };
+});
+
+jest.mock('../hooks/useQueueEntries', () => {
+  return {
+    useMutateQueueEntries: jest.fn().mockReturnValue({
+      mutateQueueEntries: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+  return {
+    ...originalModule,
+    useConfig: jest.fn().mockReturnValue({
+      showQueueNumber: true,
+      showPriorityComment: true,
+      showTransitionDateTime: true,
+      priorityConfigs: [
+        {
+          conceptUuid: 'f4620bfa-3625-4883-bd3f-84c2cce14470',
+          style: null,
+          color: 'green',
+        },
+        {
+          conceptUuid: 'dc3492ef-24a5-4fd9-b58d-4fd2acf7071f',
+          style: null,
+          color: 'orange',
+        },
+      ],
+      concepts: {
+        defaultPriorityConceptUuid: 'f4620bfa-3625-4883-bd3f-84c2cce14470',
+        defaultStatusConceptUuid: '51ae5e4d-b72b-4912-bf31-a17efb690aeb',
+        defaultTransitionStatus: 'ca7494ae-437f-4fd0-8aae-b88b9a2ba47d',
+      },
     }),
   };
 });
@@ -79,5 +117,227 @@ describe('VoidQueueEntryModal', () => {
 
     expect(mockOpenmrsFetch).toHaveBeenCalled();
     expect(showSnackbar).toHaveBeenCalled();
+  });
+});
+
+describe('QueueEntryActionModal', () => {
+  const defaultProps = {
+    queueEntry: mockQueueEntryAlice,
+    closeModal: jest.fn(),
+    modalParams: {
+      modalTitle: 'Test Modal',
+      modalInstruction: 'Test instruction',
+      submitButtonText: 'Submit',
+      submitSuccessTitle: 'Success',
+      submitSuccessText: 'Operation completed',
+      submitFailureTitle: 'Submission Failed',
+      submitAction: jest.fn(),
+      disableSubmit: jest.fn().mockReturnValue(false),
+      isEdit: false,
+      showQueuePicker: true,
+      showStatusPicker: true,
+    },
+  };
+
+  it('renders with correct content', () => {
+    renderWithSwr(<QueueEntryActionModal {...defaultProps} />);
+
+    expect(screen.getByText('Test instruction')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('shows inline error notification when submission fails with duplicate error', async () => {
+    const mockSubmitAction = jest.fn().mockRejectedValue({
+      responseBody: {
+        error: {
+          message: '[queue.entry.duplicate.patient]',
+        },
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithSwr(
+      <QueueEntryActionModal
+        {...defaultProps}
+        modalParams={{
+          ...defaultProps.modalParams,
+          submitAction: mockSubmitAction,
+        }}
+      />,
+    );
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await user.click(submitButton);
+
+    expect(await screen.findByText('This patient is already in the selected queue.')).toBeInTheDocument();
+    expect(screen.getByText('Patient already in queue')).toBeInTheDocument();
+  });
+
+  it('shows inline error notification when submission fails with generic error', async () => {
+    const mockSubmitAction = jest.fn().mockRejectedValue({
+      message: 'Network error occurred',
+    });
+
+    const user = userEvent.setup();
+    renderWithSwr(
+      <QueueEntryActionModal
+        {...defaultProps}
+        modalParams={{
+          ...defaultProps.modalParams,
+          submitAction: mockSubmitAction,
+        }}
+      />,
+    );
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await user.click(submitButton);
+
+    expect(await screen.findByText('Network error occurred')).toBeInTheDocument();
+    expect(screen.getByText('Submission Failed')).toBeInTheDocument();
+  });
+
+  it('clears error when user changes queue selection', async () => {
+    const mockSubmitAction = jest.fn().mockRejectedValue({
+      message: 'Test error',
+    });
+
+    const user = userEvent.setup();
+    renderWithSwr(
+      <QueueEntryActionModal
+        {...defaultProps}
+        modalParams={{
+          ...defaultProps.modalParams,
+          submitAction: mockSubmitAction,
+        }}
+      />,
+    );
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await user.click(submitButton);
+
+    expect(await screen.findByText('Test error')).toBeInTheDocument();
+
+    const firstQueueOption = screen.getByRole('radio', { name: 'Triage - Triage' });
+    await user.click(firstQueueOption);
+
+    expect(screen.queryByText('Test error')).not.toBeInTheDocument();
+  });
+
+  it('clears error when user changes priority', async () => {
+    const mockSubmitAction = jest.fn().mockRejectedValue({
+      message: 'Test error',
+    });
+
+    const user = userEvent.setup();
+    renderWithSwr(
+      <QueueEntryActionModal
+        {...defaultProps}
+        modalParams={{
+          ...defaultProps.modalParams,
+          submitAction: mockSubmitAction,
+        }}
+      />,
+    );
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await user.click(submitButton);
+
+    expect(await screen.findByText('Test error')).toBeInTheDocument();
+
+    const priorityOption = screen.getByRole('radio', { name: 'Non urgent' });
+    await user.click(priorityOption);
+
+    expect(screen.queryByText('Test error')).not.toBeInTheDocument();
+  });
+
+  it('clears error when user changes status', async () => {
+    const mockSubmitAction = jest.fn().mockRejectedValue({
+      message: 'Test error',
+    });
+
+    const user = userEvent.setup();
+    renderWithSwr(
+      <QueueEntryActionModal
+        {...defaultProps}
+        modalParams={{
+          ...defaultProps.modalParams,
+          submitAction: mockSubmitAction,
+        }}
+      />,
+    );
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await user.click(submitButton);
+
+    expect(await screen.findByText('Test error')).toBeInTheDocument();
+
+    const statusOption = screen.getByRole('radio', { name: 'Waiting' });
+    await user.click(statusOption);
+
+    expect(screen.queryByText('Test error')).not.toBeInTheDocument();
+  });
+
+  it('submits form successfully without errors', async () => {
+    const mockSubmitAction = jest.fn().mockResolvedValue({ status: 200 });
+    const closeModal = jest.fn();
+
+    const user = userEvent.setup();
+    renderWithSwr(
+      <QueueEntryActionModal
+        {...defaultProps}
+        closeModal={closeModal}
+        modalParams={{
+          ...defaultProps.modalParams,
+          submitAction: mockSubmitAction,
+        }}
+      />,
+    );
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await user.click(submitButton);
+
+    expect(mockSubmitAction).toHaveBeenCalled();
+    expect(closeModal).toHaveBeenCalled();
+  });
+
+  it('closes modal when cancel button is clicked', async () => {
+    const closeModal = jest.fn();
+    const user = userEvent.setup();
+
+    renderWithSwr(<QueueEntryActionModal {...defaultProps} closeModal={closeModal} />);
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await user.click(cancelButton);
+
+    expect(closeModal).toHaveBeenCalled();
+  });
+
+  it('allows user to close error notification', async () => {
+    const mockSubmitAction = jest.fn().mockRejectedValue({
+      message: 'Test error',
+    });
+
+    const user = userEvent.setup();
+    renderWithSwr(
+      <QueueEntryActionModal
+        {...defaultProps}
+        modalParams={{
+          ...defaultProps.modalParams,
+          submitAction: mockSubmitAction,
+        }}
+      />,
+    );
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await user.click(submitButton);
+
+    const errorNotification = await screen.findByText('Test error');
+    expect(errorNotification).toBeInTheDocument();
+
+    const closeButton = screen.getByRole('button', { name: 'close notification' });
+    await user.click(closeButton);
+
+    expect(screen.queryByText('Test error')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary

Augments the queue entry actions modal to handle duplicate queue entries when transitioning a patient to a different queue. Following https://github.com/openmrs/openmrs-module-queue/commit/4dd38879c77fd8c6193914b65e7e4e5e0dc5529e, the queue module now prevents ending existing queue entries when transitioning patients to different queues if they already have an entry in the target queue. This PR also:

- Replaces snackbar notifications with inline error handling for better error visibility
- Extends the `QueueEntryActionModal` test suite to cover the new error handling logic

## Screenshots
https://github.com/user-attachments/assets/d1d3f744-7d1d-4589-ae5f-116cf652aedb

## Related Issue
https://openmrs.atlassian.net/browse/O3-4985

## Other
<!-- Anything not covered above -->
