### PR TITLE
(fix) O3-5507: Replace unsafe hasOwnProperty usage with Object.hasOwn

### DIFF
--- a/packages/esm-appointments-app/src/form/appointments-form.workspace.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.workspace.tsx
@@ -339,9 +339,9 @@ const AppointmentsForm: React.FC<Workspace2DefinitionProps<AppointmentsFormProps
     // Check if a duplicate response occurs
     const response: FetchResponse = await checkAppointmentConflict(appointmentPayload);
     let errorMessage = t('appointmentConflict', 'Appointment conflict');
-    if (response?.data?.hasOwnProperty('SERVICE_UNAVAILABLE')) {
+    if (Object.hasOwn(response?.data ?? {}, 'SERVICE_UNAVAILABLE')) {
       errorMessage = t('serviceUnavailable', 'Appointment time is outside of service hours');
-    } else if (response?.data?.hasOwnProperty('PATIENT_DOUBLE_BOOKING')) {
+    } else if (Object.hasOwn(response?.data ?? {}, 'PATIENT_DOUBLE_BOOKING')) {
       errorMessage = t('patientDoubleBooking', 'Patient already booked for an appointment at this time');
     }
 

--- a/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist-base-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist-base-table.component.tsx
@@ -70,7 +70,7 @@ const QueuePatientBaseTable: React.FC<QueuePatientTableProps> = ({
         if (typeof filterableValue === 'boolean') {
           return false;
         }
-        if (filterableValue.hasOwnProperty('content')) {
+        if (Object.hasOwn(filterableValue, 'content')) {
           if (Array.isArray(filterableValue.content.props.children)) {
             return ('' + filterableValue.content.props.children[1].props.children).toLowerCase().includes(filterTerm);
           }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

---

## Summary

This PR replaces unsafe direct usage of `obj.hasOwnProperty()` with the safer modern alternative `Object.hasOwn()`.

Calling `hasOwnProperty` directly on an object can be unsafe if the object has a null prototype (`Object.create(null)`) or if the object overrides the `hasOwnProperty` method.

The following locations were updated:

- `packages/esm-appointments-app/src/form/appointments-form.workspace.tsx`
- `packages/esm-service-queues-app/src/queue-patient-linelists/queue-linelist-base-table.component.tsx`

The changes ensure property checks are safe regardless of the object's prototype.

---

## Screenshots

Not applicable.  
This change only updates internal property checks and does not modify UI behavior.

---

## Related Issue
https://openmrs.atlassian.net/browse/O3-5507

---

## Other

This change follows modern JavaScript best practices by replacing unsafe direct `hasOwnProperty` calls with `Object.hasOwn`.