### PR TITLE
(test) Try to fix flakiness in ward patient notes spec

### DIFF
--- a/e2e/commands/bed-operations.ts
+++ b/e2e/commands/bed-operations.ts
@@ -63,7 +63,7 @@ export const deleteBed = async (api: APIRequestContext, bed: Bed) => {
 };
 
 export const deleteBedType = async (api: APIRequestContext, uuid: string) => {
-  const response = await api.delete(`bedtype/${uuid}`, { data: {} });
+  const response = await api.delete(`bedtype/${uuid}`);
   expect(response.ok()).toBeTruthy();
 };
 

--- a/e2e/commands/encounter-operations.ts
+++ b/e2e/commands/encounter-operations.ts
@@ -116,5 +116,5 @@ export const createBedAssignmentEncounter = async (
 };
 
 export const deleteEncounter = async (api: APIRequestContext, uuid: string) => {
-  await api.delete(`encounter/${uuid}`, { data: {} });
+  await api.delete(`encounter/${uuid}`);
 };

--- a/e2e/commands/patient-operations.ts
+++ b/e2e/commands/patient-operations.ts
@@ -56,6 +56,6 @@ export const getPatient = async (api: APIRequestContext, uuid: string): Promise<
 };
 
 export const deletePatient = async (api: APIRequestContext, uuid: string) => {
-  const response = await api.delete(`patient/${uuid}`, { data: {} });
+  const response = await api.delete(`patient/${uuid}`);
   await expect(response.ok()).toBeTruthy();
 };

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -22,5 +22,5 @@ export const api: WorkerFixture<APIRequestContext, PlaywrightWorkerArgs> = async
     },
   });
 
-  await use(ctx);
+  use(ctx);
 };

--- a/e2e/pages/appointments-page.ts
+++ b/e2e/pages/appointments-page.ts
@@ -6,6 +6,6 @@ export class AppointmentsPage {
   readonly appointmentsTable = () => this.page.getByTestId('table');
 
   async goto(uuid: string) {
-    await this.page.goto(`/openmrs/spa/patient/${uuid}/chart/Appointments`);
+    await this.page.goto(`${process.env.E2E_BASE_URL}/spa/patient/${uuid}/chart/Appointments`);
   }
 }

--- a/e2e/pages/chart-page.ts
+++ b/e2e/pages/chart-page.ts
@@ -6,6 +6,6 @@ export class PatientChartPage {
   readonly formsTable = () => this.page.getByRole('table', { name: /forms/i });
 
   async goTo(patientUuid: string) {
-    await this.page.goto('/openmrs/spa/patient/' + patientUuid + '/chart');
+    await this.page.goto(`${process.env.E2E_BASE_URL}/spa/patient/${patientUuid}/chart`);
   }
 }

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,6 +1,6 @@
 export * from './appointments-page';
+export * from './chart-page';
 export * from './home-page';
 export * from './patient-lists-page';
 export * from './registration-and-edit-page';
 export * from './ward-page';
-export * from './chart-page';

--- a/e2e/pages/ward-page.ts
+++ b/e2e/pages/ward-page.ts
@@ -31,11 +31,12 @@ export class WardPage {
 
   async waitForAdmissionRequest(patientName: string) {
     // Wait for the admission request to appear in the list
+    // Note: API polling in test setup ensures data is available, so shorter timeout is sufficient
     await this.page
       .locator('[class*="admissionRequestCard"]')
       .filter({ hasText: patientName })
       .first()
-      .waitFor({ state: 'visible', timeout: 30000 });
+      .waitFor({ state: 'visible', timeout: 5000 });
   }
 
   async clickPatientNotesButton() {

--- a/e2e/pages/ward-page.ts
+++ b/e2e/pages/ward-page.ts
@@ -29,6 +29,15 @@ export class WardPage {
     await this.manageAdmissionRequestsButton().click();
   }
 
+  async waitForAdmissionRequest(patientName: string) {
+    // Wait for the admission request to appear in the list
+    await this.page
+      .locator('[class*="admissionRequestCard"]')
+      .filter({ hasText: patientName })
+      .first()
+      .waitFor({ state: 'visible', timeout: 30000 });
+  }
+
   async clickPatientNotesButton() {
     await this.page.getByRole('button', { name: 'Patient Note' }).click();
   }

--- a/e2e/support/github/run-e2e-docker-env.sh
+++ b/e2e/support/github/run-e2e-docker-env.sh
@@ -4,28 +4,30 @@
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # create a temporary working directory
 working_dir=$(mktemp -d "${TMPDIR:-/tmp/}openmrs-e2e-frontends.XXXXXXXXXX")
+# cleanup temp directory on exit
+trap 'rm -rf "$working_dir"' EXIT
 # get a list of all the apps in this workspace
 apps=$(yarn workspaces list --json | jq -r 'if .location | test("-app$") then .name else empty end')
 # this array will hold all of the packed app names
 app_names=()
 
 echo "Creating packed archives of apps..."
-# for each app
+# Pack each app into a tarball
 for app in $apps
 do
-  # @openmrs/esm-whatever -> _openmrs_esm_whatever
+  # Convert @openmrs/esm-whatever to _openmrs_esm_whatever
   app_name=$(echo "$app" | tr '[:punct:]' '_');
-  # add to our array
+  # Add to our array
   app_names+=("$app_name.tgz");
-  # run yarn pack for our app and add it to the working directory
+  # Run yarn pack for our app and add it to the working directory
   yarn workspace "$app" pack -o "$working_dir/$app_name.tgz" >/dev/null;
 done;
 echo "Created packed app archives"
 
 echo "Creating dynamic spa-assemble-config.json..."
-# dynamically assemble our list of frontend modules, prepending the login app and
-# primary navigation apps; apps will all be in the /app directory of the Docker
-# container
+# Dynamically assemble our list of frontend modules, including core apps
+# (form-engine, home, patient-banner, patient-chart, patient-forms, primary-navigation)
+# and workspace apps; all apps will be in the /app directory of the Docker container
 jq -n \
   --arg apps "$apps" \
   --arg app_names "$(echo ${app_names[@]})" \
@@ -45,12 +47,12 @@ jq -n \
   )' | jq '{"frontendModules": .}' > "$working_dir/spa-assemble-config.json"
 echo "Created dynamic spa-assemble-config.json"
 
-echo "Copying Docker configuration..."
+echo "Copying Docker configuration files..."
 cp "$script_dir/Dockerfile" "$working_dir/Dockerfile"
 cp "$script_dir/docker-compose.yml" "$working_dir/docker-compose.yml"
 
 cd $working_dir
-echo "Starting Docker containers..."
+echo "Building and starting Docker containers..."
 # CACHE_BUST to ensure the assemble step is always run
 docker compose build --build-arg CACHE_BUST=$(date +%s) frontend
 docker compose up -d


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR sets up an API polling mechanism to try and ensure the admission request is indexed before proceeding with UI tests. This eliminates race conditions where the frontend loads before the backend has processed the disposition observation. This seems to be the root cause of the flakiness in the ward patient notes spec. Specific changes:

- Poll `/emrapi/inpatient/request` API up to 10 times with 1s intervals
- Add specific error message indicating backend indexing issues
- Include disposition type and location filters for more precise queries
- Remove arbitrary waitForTimeout that caused test flakiness

This seems to work better than the previous approach of using UI level waits and fixed timeouts.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
