### PR TITLE
(fix) O3-4569: Resolve mobile layout overflow in Service Queues modals and forms

### DIFF
--- a/packages/esm-service-queues-app/src/admin/queue-rooms/queue-room-form.scss
+++ b/packages/esm-service-queues-app/src/admin/queue-rooms/queue-room-form.scss
@@ -54,3 +54,30 @@ $overlay-header-height: 5.5rem;
   padding: 0;
   margin-top: layout.$spacing-05;
 }
+
+@media (max-width: 600px) {
+  .tablet,
+  .desktop {
+    display: flex !important;
+    flex-direction: column-reverse !important;
+    width: 100% !important;
+    padding: layout.$spacing-05 !important;
+  }
+
+  .button {
+    width: 100% !important;
+    min-width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 !important;
+
+    justify-content: center !important;
+    align-items: center !important;
+    text-align: center !important;
+
+    padding: 0.75rem 1rem !important;
+  }
+
+  .button:last-child {
+    margin-bottom: 0.5rem !important;
+  }
+}

--- a/packages/esm-service-queues-app/src/admin/queues/queue-form.scss
+++ b/packages/esm-service-queues-app/src/admin/queues/queue-form.scss
@@ -2,6 +2,8 @@
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
+$overlay-header-height: 5.5rem;
+
 .heading {
   @include type.type-style('heading-compact-01');
   margin: layout.$spacing-05 0 layout.$spacing-05;
@@ -43,19 +45,39 @@
   min-width: 50%;
 }
 
-.buttonSet {
+.tablet {
+  padding: layout.$spacing-06 layout.$spacing-05;
+  background-color: $ui-02;
+}
+
+.desktop {
   padding: 0;
   margin-top: layout.$spacing-05;
 }
 
-/* Tablet */
-:global(.omrs-breakpoint-lt-desktop) {
-  .form {
-    height: 100%;
+@media (max-width: 600px) {
+  .tablet,
+  .desktop {
+    display: flex !important;
+    flex-direction: column-reverse !important;
+    width: 100% !important;
+    padding: layout.$spacing-05 !important;
   }
 
-  .buttonSet {
-    padding: layout.$spacing-06 layout.$spacing-05;
-    background-color: $ui-02;
+  .button {
+    width: 100% !important;
+    min-width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 !important;
+
+    justify-content: center !important;
+    align-items: center !important;
+    text-align: center !important;
+
+    padding: 0.75rem 1rem !important;
+  }
+
+  .button:last-child {
+    margin-bottom: 0.5rem !important;
   }
 }

--- a/packages/esm-service-queues-app/src/admin/queues/queue-form.scss
+++ b/packages/esm-service-queues-app/src/admin/queues/queue-form.scss
@@ -45,7 +45,7 @@ $overlay-header-height: 5.5rem;
   min-width: 50%;
 }
 
-.tablet {
+.buttonSet {
   padding: layout.$spacing-06 layout.$spacing-05;
   background-color: $ui-02;
 }
@@ -56,7 +56,7 @@ $overlay-header-height: 5.5rem;
 }
 
 @media (max-width: 600px) {
-  .tablet,
+  .buttonSet,
   .desktop {
     display: flex !important;
     flex-direction: column-reverse !important;

--- a/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.modal.tsx
+++ b/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.modal.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useState } from 'react';
 import { Button, ButtonSkeleton, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
+import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMutateQueueEntries } from '../../hooks/useQueueEntries';
 import { type QueueEntry } from '../../types';
@@ -43,7 +43,7 @@ const ClearQueueEntriesModal: React.FC<ClearQueueEntriesModalProps> = ({ queueEn
   }, [closeModal, mutateQueueEntries, t, queueEntries]);
 
   return (
-    <div>
+    <div className={styles.clearQueueModalContainer}>
       <ModalHeader
         closeModal={closeModal}
         label={t('serviceQueues', 'Service queues')}

--- a/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.scss
+++ b/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.scss
@@ -12,14 +12,14 @@
 }
 
 @media (max-width: 600px) {
-  :global {
-    .cds--modal {
+  .clearQueueModalContainer {
+    :global(.cds--modal) {
       display: flex !important;
       align-items: center !important;
       justify-content: center !important;
     }
 
-    .cds--modal-container {
+    :global(.cds--modal-container) {
       position: relative !important;
       top: auto !important;
       right: auto !important;
@@ -30,29 +30,25 @@
       max-height: 90vh !important;
     }
 
-    .cds--modal-footer {
+    :global(.cds--modal-footer) {
       display: flex !important;
       flex-direction: column-reverse !important;
       height: auto !important;
       padding: 1rem !important;
     }
 
-    .cds--modal-footer .cds--btn {
+    :global(.cds--modal-footer .cds--btn) {
       width: 100% !important;
       max-width: 100% !important;
       margin: 0 !important;
-
       justify-content: center !important;
       text-align: center !important;
-
       align-items: center !important;
-
       padding: 0.75rem 1rem !important;
-
       font-size: 1rem !important;
     }
 
-    .cds--modal-footer .cds--btn:last-child {
+    :global(.cds--modal-footer .cds--btn:last-child) {
       margin-bottom: 0.5rem !important;
     }
   }

--- a/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.scss
+++ b/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.scss
@@ -10,3 +10,50 @@
 .clearQueueButton:hover {
   color: $danger;
 }
+
+@media (max-width: 600px) {
+  :global {
+    .cds--modal {
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+    }
+
+    .cds--modal-container {
+      position: relative !important;
+      top: auto !important;
+      right: auto !important;
+      transform: none !important;
+      width: 90% !important;
+      min-width: 0 !important;
+      height: auto !important;
+      max-height: 90vh !important;
+    }
+
+    .cds--modal-footer {
+      display: flex !important;
+      flex-direction: column-reverse !important;
+      height: auto !important;
+      padding: 1rem !important;
+    }
+
+    .cds--modal-footer .cds--btn {
+      width: 100% !important;
+      max-width: 100% !important;
+      margin: 0 !important;
+
+      justify-content: center !important;
+      text-align: center !important;
+
+      align-items: center !important;
+
+      padding: 0.75rem 1rem !important;
+
+      font-size: 1rem !important;
+    }
+
+    .cds--modal-footer .cds--btn:last-child {
+      margin-bottom: 0.5rem !important;
+    }
+  }
+}


### PR DESCRIPTION
This PR addresses Jira ticket **[O3-4569](https://issues.openmrs.org/browse/O3-4569)**, which reported severe layout overflows and unresponsiveness on mobile devices for specific components within the Service Queues application.

### Requirements
- [x] PR title briefly describes the work done, includes the ticket number, and has a conventional commit label
- [x] The work is based on designs (linked or shown in the Jira ticket or description)
- [x] The work includes tests or is validated by existing tests

### Components Fixed:

**1. Clear Queue Entries Modal** (`clear-queue-entries.modal.tsx`):
* **Issue:** On mobile screens, the modal was bleeding off the edge of the viewport, cutting off text, and failing to handle the Carbon `<ModalFooter>` button layout correctly.
* **Fix:** Implemented a targeted mobile media query that forces the modal container to respect the viewport width (`90vw`). Refactored the modal footer to use `flex-direction: column-reverse`, ensuring the primary "Clear queue" action is stacked above the "Cancel" button for better mobile UX.

**2. Add Queue Room Workspace** (`queue-room-form.scss`):
* **Issue:** The `<ButtonSet>` at the bottom of the workspace was forcing a `min-width: 50%` on both buttons. On mobile, this caused the buttons to overflow the container and overlap with the floating help icon.
* **Fix:** Overrode the `50%` width constraint on mobile devices. Forced the button container to stack vertically, expanding the buttons to `100% width` for a native mobile feel, and eliminating the icon overlap.

**3. Add Queue Workspace** (`queue-form.scss`):
* **Issue:** Found identical layout overflow issues in the standard "Add Queue" workspace due to the same CSS architecture.
* **Fix:** Applied the same bulletproof mobile stacking override to ensure consistency across the administrative UI.

### Screenshots
*Before
<img width="612" height="597" alt="Before_1" src="https://github.com/user-attachments/assets/4aed3a9c-c6e3-494b-bcbf-3f14f356e622" />
<img width="736" height="660" alt="Before_2" src="https://github.com/user-attachments/assets/c4f71341-10ce-4624-8d2b-4d7957b1022a" />
<img width="822" height="523" alt="Before_3" src="https://github.com/user-attachments/assets/c1a7da4d-302a-4973-8e0f-9711c12da327" />

*After
<img width="736" height="662" alt="After_1" src="https://github.com/user-attachments/assets/397a91de-c0ca-4a21-9ead-1e60bf4b5386" />
<img width="717" height="660" alt="After_2" src="https://github.com/user-attachments/assets/e33b0a04-0f89-433c-8bdb-9c9b895a14f4" />
<img width="798" height="550" alt="After_3" src="https://github.com/user-attachments/assets/2a423683-cfaa-43bf-8777-7196a634db5d" />


[O3-4569]: https://openmrs.atlassian.net/browse/O3-4569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ