### PR TITLE
(docs) O3-5053: Improve E2E test setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,35 @@ yarn test
 
 ### E2E tests
 
+#### Setup
+
+Before running the E2E tests, you need to set up the test environment.
+
+1.  **Install Playwright browsers:**
+
+    ```sh
+    npx playwright install
+    ```
+
+2.  **Set up environment variables:**
+
+    Copy the example environment file to a new `.env` file:
+
+    ```sh
+    cp example.env .env
+    ```
+
+    The `.env` file is used to configure the E2E tests.
+
+    *   If you are running against a local OpenMRS backend instance, modify the variables in this `.env` file to match your local development environment.
+    *   If you are *not* running a local OpenMRS backend instance, you should still create the `.env` file and set the `E2E_BASE_URL` variable within it to point to a remote instance. For example:
+
+        ```
+        E2E_BASE_URL=https://dev3.openmrs.org/openmrs
+        ```
+
+#### Running tests
+
 To run E2E tests, make sure the dev server is running by using:
 
 ```sh


### PR DESCRIPTION
### Requirements

* [x] This PR has a title that briefly describes the work done, including the ticket number. If there is a ticket, the PR title follows the [[conventional commit guidelines](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines)](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines).
* [ ] My work is based on designs, which are linked or shown either in the Jira ticket or in the description below.
* [x] My work includes tests or is validated by existing tests.

---

### Summary

The existing documentation for setting up and running End-to-End (E2E) tests was minimal and often caused confusion for developers, particularly around:

* Required environment variables
* Steps to target either a local or remote backend

This PR enhances the **E2E testing documentation** in the main `README.md` by:

* Providing clear, step-by-step instructions for configuring the Playwright E2E test environment
* Introducing a new `.env.example` file that explains the purpose and usage of all required environment variables
* Adding explicit instructions for running the tests against both a local backend and the `dev3` remote server
* Clarifying the exact commands needed to execute the tests

These improvements will streamline the developer workflow and make it easier to validate changes through E2E testing.

---

### Screenshots

*No UI changes.*

---

### Related Issue

[[Jira: O3-5053](https://openmrs.atlassian.net/browse/O3-5053)](https://openmrs.atlassian.net/browse/O3-5053)

