### PR TITLE
fix: add batch actions translations (O3-5409)

### DIFF
--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
@@ -198,9 +198,19 @@ const AppointmentsTable: React.FC<AppointmentsTableProps> = ({
                 <TableBatchActions
                   shouldShowBatchActions={selectedAppointmentUuids.size > 0}
                   totalSelected={selectedAppointmentUuids.size}
-                  // TODO: add translation for Carbon's table batch actions
+                  onCancel={() => setSelectedAppointmentUuids(new Set())}
+                  translateWithId={(id) => {
+                    if (id === 'carbon.table.batch.cancel') {
+                      return t('cancel', 'Cancel');
+                    }
+                    if (id === 'carbon.table.batch.items.selected') {
+                      return t('itemsSelected', 'items selected');
+                    }
+                    if (id === 'carbon.table.batch.item.selected') {
+                      return t('itemSelected', 'item selected');
+                    }
+                  }}>
                   // https://openmrs.atlassian.net/browse/O3-5409
-                  onCancel={() => setSelectedAppointmentUuids(new Set())}>
                   <TableBatchAction
                     renderIcon={Calendar}
                     onClick={() => {


### PR DESCRIPTION
## Requirements

* [x] This PR has a title that briefly describes the work done including the ticket number.
* [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
* [x] My work includes tests or is validated by existing tests.

## Summary

This PR adds translation support for Carbon's table batch actions in the appointments table component.

Previously, labels such as **"Cancel"**, **"item selected"**, and **"items selected"** were not translated. This update introduces a `translateWithId` function to provide translations for these batch action labels.

## Screenshots

Not applicable (no UI design changes).

## Related Issue

https://openmrs.atlassian.net/browse/O3-5409

## Other

Verified that batch action labels display correctly when selecting appointments in the table.


Note: I noticed this issue was assigned, but I did not see an open PR, so I attempted to work on it. Please let me know if any changes are required.

