### PR TITLE
fix: Update type casting for patient name in appointment display (O3-5491)

### DIFF
--- a/packages/esm-appointments-app/src/appointments/common-components/batch-change-appointment-statuses.modal.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/batch-change-appointment-statuses.modal.tsx
@@ -145,8 +145,8 @@ const BatchChangeAppointmentStatusesModal: React.FC<BatchChangeAppointmentStatus
             {appointments.map((appointment) => (
               <li key={appointment.patient.uuid}>
                 <Trans i18nKey="appointmentDisplay">
-                  <strong>{{ patientName: appointment.patient.name } as any}</strong> -{' '}
-                  {{ serviceName: appointment.service.name } as any} - {{ currentStatus: appointment.status } as any}
+                  <strong>{{ patientName: appointment.patient.name } as unknown as React.ReactNode}</strong> -{' '}
+                  {{ serviceName: appointment.service.name }} - {{ currentStatus: appointment.status }}
                 </Trans>
               </li>
             ))}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR removes unsafe any casts from the translated appointment display in [batch-change-appointment-statuses.modal.tsx:147]  The issue was limited to the text rendered through the appointmentDisplay translation, not to the bulk status update logic itself.

What was fixed

The modal was passing patientName, serviceName, and currentStatus into the Trans component using any casts to satisfy TypeScript. That bypassed type checking for values that are already well-defined on the Appointment model. This change removes those broad casts, keeps serviceName and currentStatus as properly typed interpolated values, and uses a narrower React.ReactNode cast only for patientName where it is rendered inside the strong element.


## Related Issue
https://openmrs.atlassian.net/browse/O3-5491


