### PR TITLE
(fix) Prevent errors when queue entries have no priority configured

### DIFF
--- a/packages/esm-service-queues-app/src/modals/move-queue-entry.modal.tsx
+++ b/packages/esm-service-queues-app/src/modals/move-queue-entry.modal.tsx
@@ -120,7 +120,7 @@ const MoveQueueEntryModal: React.FC<MoveQueueEntryModalProps> = ({ queueEntry, c
         disableSubmit: (queueEntry, formState) =>
           formState.selectedQueue == queueEntry.queue.uuid &&
           formState.selectedStatus == queueEntry.status.uuid &&
-          formState.selectedPriority == queueEntry.priority.uuid,
+          formState.selectedPriority == queueEntry?.priority?.uuid,
         isEdit: false,
         showQueuePicker: true,
         showStatusPicker: false,

--- a/packages/esm-service-queues-app/src/modals/queue-entry-actions-modal.component.tsx
+++ b/packages/esm-service-queues-app/src/modals/queue-entry-actions-modal.component.tsx
@@ -99,7 +99,7 @@ export const QueueEntryActionModal: React.FC<QueueEntryActionModalProps> = ({
   const initialTransitionDate = isEdit ? new Date(queueEntry.startedAt) : new Date();
   const [formState, setFormState] = useState<FormState>({
     selectedQueue: queueEntry.queue.uuid,
-    selectedPriority: queueEntry.priority.uuid,
+    selectedPriority: queueEntry?.priority?.uuid,
     selectedStatus: queueEntry.status.uuid,
     priorityComment: queueEntry.priorityComment ?? '',
     modifyDefaultTransitionDateTime: false,

--- a/packages/esm-service-queues-app/src/queue-table/components/queue-priority.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/components/queue-priority.component.tsx
@@ -12,7 +12,7 @@ interface QueuePriorityProps {
 }
 
 const QueuePriority: React.FC<QueuePriorityProps> = ({ priority, priorityComment, priorityConfigs }) => {
-  const priorityConfig = priorityConfigs.find((c) => c.conceptUuid === priority.uuid);
+  const priorityConfig = priorityConfigs.find((c) => c.conceptUuid === priority?.uuid);
 
   const tag = (
     <Tag
@@ -23,7 +23,7 @@ const QueuePriority: React.FC<QueuePriorityProps> = ({ priority, priorityComment
         priorityConfig?.color === 'orange' && styles.orange,
       )}
       type={priorityConfig?.color !== 'orange' ? priorityConfig?.color : null}>
-      {priority.display}
+      {priority?.display}
     </Tag>
   );
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR prevents undefined error when the queue priority hasn't been set. This happens in our distro(KeHMIS) since priority is evaluated using TEWS calculation from triage.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
