### PR TITLE
(fix) O3-5040: Make interactive elements keyboard accessible

### DIFF
--- a/packages/esm-appointments-app/src/calendar/monthly/days-of-week.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/days-of-week.component.tsx
@@ -21,7 +21,7 @@ const DaysOfWeekCard: React.FC<DaysOfWeekProps> = ({ dayOfWeek }) => {
   const { t } = useTranslation();
   const isToday = dayjs(new Date()).format('ddd').toUpperCase() === dayOfWeek;
   return (
-    <div tabIndex={0} role="button" className={styles.tileContainer}>
+    <div className={styles.tileContainer}>
       <span className={classNames({ [styles.bold]: isToday })}>{t(dayOfWeek)}</span>
     </div>
   );

--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view-expanded.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view-expanded.component.tsx
@@ -12,6 +12,7 @@ const MonthlyWorkloadViewExpanded: React.FC<MonthlyWorkloadViewExpandedProps> = 
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const popoverRef = useRef(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   const handleClickOutside = useCallback((event) => {
     if (popoverRef.current && !popoverRef.current.contains(event.target)) {
@@ -27,6 +28,12 @@ const MonthlyWorkloadViewExpanded: React.FC<MonthlyWorkloadViewExpandedProps> = 
     };
   }, [handleClickOutside]);
 
+  useEffect(() => {
+    if (isOpen && contentRef.current) {
+      contentRef.current.focus();
+    }
+  }, [isOpen]);
+
   return (
     <Popover open={isOpen} align="top" ref={popoverRef}>
       <button
@@ -38,7 +45,9 @@ const MonthlyWorkloadViewExpanded: React.FC<MonthlyWorkloadViewExpandedProps> = 
         {t('countMore', '{{count}} more', { count })}
       </button>
       <PopoverContent>
-        <MonthlyWorkloadView events={events} dateTime={dateTime} showAllServices={true} />
+        <div ref={contentRef} tabIndex={-1}>
+          <MonthlyWorkloadView events={events} dateTime={dateTime} showAllServices={true} />
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view.component.tsx
@@ -50,7 +50,15 @@ const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({ dateTime, eve
 
   return (
     <div
+      role="button"
+      tabIndex={0}
       onClick={() => navigateToAppointmentsByDate('')}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          navigateToAppointmentsByDate('');
+        }
+      }}
       className={classNames(
         styles[isSameMonth(dateTime, dayjs(selectedDate)) ? 'monthly-cell' : 'monthly-cell-disabled'],
         showAllServices
@@ -64,7 +72,7 @@ const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({ dateTime, eve
         <div>
           <span className={classNames(styles.totals)}>
             {currentData?.services ? (
-              <div role="button" tabIndex={0}>
+              <div>
                 <User size={16} />
                 <span>{currentData?.services.reduce((sum, { count = 0 }) => sum + count, 0)}</span>
               </div>
@@ -83,6 +91,13 @@ const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({ dateTime, eve
                   onClick={(e) => {
                     e.stopPropagation();
                     navigateToAppointmentsByDate(serviceUuid);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      navigateToAppointmentsByDate(serviceUuid);
+                    }
                   }}
                   className={styles.serviceArea}>
                   <span>{serviceName}</span>

--- a/packages/esm-appointments-app/src/workload/monthly-view-workload/monthly-view.component.tsx
+++ b/packages/esm-appointments-app/src/workload/monthly-view-workload/monthly-view.component.tsx
@@ -47,7 +47,15 @@ const MonthlyCalendarView: React.FC<MonthlyCalendarViewProps> = ({
           <div className={styles.monthlyCalendar}>
             {monthDays(dayjs(monthViewDate)).map((dateTime, i) => (
               <div
+                role="button"
+                tabIndex={0}
                 onClick={() => handleClick(dayjs(dateTime).toDate())}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleClick(dayjs(dateTime).toDate());
+                  }
+                }}
                 key={i}
                 className={`${styles.monthlyWorkloadCard} ${
                   dayjs(dateTime).format('YYYY-MM-DD') === dayjs(monthViewDate).format('YYYY-MM-DD')

--- a/packages/esm-appointments-app/src/workload/monthly-view-workload/monthlyWorkCard.tsx
+++ b/packages/esm-appointments-app/src/workload/monthly-view-workload/monthlyWorkCard.tsx
@@ -34,7 +34,7 @@ const MonthlyWorkloadCard: React.FC<MonthlyWorkloadComponentProps> = ({ date, co
       <div>
         <b className={[styles.calendarDate, isToday ? styles.blue : ''].join(' ')}>{date.format('D')}</b>
         <div className={styles.currentData}>
-          <div tabIndex={0} role="button" className={classNames(styles.tileContainer, {})}></div>
+          <div className={classNames(styles.tileContainer, {})}></div>
           <div className={styles.serviceArea}>
             <span className={isActive ? styles.blue : ''}>{count}</span>
           </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

- Removed incorrect role="button" and tabIndex from non-interactive elements (day-of-week headers, empty workload card div)
- Added onKeyDown handlers (Enter/Space) to clickable calendar cells and service area items
- Added autofocus to popover content when "X more" services are revealed

## Screen Recording
<!-- Required if you are making UI changes. -->
https://github.com/user-attachments/assets/789bba76-53a8-4026-897f-2d03c773360f

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-5040](https://openmrs.atlassian.net/browse/O3-5040)

## Other
<!-- Anything not covered above -->


[O3-5040]: https://openmrs.atlassian.net/browse/O3-5040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ