### PR TITLE
(fix) (O3 4673) ward app should not allow admission to locations not tagged as admission location

### DIFF
--- a/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
+++ b/packages/esm-ward-app/src/ward-view-header/admission-requests-bar.component.tsx
@@ -9,9 +9,13 @@ import styles from './admission-requests.scss';
 
 interface AdmissionRequestsBarProps {
   wardPendingPatients: ReactNode;
+  locationAllowsAdmissions?: boolean;
 }
 
-const AdmissionRequestsBar: React.FC<AdmissionRequestsBarProps> = ({ wardPendingPatients }) => {
+const AdmissionRequestsBar: React.FC<AdmissionRequestsBarProps> = ({
+  wardPendingPatients,
+  locationAllowsAdmissions,
+}) => {
   const { wardPatientGroupDetails } = useAppContext<WardViewContext>('ward-view-context') ?? {};
   const { inpatientRequests, isLoading, error } = wardPatientGroupDetails?.inpatientRequestResponse ?? {};
   const { t } = useTranslation();
@@ -48,7 +52,7 @@ const AdmissionRequestsBar: React.FC<AdmissionRequestsBarProps> = ({ wardPending
         onClick={() => {
           launchWorkspace2(
             'admission-requests-workspace',
-            { wardPendingPatients },
+            { wardPendingPatients, locationAllowsAdmissions },
             { startVisitWorkspaceName: 'ward-app-start-visit-workspace' },
           );
         }}

--- a/packages/esm-ward-app/src/ward-view-header/ward-view-header.component.tsx
+++ b/packages/esm-ward-app/src/ward-view-header/ward-view-header.component.tsx
@@ -6,16 +6,21 @@ import useWardLocation from '../hooks/useWardLocation';
 interface WardViewHeaderProps {
   wardPendingPatients: ReactNode;
   wardMetrics: ReactNode;
+  locationAllowsAdmissions?: boolean;
 }
 
-const WardViewHeader: React.FC<WardViewHeaderProps> = ({ wardPendingPatients, wardMetrics }) => {
+const WardViewHeader: React.FC<WardViewHeaderProps> = ({
+  wardPendingPatients,
+  wardMetrics,
+  locationAllowsAdmissions,
+}) => {
   const { location } = useWardLocation();
 
   return (
     <div className={styles.wardViewHeader}>
       <h2>{location?.display}</h2>
       {wardMetrics}
-      <AdmissionRequestsBar {...{ wardPendingPatients }} />
+      {locationAllowsAdmissions && <AdmissionRequestsBar {...{ wardPendingPatients }} />}
     </div>
   );
 };

--- a/packages/esm-ward-app/src/ward-view-header/ward-view-header.component.tsx
+++ b/packages/esm-ward-app/src/ward-view-header/ward-view-header.component.tsx
@@ -20,7 +20,7 @@ const WardViewHeader: React.FC<WardViewHeaderProps> = ({
     <div className={styles.wardViewHeader}>
       <h2>{location?.display}</h2>
       {wardMetrics}
-      {locationAllowsAdmissions && <AdmissionRequestsBar {...{ wardPendingPatients }} />}
+      <AdmissionRequestsBar locationAllowsAdmissions={locationAllowsAdmissions} {...{ wardPendingPatients }} />
     </div>
   );
 };

--- a/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.component.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDefineAppContext } from '@openmrs/esm-framework';
+import { Loading, InlineNotification } from '@carbon/react';
 import { type WardViewContext } from '../../types';
+import useEmrConfiguration from '../../hooks/useEmrConfiguration';
+import useLocations from '../../hooks/useLocations';
+import useWardLocation from '../../hooks/useWardLocation';
 import { useWardPatientGrouping } from '../../hooks/useWardPatientGrouping';
 import DefaultWardBeds from './default-ward-beds.component';
 import DefaultWardPatientCardHeader from './default-ward-patient-card-header.component';
@@ -9,23 +14,61 @@ import DefaultWardUnassignedPatients from './default-ward-unassigned-patients.co
 import Ward from '../ward.component';
 import WardViewHeader from '../../ward-view-header/ward-view-header.component';
 import WardMetrics from '../../ward-view-header/ward-metrics.component';
+import styles from './default-ward-view.scss';
 
 const DefaultWardView = () => {
+  const { t } = useTranslation();
+
   const wardPatientGroupDetails = useWardPatientGrouping();
   useDefineAppContext<WardViewContext>('ward-view-context', {
     wardPatientGroupDetails,
     WardPatientHeader: DefaultWardPatientCardHeader,
   });
 
-  const wardBeds = <DefaultWardBeds />;
-  const wardMetrics = <WardMetrics />;
-  const wardUnassignedPatients = <DefaultWardUnassignedPatients />;
-  const wardPendingPatients = <DefaultWardPendingPatients />;
+  const { emrConfiguration, isLoadingEmrConfiguration } = useEmrConfiguration();
+  const { location } = useWardLocation();
+
+  const filterCriteria = useMemo(() => {
+    const tag = emrConfiguration?.supportsAdmissionLocationTag?.name;
+    return tag ? [['_tag', tag]] : [];
+  }, [emrConfiguration]);
+
+  const { data: admissionLocations, isLoading: isLoadingAdmissionLocations } = useLocations(
+    filterCriteria,
+    15,
+    !emrConfiguration,
+  );
+
+  const locationHasAllowAdmissionsTag = admissionLocations?.some((loc) => loc.id === location?.uuid) ?? false;
+
+  if (isLoadingEmrConfiguration || isLoadingAdmissionLocations) {
+    return (
+      <div className={styles.loaderContainer}>
+        <Loading withOverlay={false} />
+      </div>
+    );
+  }
 
   return (
     <>
-      <WardViewHeader {...{ wardPendingPatients, wardMetrics }} />
-      <Ward {...{ wardBeds, wardUnassignedPatients }} />
+      <WardViewHeader
+        wardPendingPatients={<DefaultWardPendingPatients />}
+        wardMetrics={<WardMetrics />}
+        locationAllowsAdmissions={locationHasAllowAdmissionsTag}
+      />
+      {!locationHasAllowAdmissionsTag && (
+        <InlineNotification
+          className={styles.noAdmissionsNotification}
+          kind="error"
+          hideCloseButton={true}
+          lowContrast={true}
+          title={t(
+            'locationDoesNotAllowAdmissions',
+            'This location does not allow admissions. If there are patients here, please discharge them.',
+          )}
+        />
+      )}
+      <Ward wardBeds={<DefaultWardBeds />} wardUnassignedPatients={<DefaultWardUnassignedPatients />} />
     </>
   );
 };

--- a/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.component.tsx
@@ -59,13 +59,10 @@ const DefaultWardView = () => {
       {!locationHasAllowAdmissionsTag && (
         <InlineNotification
           className={styles.noAdmissionsNotification}
-          kind="error"
+          kind="warning"
           hideCloseButton={true}
           lowContrast={true}
-          title={t(
-            'locationDoesNotAllowAdmissions',
-            'This location does not allow admissions. If there are patients here, please discharge them.',
-          )}
+          title={t('locationDoesNotAllowAdmissions', 'This location does not allow admissions.')}
         />
       )}
       <Ward wardBeds={<DefaultWardBeds />} wardUnassignedPatients={<DefaultWardUnassignedPatients />} />

--- a/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.scss
+++ b/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.scss
@@ -1,0 +1,13 @@
+@use '@carbon/layout';
+
+.noAdmissionsNotification {
+  margin: layout.$spacing-05 0;
+}
+
+.loaderContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
+  width: 100%;
+}

--- a/packages/esm-ward-app/src/ward-view/ward-view.test.tsx
+++ b/packages/esm-ward-app/src/ward-view/ward-view.test.tsx
@@ -30,6 +30,22 @@ jest.mock('../hooks/useWardLocation', () =>
   }),
 );
 
+jest.mock('../hooks/useEmrConfiguration', () =>
+  jest.fn().mockReturnValue({
+    emrConfiguration: {
+      supportsAdmissionLocationTag: { name: 'Admission Location' },
+    },
+    isLoadingEmrConfiguration: false,
+  }),
+);
+
+jest.mock('../hooks/useLocations', () =>
+  jest.fn().mockReturnValue({
+    data: [{ id: 'abcd', display: 'mock location' }],
+    isLoading: false,
+  }),
+);
+
 jest.mock('../hooks/useObs', () => ({
   useObs: jest.fn(),
 }));
@@ -66,6 +82,20 @@ describe('WardView', () => {
     renderWithSwr(<DefaultWardView />);
     const header = screen.getByRole('heading', { name: 'mock location' });
     expect(header).toBeInTheDocument();
+  });
+
+  it('renders a notification when the location does not allow admissions', () => {
+    mockUseWardLocation.mockReturnValueOnce({
+      location: { uuid: 'unsupported-location-uuid', display: 'Non-Admitting Ward' },
+      isLoadingLocation: false,
+      errorFetchingLocation: null,
+      invalidLocation: false,
+    });
+
+    renderWithSwr(<DefaultWardView />);
+
+    const notificationText = screen.getByText(/This location does not allow admissions/i);
+    expect(notificationText).toBeInTheDocument();
   });
 
   it('renders the correct number of occupied and empty beds', async () => {

--- a/packages/esm-ward-app/src/ward-workspace/admission-request-workspace/admission-requests.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/admission-request-workspace/admission-requests.workspace.tsx
@@ -10,10 +10,11 @@ import { Add } from '@carbon/react/icons';
 
 export interface AdmissionRequestsWorkspaceProps {
   wardPendingPatients: ReactNode;
+  locationAllowsAdmissions?: boolean;
 }
 
 const AdmissionRequestsWorkspace: React.FC<Workspace2DefinitionProps<AdmissionRequestsWorkspaceProps>> = ({
-  workspaceProps: { wardPendingPatients },
+  workspaceProps: { wardPendingPatients, locationAllowsAdmissions },
   launchChildWorkspace,
 }) => {
   const { t } = useTranslation();
@@ -55,14 +56,25 @@ const AdmissionRequestsWorkspace: React.FC<Workspace2DefinitionProps<AdmissionRe
           </div>
         )}
         {!isLoading &&
-          (inpatientRequests?.length === 0 ? (
-            <AdmissionRequestsEmptyState />
+          (locationAllowsAdmissions ? (
+            inpatientRequests?.length === 0 ? (
+              <AdmissionRequestsEmptyState />
+            ) : (
+              locationAllowsAdmissions && (
+                <div className={styles.addPatientToWardButtonContainer}>
+                  <Button renderIcon={Add} kind="ghost" onClick={handleAddPatient} disabled={!locationAllowsAdmissions}>
+                    {t('addPatientToWard', 'Add patient to ward')}
+                  </Button>
+                </div>
+              )
+            )
           ) : (
-            <div className={styles.addPatientToWardButtonContainer}>
-              <Button renderIcon={Add} kind="ghost" onClick={handleAddPatient}>
-                {t('addPatientToWard', 'Add patient to ward')}
-              </Button>
-            </div>
+            <InlineNotification
+              kind="warning"
+              hideCloseButton={true}
+              lowContrast={true}
+              title={t('locationDoesNotAllowAdmissions', 'This location does not allow admissions.')}
+            />
           ))}
         <div className={styles.content}>{wardPendingPatients}</div>
       </div>

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -61,7 +61,7 @@
   "invalidLocationSpecified": "Invalid location specified",
   "invalidWardLocation": "Invalid ward location: {{location}}",
   "labelColon": "{{label}}:",
-  "locationDoesNotAllowAdmissions": "This location does not allow admissions. If there are patients here, please discharge them.",
+  "locationDoesNotAllowAdmissions": "This location does not allow admissions.",
   "male": "Male",
   "manage": "Manage",
   "minutes_one": "{{count}} minutes",

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -61,6 +61,7 @@
   "invalidLocationSpecified": "Invalid location specified",
   "invalidWardLocation": "Invalid ward location: {{location}}",
   "labelColon": "{{label}}:",
+  "locationDoesNotAllowAdmissions": "This location does not allow admissions. If there are patients here, please discharge them.",
   "male": "Male",
   "manage": "Manage",
   "minutes_one": "{{count}} minutes",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
Under the wards app, not all locations have the 'Admission Location' tag and thus they should not allow patients to be admitted. This PR makes the following updates
- For locations with he Admission Location tag, no effect
- For locations without, 1. Hide the admission requests button (requests could not be made to any non-admitting locations so no pending requests possible) and, 2. Show an alert notification indicating that this is not an admitting location (in case the user is confused on how to interact with the page)

<!-- Please describe what problems your PR addresses. -->

## Screenshots
1. Admitting Location
<img width="1604" height="513" alt="image" src="https://github.com/user-attachments/assets/9b9de469-0ea1-499e-9656-3a9caca87571" />
2. Non-Admitting Location 1
<img width="1624" height="396" alt="image" src="https://github.com/user-attachments/assets/e692afb6-0792-462a-930a-37cc68832f8e" />
3. Non-Admitting Location 2
<img width="1613" height="365" alt="image" src="https://github.com/user-attachments/assets/d5ee85dc-61a4-4329-a0c5-f815ecd71a09" />

<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4673

## Other
<!-- Anything not covered above -->
