### PR TITLE
feat (O3-5496): avoid mounting hidden extension panels in scheduled appointments

### DIFF
--- a/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/scheduled/scheduled-appointments.component.tsx
@@ -175,11 +175,11 @@ function ExtensionWrapper({
     return null;
   }
 
+  if (currentTab !== extension.name) {
+    return null;
+  }
   return (
-    <div
-      key={extension.name}
-      className={styles.container}
-      style={{ display: currentTab === extension.name ? 'block' : 'none' }}>
+    <div key={extension.name} className={styles.container}>
       <Extension
         state={{
           date,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a conventional commit label.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
Currently, extension panels in the Scheduled Appointments view are always mounted in the DOM and hidden using `display: none`.

This means that all extensions mount and run their hooks even when they are not visible. As a result, hidden panels may still trigger unnecessary network requests and consume additional memory.

This PR replaces the `display: none` approach with conditional rendering so that only the active tab panel is mounted. Hidden panels are no longer rendered, preventing unnecessary hook execution and improving performance.

## Screenshots
No visual UI changes are expected.  
The active tab continues to render normally, while inactive panels are not mounted instead of being hidden.

## Related Issue
https://openmrs.atlassian.net/browse/O3-5496

## Other
This change follows recommended React practices by avoiding mounting components that are not visible, improving efficiency and reducing unnecessary work during rendering.