### PR TITLE
(fix) O3-5074: Prevent home page crashing when default dashboard is not found

### DIFF
--- a/packages/esm-home-app/src/dashboard-container/dashboard-not-found.component.tsx
+++ b/packages/esm-home-app/src/dashboard-container/dashboard-not-found.component.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { isDesktop, useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { Layer, Tile } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
+
+import styles from './dashboard-not-found.scss';
+import classNames from 'classnames';
+import { type HomeConfig } from '../config-schema';
+
+export const DashboardNotFound = () => {
+  const layout = useLayoutType();
+  const { leftNavMode } = useConfig<HomeConfig>();
+  const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
+
+  return (
+    <div className={styles.homePageWrapper}>
+      <section
+        className={classNames([
+          isDesktop(layout) ? styles.dashboardContainer : styles.dashboardContainerTablet,
+          leftNavMode == 'normal' ? styles.hasLeftNav : '',
+        ])}>
+        <Layer>
+          <Tile className={styles.notFoundTile}>
+            <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
+              <h4>{t('pageNotFound', 'Page not found')}</h4>
+            </div>
+            <div className={styles.notFoundContent}>
+              <h1 className={styles.errorCode}>404</h1>
+              <p className={styles.errorMessage}>
+                {t('dashboardNotFound', 'The dashboard you are looking for does not exist.')}
+              </p>
+              <p className={styles.errorDescription}>
+                {t(
+                  'dashboardNotFoundDescription',
+                  'The page you requested could not be found. It may have been moved, deleted, or the configured dashboard does not exist.',
+                )}
+              </p>
+              <p className={styles.errorDescription}>
+                {t(
+                  'contactAdministrator',
+                  'Please try using the left navigation menu links. If the issue persists, contact your system administrator.',
+                )}
+              </p>
+            </div>
+          </Tile>
+        </Layer>
+      </section>
+    </div>
+  );
+};

--- a/packages/esm-home-app/src/dashboard-container/dashboard-not-found.scss
+++ b/packages/esm-home-app/src/dashboard-container/dashboard-not-found.scss
@@ -1,0 +1,77 @@
+@use '@carbon/layout';
+@use '@carbon/type';
+@use '@carbon/colors';
+
+@use './dashboard-container.scss';
+
+// 404 Not Found Styles
+.notFoundTile {
+  text-align: center;
+  margin: layout.$spacing-05;
+  padding: layout.$spacing-05;
+  border: 1px solid colors.$gray-20;
+}
+
+.desktopHeading {
+  h4 {
+    @include type.type-style('heading-compact-02');
+    color: colors.$gray-70;
+  }
+}
+
+.tabletHeading {
+  h4 {
+    @include type.type-style('heading-03');
+    color: colors.$gray-70;
+  }
+}
+
+.desktopHeading,
+.tabletHeading {
+  text-align: left;
+  margin-bottom: layout.$spacing-05;
+
+  h4:after {
+    content: '';
+    display: block;
+    width: layout.$spacing-07;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid var(--brand-03);
+  }
+}
+
+.notFoundContent {
+  padding: layout.$spacing-07 0;
+}
+
+.errorCode {
+  font-size: 6rem;
+  font-weight: 300;
+  line-height: 1.2;
+  color: colors.$gray-60;
+  margin-bottom: layout.$spacing-05;
+}
+
+.errorMessage {
+  @include type.type-style('heading-03');
+  color: colors.$gray-100;
+  margin-bottom: layout.$spacing-05;
+}
+
+.errorDescription {
+  @include type.type-style('body-01');
+  color: colors.$gray-70;
+  margin-bottom: layout.$spacing-04;
+}
+
+.homeButton {
+  margin-top: layout.$spacing-05;
+}
+
+// RTL support
+html[dir='rtl'] {
+  .desktopHeading,
+  .tabletHeading {
+    text-align: right;
+  }
+}

--- a/packages/esm-home-app/src/default-dashboard-redirect.component.tsx
+++ b/packages/esm-home-app/src/default-dashboard-redirect.component.tsx
@@ -16,5 +16,9 @@ export function DefaultDashboardRedirect() {
   const dashboards = ungroupedDashboards as Array<DashboardConfig>;
   const activeDashboard = dashboards.find((dashboard) => dashboard.name === defaultDashboard);
 
+  if (!activeDashboard && dashboards.length > 0) {
+    return <Navigate to={`/home/${dashboards[0].name}`} />;
+  }
+
   return <Navigate to={`/home/${activeDashboard.name}`} />;
 }

--- a/packages/esm-home-app/src/default-dashboard-redirect.component.tsx
+++ b/packages/esm-home-app/src/default-dashboard-redirect.component.tsx
@@ -4,6 +4,8 @@ import { useAssignedExtensions, useConfig, useSession } from '@openmrs/esm-frame
 import { type DashboardConfig } from './types/index';
 import { type HomeConfig } from './config-schema';
 
+import { DashboardNotFound } from './dashboard-container/dashboard-not-found.component';
+
 export function DefaultDashboardRedirect() {
   const assignedExtensions = useAssignedExtensions('homepage-dashboard-slot');
   const { defaultDashboardPerRole } = useConfig<HomeConfig>();
@@ -14,11 +16,11 @@ export function DefaultDashboardRedirect() {
 
   const ungroupedDashboards = assignedExtensions.map((e) => e.meta).filter((e) => Object.keys(e).length) || [];
   const dashboards = ungroupedDashboards as Array<DashboardConfig>;
-  const activeDashboard = dashboards.find((dashboard) => dashboard.name === defaultDashboard);
+  const activeDashboard = dashboards.find((dashboard) => dashboard.name === defaultDashboard) ?? dashboards[0];
 
-  if (!activeDashboard && dashboards.length > 0) {
-    return <Navigate to={`/home/${dashboards[0].name}`} />;
+  if (activeDashboard) {
+    return <Navigate to={`/home/${activeDashboard.name}`} />;
   }
 
-  return <Navigate to={`/home/${activeDashboard.name}`} />;
+  return <DashboardNotFound />;
 }

--- a/packages/esm-home-app/translations/en.json
+++ b/packages/esm-home-app/translations/en.json
@@ -1,1 +1,6 @@
-{}
+{
+  "contactAdministrator": "Please try using the left navigation menu links. If the issue persists, contact your system administrator.",
+  "dashboardNotFound": "The dashboard you are looking for does not exist.",
+  "dashboardNotFoundDescription": "The page you requested could not be found. It may have been moved, deleted, or the configured dashboard does not exist.",
+  "pageNotFound": "Page not found"
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
Add null check before accessing `activeDashboard` to prevent application crash when the configured or fallback dashboard doesn't exist in available dashboards.

The issue occurs in several scenarios:
1. When a user's role is mapped to a non-existent dashboard
2. When service-queues package is not installed (happens for kenya-emr)
3. When users have unconfigured roles (falls back to hardcoded 'service-queues')

The code has a hard coded fallback to 'service-queues' which creates a hidden dependency - deployments without service-queues will crash on the home page.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://thepalladiumgroup.atlassian.net/browse/KHP3-8575
## Other
<!-- Anything not covered above -->
