### PR TITLE
(fix) O3-4673: Ward app should not allow admission to locations not tagged as Admission Location

### DIFF
--- a/__mocks__/locations.mock.ts
+++ b/__mocks__/locations.mock.ts
@@ -10,6 +10,16 @@ export const mockLocationInpatientWard: Location = {
   uuid: 'b1a8b05e-3542-4037-bbd3-998ee9c40574',
   display: 'Inpatient Ward',
   name: 'Inpatient Ward',
+  tags: [
+    {
+      uuid: '1c783dca-fd54-4ea8-a0fc-2875374e9cb6',
+      display: 'Admission Location',
+    },
+    {
+      uuid: '8d4626ca-7abd-42ad-be48-56767bbcf272',
+      display: 'Transfer Location',
+    },
+  ],
 };
 
 export const mockLocations = {

--- a/packages/esm-ward-app/src/hooks/useLocation.test.ts
+++ b/packages/esm-ward-app/src/hooks/useLocation.test.ts
@@ -18,7 +18,7 @@ describe('useLocation hook', () => {
   it('should call useLocation', () => {
     const { result } = renderHook(() => useLocation('testUUID'));
     expect(useSWRImmutableMock).toHaveBeenCalledWith(
-      `${restBaseUrl}/location/testUUID?v=custom:(display,uuid)`,
+      `${restBaseUrl}/location/testUUID?v=custom:(display,uuid,tags:(uuid,display,name))`,
       expect.any(Function),
     );
   });

--- a/packages/esm-ward-app/src/hooks/useLocation.ts
+++ b/packages/esm-ward-app/src/hooks/useLocation.ts
@@ -1,7 +1,10 @@
 import { type Location, openmrsFetch, restBaseUrl, type FetchResponse } from '@openmrs/esm-framework';
 import useSWRImmutable from 'swr/immutable';
 
-export default function useLocation(locationUuid: string, rep: string = 'custom:(display,uuid)') {
+export default function useLocation(
+  locationUuid: string,
+  rep: string = 'custom:(display,uuid,tags:(uuid,display,name))',
+) {
   return useSWRImmutable<FetchResponse<Location>>(
     locationUuid ? `${restBaseUrl}/location/${locationUuid}?v=${rep}` : null,
     openmrsFetch,

--- a/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.component.tsx
+++ b/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.component.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDefineAppContext } from '@openmrs/esm-framework';
 import { type WardViewContext } from '../../types';
+import useEmrConfiguration from '../../hooks/useEmrConfiguration';
+import useWardLocation from '../../hooks/useWardLocation';
+import { isAdmissionLocation } from '../ward-view.resource';
 import { useWardPatientGrouping } from '../../hooks/useWardPatientGrouping';
 import DefaultWardBeds from './default-ward-beds.component';
 import DefaultWardPatientCardHeader from './default-ward-patient-card-header.component';
@@ -9,23 +13,35 @@ import DefaultWardUnassignedPatients from './default-ward-unassigned-patients.co
 import Ward from '../ward.component';
 import WardViewHeader from '../../ward-view-header/ward-view-header.component';
 import WardMetrics from '../../ward-view-header/ward-metrics.component';
+import styles from './default-ward-view.scss';
 
 const DefaultWardView = () => {
+  const { t } = useTranslation();
   const wardPatientGroupDetails = useWardPatientGrouping();
   useDefineAppContext<WardViewContext>('ward-view-context', {
     wardPatientGroupDetails,
     WardPatientHeader: DefaultWardPatientCardHeader,
   });
 
-  const wardBeds = <DefaultWardBeds />;
-  const wardMetrics = <WardMetrics />;
-  const wardUnassignedPatients = <DefaultWardUnassignedPatients />;
-  const wardPendingPatients = <DefaultWardPendingPatients />;
+  const { emrConfiguration } = useEmrConfiguration();
+  const { location } = useWardLocation();
+  const locationSupportsAdmission = isAdmissionLocation(location, emrConfiguration);
+
+  if (!locationSupportsAdmission) {
+    return (
+      <div className={styles.nonAdmissionView}>
+        <h2>{location?.display}</h2>
+        <p className={styles.nonAdmissionSubtitle}>
+          {t('locationDoesNotAllowAdmissions', 'This location does not allow admissions.')}
+        </p>
+      </div>
+    );
+  }
 
   return (
     <>
-      <WardViewHeader {...{ wardPendingPatients, wardMetrics }} />
-      <Ward {...{ wardBeds, wardUnassignedPatients }} />
+      <WardViewHeader wardPendingPatients={<DefaultWardPendingPatients />} wardMetrics={<WardMetrics />} />
+      <Ward wardBeds={<DefaultWardBeds />} wardUnassignedPatients={<DefaultWardUnassignedPatients />} />
     </>
   );
 };

--- a/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.scss
+++ b/packages/esm-ward-app/src/ward-view/default-ward/default-ward-view.scss
@@ -1,0 +1,12 @@
+@use '@carbon/layout';
+@use '@carbon/type';
+
+.nonAdmissionView {
+  margin: layout.$spacing-05;
+}
+
+.nonAdmissionSubtitle {
+  @include type.type-style('body-compact-01');
+  color: var(--cds-text-secondary, #525252);
+  margin-top: layout.$spacing-02;
+}

--- a/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
+++ b/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
@@ -11,6 +11,7 @@ import {
   type WardDefinition,
   type AdmissionRequestNoteElementConfig,
 } from '../config-schema';
+import type { EmrApiConfigurationResponse } from '../hooks/useEmrConfiguration';
 import type {
   AdmissionLocationFetchResponse,
   Bed,
@@ -210,4 +211,15 @@ export function useWardConfig(locationUuid: string): WardDefinition {
   }
 
   return currentWardConfig;
+}
+
+/**
+ * Checks if a location is tagged as an Admission Location based on the
+ * `supportsAdmissionLocationTag` from the EMR configuration.
+ */
+export function isAdmissionLocation(location: Location, emrConfiguration: EmrApiConfigurationResponse): boolean {
+  if (!location?.tags || !emrConfiguration?.supportsAdmissionLocationTag) {
+    return false;
+  }
+  return location.tags.some((tag) => tag.uuid === emrConfiguration.supportsAdmissionLocationTag.uuid);
 }

--- a/packages/esm-ward-app/src/ward-view/ward-view.test.tsx
+++ b/packages/esm-ward-app/src/ward-view/ward-view.test.tsx
@@ -23,10 +23,27 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('../hooks/useWardLocation', () =>
   jest.fn().mockReturnValue({
-    location: { uuid: 'abcd', display: 'mock location' },
+    location: {
+      uuid: 'abcd',
+      display: 'mock location',
+      tags: [{ uuid: '1c783dca-fd54-4ea8-a0fc-2875374e9cb6', display: 'Admission Location' }],
+    },
     isLoadingLocation: false,
     errorFetchingLocation: null,
     invalidLocation: false,
+  }),
+);
+
+jest.mock('../hooks/useEmrConfiguration', () =>
+  jest.fn().mockReturnValue({
+    emrConfiguration: {
+      supportsAdmissionLocationTag: {
+        uuid: '1c783dca-fd54-4ea8-a0fc-2875374e9cb6',
+        name: 'Admission Location',
+      },
+    },
+    isLoadingEmrConfiguration: false,
+    errorFetchingEmrConfiguration: null,
   }),
 );
 
@@ -85,6 +102,21 @@ describe('WardView', () => {
     renderWithSwr(<DefaultWardView />);
     const admittedPatientWithoutBed = screen.queryByText('Brian Johnson');
     expect(admittedPatientWithoutBed).toBeInTheDocument();
+  });
+
+  it('renders a message when the location does not allow admissions', () => {
+    mockUseWardLocation.mockReturnValueOnce({
+      location: { uuid: 'no-admission-uuid', display: 'Mobile Clinic' },
+      isLoadingLocation: false,
+      errorFetchingLocation: null,
+      invalidLocation: false,
+    });
+
+    renderWithSwr(<DefaultWardView />);
+    const header = screen.getByRole('heading', { name: 'Mobile Clinic' });
+    expect(header).toBeInTheDocument();
+    const message = screen.getByText(/This location does not allow admissions/i);
+    expect(message).toBeInTheDocument();
   });
 
   it('renders notification for invalid location uuid', () => {

--- a/packages/esm-ward-app/src/ward-workspace/admission-request-workspace/admission-requests-empty-state.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/admission-request-workspace/admission-requests-empty-state.component.tsx
@@ -9,12 +9,18 @@ import {
   useWorkspace2Context,
   type Workspace2DefinitionProps,
 } from '@openmrs/esm-framework';
+import useEmrConfiguration from '../../hooks/useEmrConfiguration';
+import useWardLocation from '../../hooks/useWardLocation';
+import { isAdmissionLocation } from '../../ward-view/ward-view.resource';
 import styles from './admission-requests-empty-state.scss';
 
 const AdmissionRequestsEmptyState: React.FC = () => {
   const { t } = useTranslation();
   const isDesktop = useLayoutType() !== 'tablet';
   const { launchChildWorkspace } = useWorkspace2Context();
+  const { emrConfiguration } = useEmrConfiguration();
+  const { location } = useWardLocation();
+  const locationSupportsAdmission = isAdmissionLocation(location, emrConfiguration);
 
   const handleAddPatient = () => {
     launchChildWorkspace('ward-app-patient-search-workspace', {
@@ -46,9 +52,11 @@ const AdmissionRequestsEmptyState: React.FC = () => {
           )}
         </p>
         <div className={styles.action}>
-          <Button renderIcon={Add} kind="ghost" onClick={handleAddPatient}>
-            {t('addPatientToWard', 'Add patient to ward')}
-          </Button>
+          {locationSupportsAdmission && (
+            <Button renderIcon={Add} kind="ghost" onClick={handleAddPatient}>
+              {t('addPatientToWard', 'Add patient to ward')}
+            </Button>
+          )}
         </div>
       </Tile>
     </Layer>

--- a/packages/esm-ward-app/src/ward-workspace/admission-request-workspace/admission-requests.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/admission-request-workspace/admission-requests.workspace.tsx
@@ -5,6 +5,8 @@ import { useAppContext, Workspace2, type Workspace2DefinitionProps } from '@open
 import { type WardViewContext } from '../../types';
 import AdmissionRequestsEmptyState from './admission-requests-empty-state.component';
 import useEmrConfiguration from '../../hooks/useEmrConfiguration';
+import useWardLocation from '../../hooks/useWardLocation';
+import { isAdmissionLocation } from '../../ward-view/ward-view.resource';
 import styles from './admission-requests-workspace.scss';
 import { Add } from '@carbon/react/icons';
 
@@ -17,9 +19,11 @@ const AdmissionRequestsWorkspace: React.FC<Workspace2DefinitionProps<AdmissionRe
   launchChildWorkspace,
 }) => {
   const { t } = useTranslation();
-  const { errorFetchingEmrConfiguration } = useEmrConfiguration();
+  const { emrConfiguration, errorFetchingEmrConfiguration } = useEmrConfiguration();
   const { wardPatientGroupDetails } = useAppContext<WardViewContext>('ward-view-context') ?? {};
   const { inpatientRequests, isLoading } = wardPatientGroupDetails?.inpatientRequestResponse ?? {};
+  const { location } = useWardLocation();
+  const locationSupportsAdmission = isAdmissionLocation(location, emrConfiguration);
 
   const handleAddPatient = () => {
     launchChildWorkspace('ward-app-patient-search-workspace', {
@@ -58,11 +62,13 @@ const AdmissionRequestsWorkspace: React.FC<Workspace2DefinitionProps<AdmissionRe
           (inpatientRequests?.length === 0 ? (
             <AdmissionRequestsEmptyState />
           ) : (
-            <div className={styles.addPatientToWardButtonContainer}>
-              <Button renderIcon={Add} kind="ghost" onClick={handleAddPatient}>
-                {t('addPatientToWard', 'Add patient to ward')}
-              </Button>
-            </div>
+            locationSupportsAdmission && (
+              <div className={styles.addPatientToWardButtonContainer}>
+                <Button renderIcon={Add} kind="ghost" onClick={handleAddPatient}>
+                  {t('addPatientToWard', 'Add patient to ward')}
+                </Button>
+              </div>
+            )
           ))}
         <div className={styles.content}>{wardPendingPatients}</div>
       </div>

--- a/packages/esm-ward-app/src/ward-workspace/admit-patient-button.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/admit-patient-button.component.tsx
@@ -9,7 +9,9 @@ import {
   useLayoutType,
   useWorkspace2Context,
 } from '@openmrs/esm-framework';
+import useEmrConfiguration from '../hooks/useEmrConfiguration';
 import useWardLocation from '../hooks/useWardLocation';
+import { isAdmissionLocation } from '../ward-view/ward-view.resource';
 import type { DispositionType, WardPatient, WardViewContext } from '../types';
 import { useAdmitPatient } from '../ward.resource';
 
@@ -36,8 +38,10 @@ const AdmitPatientButton: React.FC<AdmitPatientButtonProps> = ({
   const responsiveSize = useLayoutType() === 'tablet' ? 'lg' : 'md';
   const { wardPatientGroupDetails } = useAppContext<WardViewContext>('ward-view-context') ?? {};
   const { admitPatient, isLoadingEmrConfiguration, errorFetchingEmrConfiguration } = useAdmitPatient();
+  const { emrConfiguration } = useEmrConfiguration();
   const [isAdmitting, setIsAdmitting] = useState(false);
   const { launchChildWorkspace } = useWorkspace2Context();
+  const locationSupportsAdmission = isAdmissionLocation(location, emrConfiguration);
 
   const launchPatientAdmissionForm = () => launchChildWorkspace('admit-patient-form-workspace', { wardPatient });
 
@@ -93,7 +97,8 @@ const AdmitPatientButton: React.FC<AdmitPatientButtonProps> = ({
     }
   };
 
-  const disabledButton = isLoadingEmrConfiguration || errorFetchingEmrConfiguration || disabled || isAdmitting;
+  const disabledButton =
+    isLoadingEmrConfiguration || errorFetchingEmrConfiguration || disabled || isAdmitting || !locationSupportsAdmission;
   return (
     <Button kind="ghost" renderIcon={ArrowRightIcon} size={responsiveSize} disabled={disabledButton} onClick={onAdmit}>
       {dispositionType === 'ADMIT' || disabledButton

--- a/packages/esm-ward-app/src/ward-workspace/create-admission-encounter/create-admission-encounter.test.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/create-admission-encounter/create-admission-encounter.test.tsx
@@ -138,6 +138,11 @@ jest.mocked(useEmrConfiguration).mockReturnValue({
     clinicianEncounterRole: {
       uuid: 'clinician-encounter-role-uuid',
     },
+    supportsAdmissionLocationTag: {
+      uuid: '1c783dca-fd54-4ea8-a0fc-2875374e9cb6',
+      display: 'Admission Location',
+      name: 'Admission Location',
+    },
   },
   mutateEmrConfiguration: jest.fn(),
 });

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -61,6 +61,7 @@
   "invalidLocationSpecified": "Invalid location specified",
   "invalidWardLocation": "Invalid ward location: {{location}}",
   "labelColon": "{{label}}:",
+  "locationDoesNotAllowAdmissions": "This location does not allow admissions.",
   "male": "Male",
   "manage": "Manage",
   "minutes_one": "{{count}} minutes",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number with a conventional commit label.
- [x] My work conforms to the OpenMRS 3.0 Styleguide and design specifications.
- [x] My work includes tests or is validated by existing tests.

## Summary

Locations in the ward app that lack the `Admission Location` tag should not allow patient admissions. This PR implements a multi-layered approach:

**For non-admission locations:**
- The entire ward view (beds, metrics, admission requests bar) is replaced with a clean heading showing the location name and a subtitle: *"This location does not allow admissions."*
- This matches the UX requested in the JIRA ticket comments.

**For admission locations:**
- No change — the ward app functions exactly as before.

**Defense in depth** — even if a user somehow reaches admission UI through deep links or workspaces:
- The "Admit patient" button is disabled when the location lacks the admission tag
- The "Add patient to ward" button is hidden in the admission requests workspace and empty state

### Technical approach

- **Zero extra API calls**: The `useLocation` hook now fetches location tags alongside `display` and `uuid` by expanding the default representation to `custom:(display,uuid,tags:(uuid,display,name))`. The tag UUID is compared against `emrConfiguration.supportsAdmissionLocationTag` - no need to fetch all admission locations separately.
- **Reusable utility**: `isAdmissionLocation(location, emrConfiguration)` in `ward-view.resource.ts` can be used by any component.
- **Proper i18n**: Translation key `locationDoesNotAllowAdmissions` added.

## Screenshots

**Non-admission location (e.g. Mobile Clinic):**
Only the location heading and subtitle are shown. No beds, metrics, or admission controls.

**Admission location:**
Unchanged - full ward view with beds, metrics, and admission requests.

## Related Issue

https://openmrs.atlassian.net/browse/O3-4673

## Other

- Revives the intent of graveyard-candidate PR #1584 with a cleaner approach
- 49 tests passing (1 new test added for non-admission location behavior)