### PR TITLE
(fix) O3-5506: Handle serveQueueEntry errors in call queue modal

### DIFF
--- a/packages/esm-service-queues-app/src/modals/call-modal/call-queue-entry.modal.tsx
+++ b/packages/esm-service-queues-app/src/modals/call-modal/call-queue-entry.modal.tsx
@@ -31,43 +31,40 @@ const CallQueueEntryModal: React.FC<CallQueueEntryModalProps> = ({ closeModal, q
 
   const { mutateQueueEntries } = useMutateQueueEntries();
 
-  const launchEditPriorityModal = useCallback(() => {
-    const endedAt = new Date();
-    updateQueueEntry(
-      mappedQueueEntry.visitUuid,
-      mappedQueueEntry.queueUuid,
-      mappedQueueEntry.queueUuid,
-      mappedQueueEntry.queueEntryUuid,
-      mappedQueueEntry.patientUuid,
-      mappedQueueEntry.priority?.uuid,
-      defaultTransitionStatus,
-      endedAt,
-      mappedQueueEntry.sortWeight,
-    ).then(
-      () => {
-        serveQueueEntry(mappedQueueEntry.queue.name, mappedQueueEntry.visitQueueNumber, 'serving').then(
-          ({ status }) => {
-            showSnackbar({
-              isLowContrast: true,
-              title: t('success', 'Success'),
-              kind: 'success',
-              subtitle: t('patientAttendingService', 'Patient attending service'),
-            });
-            closeModal();
-            mutateQueueEntries();
-            navigate({ to: `\${openmrsSpaBase}/patient/${mappedQueueEntry.patientUuid}/chart` });
-          },
-        );
-      },
-      (error) => {
-        showSnackbar({
-          title: t('queueEntryUpdateFailed', 'Error updating queue entry'),
-          kind: 'error',
-          isLowContrast: false,
-          subtitle: error?.message,
-        });
-      },
-    );
+  const launchEditPriorityModal = useCallback(async () => {
+    try {
+      const endedAt = new Date();
+      await updateQueueEntry(
+        mappedQueueEntry.visitUuid,
+        mappedQueueEntry.queueUuid,
+        mappedQueueEntry.queueUuid,
+        mappedQueueEntry.queueEntryUuid,
+        mappedQueueEntry.patientUuid,
+        mappedQueueEntry.priority?.uuid,
+        defaultTransitionStatus,
+        endedAt,
+        mappedQueueEntry.sortWeight,
+      );
+
+      await serveQueueEntry(mappedQueueEntry.queue.name, mappedQueueEntry.visitQueueNumber, 'serving');
+
+      showSnackbar({
+        isLowContrast: true,
+        title: t('success', 'Success'),
+        kind: 'success',
+        subtitle: t('patientAttendingService', 'Patient attending service'),
+      });
+      closeModal();
+      mutateQueueEntries();
+      navigate({ to: `\${openmrsSpaBase}/patient/${mappedQueueEntry.patientUuid}/chart` });
+    } catch (error) {
+      showSnackbar({
+        title: t('queueEntryUpdateFailed', 'Error updating queue entry'),
+        kind: 'error',
+        isLowContrast: false,
+        subtitle: error?.message,
+      });
+    }
   }, [
     closeModal,
     defaultTransitionStatus,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

---

## Summary

This PR fixes an issue in the call queue entry modal where errors from `serveQueueEntry` were not handled.

Previously, the implementation used nested `.then()` chains:

- `updateQueueEntry` had an error handler
- `serveQueueEntry` did **not** have an error handler

If `serveQueueEntry` failed (for example due to a network or API error), the error would be silently swallowed and the user would receive no feedback.

This PR refactors the logic by:

- Converting the nested `.then()` chain to `async/await`
- Wrapping the logic inside a `try/catch` block
- Ensuring errors from both `updateQueueEntry` and `serveQueueEntry` are properly handled

Now, if serving the queue entry fails, the user receives an error notification instead of the failure being silent.

---

## Screenshots

Not applicable.  
This change only improves error handling and does not introduce UI changes.

---

## Related Issue

https://openmrs.atlassian.net/browse/O3-5506

---

## Other

This change improves reliability of the service queues workflow by ensuring failures during the serving process are surfaced to the user instead of being silently ignored.