### PR TITLE
(fix) O3-5505: Ensure isSubmitting resets when checkAppointmentConflict throws

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.workspace.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.workspace.tsx
@@ -333,78 +333,81 @@ const AppointmentsForm: React.FC<Workspace2DefinitionProps<AppointmentsFormProps
   // Same for creating and editing
   const handleSaveAppointment = async (data: AppointmentFormData) => {
     setIsSubmitting(true);
-    // Construct appointment payload
-    const appointmentPayload = constructAppointmentPayload(data);
+    try {
+      // Construct appointment payload
+      const appointmentPayload = constructAppointmentPayload(data);
 
-    // Check if a duplicate response occurs
-    const response: FetchResponse = await checkAppointmentConflict(appointmentPayload);
-    let errorMessage = t('appointmentConflict', 'Appointment conflict');
-    if (response?.data?.hasOwnProperty('SERVICE_UNAVAILABLE')) {
-      errorMessage = t('serviceUnavailable', 'Appointment time is outside of service hours');
-    } else if (response?.data?.hasOwnProperty('PATIENT_DOUBLE_BOOKING')) {
-      errorMessage = t('patientDoubleBooking', 'Patient already booked for an appointment at this time');
-    }
+      // Check if a duplicate response occurs
+      const response: FetchResponse = await checkAppointmentConflict(appointmentPayload);
+      let errorMessage = t('appointmentConflict', 'Appointment conflict');
 
-    if (response.status === 200 && errorMessage) {
-      setIsSubmitting(false);
-      showSnackbar({
-        isLowContrast: true,
-        kind: 'error',
-        title: errorMessage,
-      });
-      return;
-    }
+      if (response?.data?.hasOwnProperty('SERVICE_UNAVAILABLE')) {
+        errorMessage = t('serviceUnavailable', 'Appointment time is outside of service hours');
+      } else if (response?.data?.hasOwnProperty('PATIENT_DOUBLE_BOOKING')) {
+        errorMessage = t('patientDoubleBooking', 'Patient already booked for an appointment at this time');
+      }
 
-    // Construct recurring pattern payload
-    const recurringAppointmentPayload = {
-      appointmentRequest: appointmentPayload,
-      recurringPattern: constructRecurringPattern(data),
-    };
+      if (response.status === 200 && errorMessage) {
+        showSnackbar({
+          isLowContrast: true,
+          kind: 'error',
+          title: errorMessage,
+        });
+        return; // finally block will still run and set isSubmitting to false
+      }
 
-    const abortController = new AbortController();
+      // Construct recurring pattern payload
+      const recurringAppointmentPayload = {
+        appointmentRequest: appointmentPayload,
+        recurringPattern: constructRecurringPattern(data),
+      };
 
-    (isRecurringAppointment
-      ? saveRecurringAppointments(recurringAppointmentPayload, abortController)
-      : saveAppointment(appointmentPayload, abortController)
-    ).then(
-      ({ status }) => {
-        if (status === 200) {
-          setIsSubmitting(false);
-          setIsSuccessful(true);
-          mutateAppointments();
-          showSnackbar({
-            isLowContrast: true,
-            kind: 'success',
-            subtitle: t('appointmentNowVisible', 'It is now visible on the Appointments page'),
-            title: isEditing
-              ? t('appointmentEdited', 'Appointment edited')
-              : t('appointmentScheduled', 'Appointment scheduled'),
-          });
-        }
-        if (status === 204) {
-          setIsSubmitting(false);
-          showSnackbar({
-            title: isEditing
-              ? t('appointmentEditError', 'Error editing appointment')
-              : t('appointmentFormError', 'Error scheduling appointment'),
-            kind: 'error',
-            isLowContrast: false,
-            subtitle: t('noContent', 'No Content'),
-          });
-        }
-      },
-      (error) => {
-        setIsSubmitting(false);
+      const abortController = new AbortController();
+
+      // Convert the .then() chain into a clean await so 'finally' fires at the correct time
+      const saveResponse = await (isRecurringAppointment
+        ? saveRecurringAppointments(recurringAppointmentPayload, abortController)
+        : saveAppointment(appointmentPayload, abortController));
+
+      const { status } = saveResponse;
+
+      if (status === 200) {
+        setIsSuccessful(true);
+        mutateAppointments();
+        showSnackbar({
+          isLowContrast: true,
+          kind: 'success',
+          subtitle: t('appointmentNowVisible', 'It is now visible on the Appointments page'),
+          title: isEditing
+            ? t('appointmentEdited', 'Appointment edited')
+            : t('appointmentScheduled', 'Appointment scheduled'),
+        });
+      }
+
+      if (status === 204) {
         showSnackbar({
           title: isEditing
             ? t('appointmentEditError', 'Error editing appointment')
             : t('appointmentFormError', 'Error scheduling appointment'),
           kind: 'error',
           isLowContrast: false,
-          subtitle: error?.message,
+          subtitle: t('noContent', 'No Content'),
         });
-      },
-    );
+      }
+    } catch (error: any) {
+      // Catches errors from BOTH checkAppointmentConflict and saveAppointment
+      showSnackbar({
+        title: isEditing
+          ? t('appointmentEditError', 'Error editing appointment')
+          : t('appointmentFormError', 'Error scheduling appointment'),
+        kind: 'error',
+        isLowContrast: false,
+        subtitle: error?.message,
+      });
+    } finally {
+      // Guarantees the button is re-enabled regardless of success, early returns, or thrown errors
+      setIsSubmitting(false);
+    }
   };
 
   const constructAppointmentPayload = (data: AppointmentFormData): AppointmentPayload => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

---

## Summary

This PR fixes an issue where the `isSubmitting` state in the appointments form could remain `true` if an error occurs while checking appointment conflicts.

In `handleSaveAppointment`, `setIsSubmitting(true)` is called before the async request `checkAppointmentConflict()`. If this request throws an error (e.g., network failure or API error), execution exits the function before `setIsSubmitting(false)` is called. This causes the submit button to remain disabled and the form becomes stuck in a submitting state.

To resolve this:

- The logic inside `handleSaveAppointment` is wrapped in a `try/catch/finally` block.
- The `.then()` promise chain was converted to `async/await` for cleaner error handling.
- The `finally` block ensures `setIsSubmitting(false)` is always executed, regardless of success, failure, or early return.

This guarantees that the submit button is re-enabled and the form does not remain stuck after an error.

---

## Screenshots

Not applicable.  
This change only affects error handling logic and does not modify the UI.

---

## Related Issue

https://openmrs.atlassian.net/browse/O3-5505

---

## Other

This change improves reliability of the appointments form by ensuring the submitting state is always reset, preventing a poor user experience where the form becomes permanently disabled after an error.