### PR TITLE
(feat)O3-5068: darken placeholder and focus input on empty search

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Search } from '@carbon/react';
 import styles from './patient-search-bar.scss';
@@ -16,7 +16,9 @@ const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChild
   ({ buttonProps, initialSearchTerm = '', onChange, onClear, onSubmit, isCompact }, ref) => {
     const { t } = useTranslation();
     const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
+    const [isInputClicked, setIsInputClicked] = useState(false);
     const responsiveSize = isCompact ? 'sm' : 'lg';
+    const inputRef = useRef(null);
 
     const handleChange = useCallback(
       (value: string) => {
@@ -27,21 +29,33 @@ const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChild
     );
 
     const handleSubmit = useCallback(
-      (event: React.FormEvent<HTMLFormElement>) => {
+      (event) => {
         event.preventDefault();
         if (searchTerm && searchTerm.trim()) {
           onSubmit(searchTerm.trim());
+        } else {
+          setIsInputClicked(true);
+          inputRef.current.focus();
         }
       },
       [onSubmit, searchTerm],
     );
+
+    useEffect(() => {
+      if (isInputClicked) {
+        const timeout = setTimeout(() => {
+          setIsInputClicked(false);
+        }, 5000);
+        return () => clearTimeout(timeout);
+      }
+    }, [isInputClicked]);
 
     return (
       <form onSubmit={handleSubmit} className={styles.searchArea}>
         {/* data-tutorial-target attribute is essential for joyride in onboarding app ! */}
         <Search
           autoFocus
-          className={styles.patientSearchInput}
+          className={`${styles.patientSearchInput} ${isInputClicked ? styles.darkPlaceholder : ''}`}
           closeButtonLabelText={t('clearSearch', 'Clear')}
           data-testid="patientSearchBar"
           data-tutorial-target="patient-search-bar"
@@ -49,7 +63,7 @@ const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChild
           onChange={(event) => handleChange(event.target.value)}
           onClear={onClear}
           placeholder={t('searchForPatient', 'Search for a patient by name or identifier number')}
-          ref={ref}
+          ref={inputRef}
           size={responsiveSize}
           value={searchTerm}
         />

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.scss
@@ -6,3 +6,7 @@
   justify-content: center;
   align-items: center;
 }
+
+.darkPlaceholder ::placeholder {
+  color: #393939 !important;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR addresses the issue of no visual feedback when a user clicks the search button with an empty search term. To improve user experience, the following changes have been implemented:

-   When the search button is clicked with an empty search field, the placeholder text of the search input darkens for 5 seconds.
-   The search input field is also focused for 5 seconds in this scenario.

These changes provide a clear visual cue to the user that the search term is missing.

## Screenshots

[_Please add a screenshot or a short video of the feature in action._](https://github.com/user-attachments/assets/612b997e-2959-4e5d-aaaf-8aa80a880e4b)

## Related Issue

https://openmrs.atlassian.net/browse/O3-5068

## Other

None.



