### PR TITLE
fix (O3-5493) : fix: remove invalid CSS backgroundColor value in queue linelist toolbar

### DIFF
--- a/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist-base-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist-base-table.component.tsx
@@ -156,7 +156,7 @@ const QueuePatientBaseTable: React.FC<QueuePatientTableProps> = ({
         useZebraStyles>
         {({ rows, headers, getHeaderProps, getTableProps, getRowProps, onInputChange }) => (
           <TableContainer className={styles.tableContainer}>
-            <TableToolbar style={{ position: 'static', height: '3rem', overflow: 'visible', backgroundColor: 'color' }}>
+            <TableToolbar style={{ position: 'static', height: '3rem', overflow: 'visible' }}>
               <TableToolbarContent className={styles.toolbarContent}>
                 <TableToolbarSearch
                   className={styles.search}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a conventional commit label.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an invalid CSS value used in the queue linelist toolbar.

The `TableToolbar` component was using `backgroundColor: 'color'`, which is not a valid CSS value. Browsers ignore this value, causing the toolbar background styling to be inconsistent.

The invalid value has been removed so the component can inherit the correct background styling from the Carbon theme used in the OpenMRS O3 frontend.

## Screenshots
Before:
Toolbar background style was ignored because `'color'` is not a valid CSS value.

After:
Toolbar now correctly inherits the background styling.

## Related Issue
https://openmrs.atlassian.net/browse/O3-5493

## Other
This is a small UI fix that improves consistency and prevents invalid CSS from being applied.
