### PR TITLE
(fix) O3-5007: Enable workspace functionality for Start Visit button in patient search

### DIFF
--- a/packages/esm-patient-search-app/src/root.component.tsx
+++ b/packages/esm-patient-search-app/src/root.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import PatientSearchPageComponent from './patient-search-page/patient-search-page.component';
 import { WorkspaceContainer } from '@openmrs/esm-framework';
+import PatientSearchPageComponent from './patient-search-page/patient-search-page.component';
 
 const PatientSearchRootComponent: React.FC = () => {
   return (

--- a/packages/esm-patient-search-app/src/root.component.tsx
+++ b/packages/esm-patient-search-app/src/root.component.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import PatientSearchPageComponent from './patient-search-page/patient-search-page.component';
+import { WorkspaceContainer } from '@openmrs/esm-framework';
 
 const PatientSearchRootComponent: React.FC = () => {
   return (
@@ -8,6 +9,7 @@ const PatientSearchRootComponent: React.FC = () => {
       <Routes>
         <Route path="search" element={<PatientSearchPageComponent />} />
       </Routes>
+      <WorkspaceContainer contextKey="search" />
     </BrowserRouter>
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

The Start Visit button in the advanced patient search was calling `launchWorkspace()` from the patient chart app to launch the Visit form, but that was failing silently because patient search lacked a `WorkspaceContainer` in which to render the workspace. 

This PR registers a `WorkspaceContainer` in the Patient search app with the "search" `contextKey`. This enables launching workspaces directly from the Search app.

## Screenshots

https://github.com/user-attachments/assets/ab90dea2-6751-460d-842f-c5e9a4b06fbc

## Related Issue
https://issues.openmrs.org/browse/O3-5007

## Other
<!-- Anything not covered above -->
