### PR TITLE
(fix) O3-5014: Surface actual error messages from appointment status change API

### DIFF
--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-base.component.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-base.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Button, ContentSwitcher, DataTableSkeleton, InlineLoading, Layer, Switch, Tile } from '@carbon/react';
@@ -28,13 +28,17 @@ const PatientAppointmentsBase: React.FC<PatientAppointmentsBaseProps> = ({ patie
   const [switchedView, setSwitchedView] = useState(false);
 
   const [contentSwitcherValue, setContentSwitcherValue] = useState(0);
-  const startDate = dayjs(new Date().toISOString()).subtract(6, 'month').toISOString();
+  const startDate = useMemo(() => dayjs().subtract(6, 'month').toISOString(), []);
   const {
     data: appointmentsData,
     error,
     isLoading,
     isValidating,
-  } = usePatientAppointments(patientUuid, startDate, new AbortController());
+  } = usePatientAppointments(
+    patientUuid,
+    startDate,
+    useMemo(() => new AbortController(), []),
+  );
 
   const handleLaunchAppointmentsForm = () => {
     if (
@@ -114,6 +118,7 @@ const PatientAppointmentsBase: React.FC<PatientAppointmentsBaseProps> = ({ patie
               </Layer>
             );
           }
+
           if (contentSwitcherValue === AppointmentTypes.TODAY) {
             if (appointmentsData.todaysAppointments?.length) {
               return (

--- a/packages/esm-appointments-app/src/patient-appointments/patient-upcoming-appointments-card.component.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-upcoming-appointments-card.component.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import {
   InlineLoading,
@@ -11,12 +12,11 @@ import {
   StructuredListWrapper,
 } from '@carbon/react';
 import { formatDate, parseDate, showSnackbar, type Visit } from '@openmrs/esm-framework';
-import { changeAppointmentStatus, usePatientAppointments } from './patient-appointments.resource';
 import { ErrorState } from '@openmrs/esm-patient-common-lib';
-import styles from './patient-upcoming-appointments-card.scss';
-import dayjs from 'dayjs';
+import { changeAppointmentStatus, usePatientAppointments } from './patient-appointments.resource';
 import { type Appointment } from '../types';
 import { useMutateAppointments } from '../form/appointments-form.resource';
+import styles from './patient-upcoming-appointments-card.scss';
 
 interface VisitFormCallbacks {
   onVisitCreatedOrUpdated: (visit: Visit) => Promise<any>;
@@ -44,7 +44,7 @@ const PatientUpcomingAppointmentsCard: React.FC<PatientUpcomingAppointmentsProps
   patientChartConfig,
 }) => {
   const { t } = useTranslation();
-  const startDate = dayjs(new Date().toISOString()).subtract(6, 'month').toISOString();
+  const startDate = useMemo(() => dayjs().subtract(6, 'month').toISOString(), []);
   const headerTitle = t('upcomingAppointments', 'Upcoming appointments');
   const [selectedAppointment, setSelectedAppointment] = useState<Appointment>(null);
   const { mutateAppointments } = useMutateAppointments();
@@ -102,12 +102,13 @@ const PatientUpcomingAppointmentsCard: React.FC<PatientUpcomingAppointmentsProps
   };
 
   if (!patientChartConfig.showUpcomingAppointments) {
-    return <></>;
+    return null;
   }
 
   if (error) {
     return <ErrorState headerTitle={headerTitle} error={error} />;
   }
+
   if (isLoading) {
     return (
       <span>
@@ -159,11 +160,11 @@ const PatientUpcomingAppointmentsCard: React.FC<PatientUpcomingAppointmentsProps
 
   return (
     <InlineNotification
-      kind={'info'}
-      lowContrast
       className={styles.inlineNotification}
-      title={t('upcomingAppointments', 'Upcoming appointments')}
+      kind="info"
+      lowContrast
       subtitle={t('noUpcomingAppointments', 'No upcoming appointments found')}
+      title={t('upcomingAppointments', 'Upcoming appointments')}
     />
   );
 };

--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -149,6 +149,7 @@
   "todays": "Today's",
   "TUE": "TUE",
   "type": "Type",
+  "unknownError": "An unknown error occurred",
   "unscheduled": "Unscheduled",
   "unscheduledAppointments": "Unscheduled appointments",
   "unscheduledAppointments_lower": "unscheduled appointments",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Previously, when users attempted to cancel missed appointments, generic error messages were displayed instead of the specific backend validation errors. Now the actual API exception message is properly extracted and shown to users.

- Extract error messages from responseBody.error.message chain
- Remove square brackets from backend error formatting
- Surface specific validation errors like "Appointment status can not be changed from Missed to Cancelled"
- Fix SWR cache invalidation issues causing premature UI updates
- Enable retry capability by resetting loading state in error handler
- Modernize error handling with async/await pattern

Fixes issue where backend validation errors (e.g., missed appointments cannot be cancelled due to status sequence rules) were not properly communicated to users.

## Screenshots

https://github.com/user-attachments/assets/bb59dcd7-15eb-4854-a8aa-27ebc9659d23

## Related Issue
https://openmrs.atlassian.net/browse/O3-5014

## Other
<!-- Anything not covered above -->
