### PR TITLE
(feat) O3-5024 Ward App - provide option to transfer mother and child…

### DIFF
--- a/packages/esm-ward-app/src/types/index.ts
+++ b/packages/esm-ward-app/src/types/index.ts
@@ -52,6 +52,12 @@ export type WardPatient = {
 
 export interface WardPatientWorkspaceProps extends DefaultWorkspaceProps {
   wardPatient: WardPatient;
+
+  /**
+   * Related patients that are in the same bed as wardPatient. On transfer or bed swap
+   * these related patients have the option to be transferred / swapped together
+   */
+  relatedTransferPatients?: WardPatient[];
 }
 
 // server-side types defined in openmrs-module-bedmanagement:

--- a/packages/esm-ward-app/src/ward-patient-card/ward-patient-card.component.tsx
+++ b/packages/esm-ward-app/src/ward-patient-card/ward-patient-card.component.tsx
@@ -7,9 +7,15 @@ import styles from './ward-patient-card.scss';
 interface Props {
   children: ReactNode;
   wardPatient: WardPatient;
+
+  /**
+   * Related patients that are in the same bed as wardPatient. On transfer or bed swap
+   * these related patients have the option to be transferred / swapped together
+   */
+  relatedTransferPatients?: WardPatient[];
 }
 
-const WardPatientCard: React.FC<Props> = ({ children, wardPatient }) => {
+const WardPatientCard: React.FC<Props> = ({ children, wardPatient, relatedTransferPatients }) => {
   const { patient } = wardPatient;
 
   return (
@@ -23,6 +29,7 @@ const WardPatientCard: React.FC<Props> = ({ children, wardPatient }) => {
               wardPatient,
               patient,
               patientUuid: patient.uuid,
+              relatedTransferPatients,
             },
             onWorkspaceGroupLaunch: () => {
               const store = getPatientChartStore();

--- a/packages/esm-ward-app/src/ward-view/materal-ward/maternal-ward-patient-card.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/materal-ward/maternal-ward-patient-card.component.tsx
@@ -42,7 +42,7 @@ const MaternalWardPatientCard: React.FC<MaternalWardPatientCardProps> = (props) 
 
   const card = (
     <>
-      <WardPatientCard wardPatient={wardPatient}>
+      <WardPatientCard wardPatient={wardPatient} relatedTransferPatients={childrenOfWardPatientInSameBed}>
         <MaternalWardPatientCardHeader {...{ wardPatient }} />
         <div className={classNames(styles.wardPatientCardRow, styles.dotSeparatedChildren)}>
           <WardPatientTimeOnWard
@@ -55,10 +55,15 @@ const MaternalWardPatientCard: React.FC<MaternalWardPatientCardProps> = (props) 
         <MotherChildRow {...props} />
       </WardPatientCard>
       {childrenOfWardPatientInSameBed?.map((childWardPatient) => {
+        // for eahch child, includes the mother and the child's siblings
+        const relatedTransferPatients = [
+          wardPatient,
+          ...childrenOfWardPatientInSameBed.filter((wp) => wp.patient.uuid !== childWardPatient.patient.uuid),
+        ];
         return (
           <React.Fragment key={childWardPatient.patient.uuid}>
             <MotherChildBedShareDivider />
-            <WardPatientCard wardPatient={childWardPatient}>
+            <WardPatientCard wardPatient={childWardPatient} relatedTransferPatients={relatedTransferPatients}>
               <MaternalWardPatientCardHeader wardPatient={childWardPatient} />
               <PendingItemsRow id={'pending-items'} wardPatient={childWardPatient} />
             </WardPatientCard>

--- a/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-bed-swap-form.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-bed-swap-form.component.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, ButtonSet, Form, InlineNotification } from '@carbon/react';
+import { Button, ButtonSet, Form, InlineNotification , CheckboxGroup , Checkbox , Stack } from '@carbon/react';
 import classNames from 'classnames';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Controller, useForm } from 'react-hook-form';
@@ -10,11 +10,14 @@ import type { WardPatientWorkspaceProps, WardViewContext } from '../../types';
 import { assignPatientToBed, useCreateEncounter, removePatientFromBed } from '../../ward.resource';
 import BedSelector from '../bed-selector.component';
 import styles from './patient-transfer-swap.scss';
+import WardPatientIdentifier from '../../ward-patient-card/row-elements/ward-patient-identifier.component';
+import WardPatientName from '../../ward-patient-card/row-elements/ward-patient-name.component';
 
 export default function PatientBedSwapForm({
   promptBeforeClosing,
   closeWorkspaceWithSavedChanges,
   wardPatient,
+  relatedTransferPatients,
 }: WardPatientWorkspaceProps) {
   const { patient, visit } = wardPatient;
   const { t } = useTranslation();
@@ -24,6 +27,7 @@ export default function PatientBedSwapForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { wardPatientGroupDetails } = useAppContext<WardViewContext>('ward-view-context') ?? {};
   const { isLoading } = wardPatientGroupDetails?.admissionLocationResponse ?? {};
+  const [selectedRelatedPatient, setCheckedRelatedPatient] = useState<string[]>([]);
 
   const zodSchema = useMemo(
     () =>
@@ -56,27 +60,40 @@ export default function PatientBedSwapForm({
       const bedSelected = beds.find((bed) => bed.bedId === values.bedId);
       setIsSubmitting(true);
       setShowErrorNotifications(false);
-      createEncounter(patient, emrConfiguration.bedAssignmentEncounterType, visit.uuid)
-        .then(async (response) => {
+      const wardPatientsToSwap = [
+        wardPatient,
+        ...relatedTransferPatients.filter((rp) => selectedRelatedPatient.includes(rp.patient.uuid)),
+      ];
+
+      Promise.all(
+        wardPatientsToSwap.map(async (wardPatientToSwap) => {
+          const { patient: patientToSwap, visit: patientToSwapVisit } = wardPatientToSwap;
+
+          const response = await createEncounter(
+            patientToSwap,
+            emrConfiguration.bedAssignmentEncounterType,
+            patientToSwapVisit.uuid,
+          );
           if (response.ok) {
             if (bedSelected) {
-              return assignPatientToBed(values.bedId, patient.uuid, response.data.uuid);
+              return assignPatientToBed(values.bedId, patientToSwap.uuid, response.data.uuid);
             } else {
               // get the bed that the patient is currently assigned to
               const bedAssignedToPatient = beds.find((bed) =>
-                bed.patients.some((bedPatient) => bedPatient.uuid == patient.uuid),
+                bed.patients.some((bedPatient) => bedPatient.uuid == patientToSwap.uuid),
               );
               if (bedAssignedToPatient) {
-                return removePatientFromBed(bedAssignedToPatient.bedId, patient.uuid);
+                return removePatientFromBed(bedAssignedToPatient.bedId, patientToSwap.uuid);
               } else {
                 // no-op
                 return Promise.resolve({ ok: true });
               }
             }
           }
-        })
-        .then((response) => {
-          if (response && response?.ok) {
+        }),
+      )
+        .then((responses) => {
+          if (responses.every((response) => response?.ok)) {
             if (bedSelected) {
               showSnackbar({
                 kind: 'success',
@@ -118,7 +135,9 @@ export default function PatientBedSwapForm({
       t,
       wardPatientGroupDetails,
       closeWorkspaceWithSavedChanges,
-      visit.uuid,
+      selectedRelatedPatient,
+      relatedTransferPatients,
+      wardPatient,
     ],
   );
 
@@ -131,7 +150,7 @@ export default function PatientBedSwapForm({
     <Form
       onSubmit={handleSubmit(onSubmit, onError)}
       className={classNames(styles.formContainer, styles.workspaceContent)}>
-      <div>
+      <Stack gap={4}>
         {errorFetchingEmrConfiguration && (
           <div className={styles.formError}>
             <InlineNotification
@@ -146,22 +165,51 @@ export default function PatientBedSwapForm({
             />
           </div>
         )}
-        <h2 className={styles.productiveHeading02}>{t('selectABed', 'Select a bed')}</h2>
-        <Controller
-          name="bedId"
-          control={control}
-          render={({ field: { onChange, value }, fieldState: { error } }) => (
-            <BedSelector
-              beds={beds}
-              isLoadingBeds={isLoading}
-              currentPatient={patient}
-              selectedBedId={value}
-              error={error}
-              control={control}
-              onChange={onChange}
-            />
-          )}
-        />
+        {relatedTransferPatients?.length > 0 && (
+          <div>
+            <CheckboxGroup legendText={t('alsoSwap', 'Also swap:')}>
+              {relatedTransferPatients?.map(({ patient: relatedPatient }) => (
+                <div key={'also-swap-' + relatedPatient.uuid}>
+                  <Checkbox
+                    checked={selectedRelatedPatient.includes(relatedPatient.uuid)}
+                    className={styles.checkbox}
+                    id={relatedPatient.uuid}
+                    labelText={
+                      <div className={styles.relatedPatientTransferSwapOption}>
+                        <WardPatientName patient={relatedPatient} />
+                        <WardPatientIdentifier id="patient-identifier" patient={relatedPatient} />
+                      </div>
+                    }
+                    onChange={(_, { checked, id }) => {
+                      const currentValue = selectedRelatedPatient;
+                      setCheckedRelatedPatient(
+                        checked ? [...currentValue, id] : currentValue.filter((item) => item !== id),
+                      );
+                    }}
+                  />
+                </div>
+              ))}
+            </CheckboxGroup>
+          </div>
+        )}
+        <div className={styles.field}>
+          <h2 className={styles.productiveHeading02}>{t('selectABed', 'Select a bed')}</h2>
+          <Controller
+            name="bedId"
+            control={control}
+            render={({ field: { onChange, value }, fieldState: { error } }) => (
+              <BedSelector
+                beds={beds}
+                isLoadingBeds={isLoading}
+                currentPatient={patient}
+                selectedBedId={value}
+                error={error}
+                control={control}
+                onChange={onChange}
+              />
+            )}
+          />
+        </div>
         {showErrorNotifications && (
           <div className={styles.notifications}>
             {Object.values(errors).map((error) => (
@@ -169,7 +217,7 @@ export default function PatientBedSwapForm({
             ))}
           </div>
         )}
-      </div>
+      </Stack>
       <ButtonSet className={styles.buttonSet}>
         <Button size="xl" kind="secondary" onClick={closeWorkspaceWithSavedChanges}>
           {t('cancel', 'Cancel')}

--- a/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-transfer-swap.scss
+++ b/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-transfer-swap.scss
@@ -85,3 +85,9 @@
 .notifications {
   margin-top: layout.$spacing-05;
 }
+
+.relatedPatientTransferSwapOption {
+  display: flex;
+  flex-wrap: wrap;
+  gap: layout.$spacing-05;
+}

--- a/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-transfer-swap.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-transfer-swap.workspace.tsx
@@ -15,6 +15,10 @@ const TransferSection = {
 
 type TransferSectionValues = (typeof TransferSection)[keyof typeof TransferSection];
 
+/**
+ * This workspace opens the form to either transfer a patient to a different ward location
+ * or to change their currently assigned bed
+ */
 export default function PatientTransferAndSwapWorkspace(props: WardPatientWorkspaceProps) {
   const { t } = useTranslation();
   const [selectedSection, setSelectedSection] = useState<TransferSectionValues>(TransferSection.TRANSFER);

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -7,6 +7,8 @@
   "admitElsewhere": "Admit elsewhere",
   "admitPatient": "Admit patient",
   "admitting": "Admitting...",
+  "alsoSwap": "Also swap:",
+  "alsoTransfer": "Also transfer:",
   "backToSearchResults": "Back to search results",
   "bedShare": "Bed share",
   "bedSwap": "Bed swap",


### PR DESCRIPTION
… in same bed together

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR add the ability to transfer or bed swap mother and her newborns together without needing to fill out the transfer / bed swap form for each patient. 

Testing done:
- For mother + her newborns in the same bed:
  - able to create multiple transfer requests by selecting mother and her babies in the transfer form
  - able to bed swap mother and all of her babies by select mother and her babies in the bed swap form
- Tested that the option to select babies show up in transfer / bed swap form when we clicking on the mother's patient card
- Tested that the option to select the mother and her other newborns (siblings) show up in transfer / bed swap form when we clicking on a newborn's patient card

## Screenshots
<!-- Required if you are making UI changes. -->
See video:
https://github.com/user-attachments/assets/087c8094-0900-49b2-80a2-7da57a4ac739


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-5024

## Other
<!-- Anything not covered above -->
