### PR TITLE
(fix): O3-5490 Prevent AbortController recreation on every render in appointment hooks

### DIFF
--- a/packages/esm-appointments-app/src/hooks/useAppointmentList.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentList.ts
@@ -3,18 +3,24 @@ import useSWR from 'swr';
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentsFetchResponse } from '../types';
 import { useAppointmentsStore } from '../store';
+import { useRef, useEffect } from 'react';
 
 export const useAppointmentList = (appointmentStatus: string, date?: string) => {
   const { selectedDate } = useAppointmentsStore();
   const startDate = date ? date : selectedDate;
   const endDate = dayjs(startDate).endOf('day').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'); // TODO: fix? is this correct?
   const searchUrl = `${restBaseUrl}/appointments/search`;
-  const abortController = new AbortController();
+  const abortControllerRef = useRef(new AbortController());
+
+  useEffect(() => {
+    const controller = abortControllerRef.current;
+    return () => controller.abort();
+  }, []);
 
   const fetcher = ([url, startDate, endDate, status]) =>
     openmrsFetch(url, {
       method: 'POST',
-      signal: abortController.signal,
+      signal: abortControllerRef.current.signal,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/packages/esm-appointments-app/src/hooks/useAppointmentList.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentList.ts
@@ -10,15 +10,14 @@ export const useAppointmentList = (appointmentStatus: string, date?: string) => 
   const startDate = date ? date : selectedDate;
   const endDate = dayjs(startDate).endOf('day').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'); // TODO: fix? is this correct?
   const searchUrl = `${restBaseUrl}/appointments/search`;
-  const abortControllerRef = useRef(new AbortController());
+  const abortControllerRef = useRef<AbortController | null>(null);
 
-  useEffect(() => {
-    const controller = abortControllerRef.current;
-    return () => controller.abort();
-  }, []);
-
-  const fetcher = ([url, startDate, endDate, status]) =>
-    openmrsFetch(url, {
+  const fetcher = ([url, startDate, endDate, status]) => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+    abortControllerRef.current = new AbortController();
+    return openmrsFetch(url, {
       method: 'POST',
       signal: abortControllerRef.current.signal,
       headers: {
@@ -30,12 +29,19 @@ export const useAppointmentList = (appointmentStatus: string, date?: string) => 
         status: status,
       },
     });
+  };
 
   const { data, error, isLoading, mutate } = useSWR<AppointmentsFetchResponse, Error>(
     [searchUrl, startDate, endDate, appointmentStatus],
     fetcher,
     { errorRetryCount: 2 },
   );
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   return { appointmentList: data?.data ?? [], isLoading, error, mutate };
 };

--- a/packages/esm-appointments-app/src/hooks/usePatientAppointmentHistory.ts
+++ b/packages/esm-appointments-app/src/hooks/usePatientAppointmentHistory.ts
@@ -6,27 +6,30 @@ import { useAppointmentsStore } from '../store';
 import { useRef, useEffect } from 'react';
 
 export function usePatientAppointmentHistory(patientUuid: string) {
-  const abortControllerRef = useRef(new AbortController());
+  const abortControllerRef = useRef<AbortController | null>(null);
 
-  useEffect(() => {
-    const controller = abortControllerRef.current;
-    return () => controller.abort();
-  }, []);
   const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
   const { selectedDate } = useAppointmentsStore();
 
-  const fetcher = () =>
-    openmrsFetch(appointmentsSearchUrl, {
+  const fetcher = () => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+
+    abortControllerRef.current = new AbortController();
+
+    return openmrsFetch(appointmentsSearchUrl, {
       method: 'POST',
       signal: abortControllerRef.current.signal,
       headers: {
         'Content-Type': 'application/json',
       },
       body: {
-        patientUuid: patientUuid,
+        patientUuid,
         startDate: selectedDate,
       },
     });
+  };
 
   const { data, error, isLoading, isValidating } = useSWR<AppointmentsFetchResponse, Error>(
     patientUuid ? appointmentsSearchUrl : null,
@@ -46,6 +49,11 @@ export function usePatientAppointmentHistory(patientUuid: string) {
     ? data.data?.filter((appointment: any) => dayjs((appointment.startDateTime / 1000) * 1000).isAfter(dayjs())).length
     : 0;
 
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
   return {
     appointmentsCount: { missedAppointments, completedAppointments, cancelledAppointments, upcomingAppointments },
     error,

--- a/packages/esm-appointments-app/src/hooks/usePatientAppointmentHistory.ts
+++ b/packages/esm-appointments-app/src/hooks/usePatientAppointmentHistory.ts
@@ -3,16 +3,22 @@ import useSWR from 'swr';
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentsFetchResponse } from '../types';
 import { useAppointmentsStore } from '../store';
+import { useRef, useEffect } from 'react';
 
 export function usePatientAppointmentHistory(patientUuid: string) {
-  const abortController = new AbortController();
+  const abortControllerRef = useRef(new AbortController());
+
+  useEffect(() => {
+    const controller = abortControllerRef.current;
+    return () => controller.abort();
+  }, []);
   const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
   const { selectedDate } = useAppointmentsStore();
 
   const fetcher = () =>
     openmrsFetch(appointmentsSearchUrl, {
       method: 'POST',
-      signal: abortController.signal,
+      signal: abortControllerRef.current.signal,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist.resource.ts
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist.resource.ts
@@ -48,26 +48,28 @@ export function useProviders() {
 }
 
 export function usePatientAppointments(patientUuid: string, startDate) {
-  const abortControllerRef = useRef(new AbortController());
-
-  useEffect(() => {
-    const controller = abortControllerRef.current;
-    return () => controller.abort();
-  }, []);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
-  const fetcher = () =>
-    openmrsFetch(appointmentsSearchUrl, {
+  const fetcher = () => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+
+    abortControllerRef.current = new AbortController();
+
+    return openmrsFetch(appointmentsSearchUrl, {
       method: 'POST',
       signal: abortControllerRef.current.signal,
       headers: {
         'Content-Type': 'application/json',
       },
       body: {
-        patientUuid: patientUuid,
-        startDate: startDate,
+        patientUuid,
+        startDate,
       },
     });
+  };
 
   const { data, error, isLoading, isValidating } = useSWR<AppointmentsFetchResponse, Error>(
     appointmentsSearchUrl,
@@ -80,6 +82,12 @@ export function usePatientAppointments(patientUuid: string, startDate) {
     ?.sort((a, b) => (a.startDateTime > b.startDateTime ? 1 : -1))
     ?.filter(({ status }) => status !== 'Cancelled')
     ?.filter(({ startDateTime }) => dayjs(new Date(startDateTime).toISOString()).isAfter(new Date()));
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   return {
     upcomingAppointment: upcomingAppointments ? upcomingAppointments?.[0] : null,

--- a/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist.resource.ts
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist.resource.ts
@@ -4,6 +4,7 @@ import { type Appointment, type AppointmentsFetchResponse } from '../types/index
 import { type Provider } from '../types';
 import { startOfDay } from '../constants';
 import dayjs from 'dayjs';
+import { useRef, useEffect } from 'react';
 
 export function useAppointments() {
   const apiUrl = `${restBaseUrl}/appointment/all?forDate=${startOfDay}`;
@@ -47,13 +48,18 @@ export function useProviders() {
 }
 
 export function usePatientAppointments(patientUuid: string, startDate) {
-  const abortController = new AbortController();
+  const abortControllerRef = useRef(new AbortController());
+
+  useEffect(() => {
+    const controller = abortControllerRef.current;
+    return () => controller.abort();
+  }, []);
 
   const appointmentsSearchUrl = `${restBaseUrl}/appointments/search`;
   const fetcher = () =>
     openmrsFetch(appointmentsSearchUrl, {
       method: 'POST',
-      signal: abortController.signal,
+      signal: abortControllerRef.current.signal,
       headers: {
         'Content-Type': 'application/json',
       },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

AbortController was being instantiated inside several React hook bodies. Since React hooks execute on every render, this resulted in a new AbortController being created each time the component rendered.

As a result, requests initiated with previous controllers could not be properly aborted when the component unmounted.

This PR fixes the issue by storing the AbortController instance in a `useRef` so it persists across renders, and aborting the request during component cleanup using `useEffect`.

## Changes Made

- Store `AbortController` in `useRef` instead of creating it on every render.
- Abort the request in `useEffect` cleanup.
- Updated the following files:

- `packages/esm-appointments-app/src/hooks/useAppointmentList.ts`
- `packages/esm-appointments-app/src/hooks/usePatientAppointmentHistory.ts`
- `packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist.resource.ts`

## Screenshots

Not applicable. This change only affects request lifecycle management and does not introduce UI changes.

## Related Issue

https://openmrs.atlassian.net/browse/O3-5490

## Other

Existing tests pass successfully after the change.