### PR TITLE
(fix) O3-5472: Fix type error in active visits app

### DIFF
--- a/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
+++ b/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
@@ -2,9 +2,9 @@ import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { ContentSwitcher, DataTableSkeleton, Switch } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { formatDatetime, formatTime, parseDate } from '@openmrs/esm-framework';
+import { formatDatetime, formatTime, Obs, parseDate } from '@openmrs/esm-framework';
 import { useVisit } from './visit.resource';
-import EncounterList from './visits-components/encounter-list.component';
+import EncounterList, { type EncounterListItem } from './visits-components/encounter-list.component';
 import VisitSummary from './visits-components/visit-summary.component';
 import styles from './visit-detail-overview.scss';
 
@@ -18,7 +18,7 @@ const VisitDetailComponent: React.FC<VisitDetailComponentProps> = ({ visitUuid, 
   const [contentSwitcherIndex, setContentSwitcherIndex] = useState(0);
   const { visit, isLoading } = useVisit(visitUuid);
 
-  const encounters = useMemo(
+  const encounters = useMemo<Array<EncounterListItem>>(
     () =>
       visit
         ? visit?.encounters?.map((encounter) => ({

--- a/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
+++ b/packages/esm-active-visits-app/src/visits-summary/visit-detail.component.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { ContentSwitcher, DataTableSkeleton, Switch } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { formatDatetime, formatTime, Obs, parseDate } from '@openmrs/esm-framework';
+import { formatDatetime, formatTime, parseDate } from '@openmrs/esm-framework';
 import { useVisit } from './visit.resource';
 import EncounterList, { type EncounterListItem } from './visits-components/encounter-list.component';
 import VisitSummary from './visits-components/visit-summary.component';

--- a/packages/esm-active-visits-app/src/visits-summary/visits-components/encounter-list.component.tsx
+++ b/packages/esm-active-visits-app/src/visits-summary/visits-components/encounter-list.component.tsx
@@ -18,14 +18,16 @@ import { useTranslation } from 'react-i18next';
 import styles from '../visit-detail-overview.scss';
 import EncounterObservations from './encounter-observations.component';
 
+export interface EncounterListItem {
+  id: string;
+  time: string;
+  encounterType: string;
+  provider: string;
+  obs: Array<Obs>;
+}
+
 interface EncounterListProps {
-  encounters: Array<{
-    id: any;
-    time: any;
-    encounterType: string;
-    provider: string;
-    obs: Array<Obs>;
-  }>;
+  encounters: Array<EncounterListItem>;
   visitUuid: string;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
In esm-active-visits-app, the EncounterListProps interface types the encounter list items with id: any and time: any. That weakens type safety, hides real types, and can allow invalid data to be passed into the encounter list without compile-time checks.

## Screenshots: 
<img width="1225" height="376" alt="image" src="https://github.com/user-attachments/assets/1f620fa1-9233-4951-83d3-0e34cb20267e" />



## Related Issue
https://openmrs.atlassian.net/browse/O3-5472


