### PR TITLE
(fix) O3-5509: Prevent undefined values in inpatientAdmissions array

### DIFF
--- a/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
+++ b/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
@@ -87,10 +87,12 @@ export function createAndGetWardPatientGrouping(
   inpatientAdmissionsAtOtherLocations: InpatientAdmission[],
   currentWardLocation: Location,
 ) {
-  const inpatientAdmissionsByPatientUuid = getInpatientAdmissionsUuidMap([
+  const inpatientAdmissions = [
     ...(inpatientAdmissionsAtCurrentLocation ?? []),
     ...(inpatientAdmissionsAtOtherLocations ?? []),
-  ]);
+  ].filter((admission): admission is InpatientAdmission => admission != null);
+
+  const inpatientAdmissionsByPatientUuid = getInpatientAdmissionsUuidMap(inpatientAdmissions);
 
   const wardAdmittedPatientsWithBed = new Map<string, InpatientAdmission>();
   const wardUnadmittedPatientsWithBed = new Map<string, Patient>();
@@ -124,6 +126,7 @@ export function createAndGetWardPatientGrouping(
 
   for (const inpatientRequest of inpatientRequests ?? []) {
     // TODO: inpatientRequest is undefined sometimes, why?
+    //FIXED
     if (inpatientRequest) {
       allWardPatientUuids.add(inpatientRequest.patient.uuid);
     }


### PR DESCRIPTION
## Requirements

* [x] This PR has a title that briefly describes the work done including the ticket number.
* [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
* [x] My work includes tests or is validated by existing tests.

---

## Summary

This PR fixes an issue where the `inpatientAdmissions` array may contain `undefined` values when combining:

* `inpatientAdmissionsAtCurrentLocation`
* `inpatientAdmissionsAtOtherLocations`

The arrays were previously merged using spread syntax:

```
[
  ...(inpatientAdmissionsAtCurrentLocation ?? []),
  ...(inpatientAdmissionsAtOtherLocations ?? []),
]
```

When paginated data is still loading or incomplete, these arrays may contain `undefined` values. As a result, `undefined` entries could propagate into `getInpatientAdmissionsUuidMap`, which is acknowledged in the code by the comment:

```
// TODO: inpatientAdmission is undefined sometimes, why?
```

To address this, the merged array is now filtered using a TypeScript type guard to ensure that only valid `InpatientAdmission` objects are included.

```
const inpatientAdmissions = [
  ...(inpatientAdmissionsAtCurrentLocation ?? []),
  ...(inpatientAdmissionsAtOtherLocations ?? []),
].filter((admission): admission is InpatientAdmission => admission != null);
```

This guarantees that `getInpatientAdmissionsUuidMap` receives a clean `InpatientAdmission[]`.

### Result

* Prevents `undefined` values from entering the admissions array
* Aligns runtime behavior with the declared TypeScript types
* Resolves the TODO comment indicating unexpected undefined values
* No functional changes to existing logic

---

## Screenshots

N/A – This change does not affect UI.

---

## Related Issue

https://openmrs.atlassian.net/browse/O3-5509

---

## Other

This change is a small internal improvement that ensures stronger type safety and prevents runtime inconsistencies when handling inpatient admissions data.
