### PR TITLE
(fix) O3-5510: Replace map with forEach and prevent undefined inpatientAdmissions

### DIFF
--- a/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
+++ b/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
@@ -97,9 +97,9 @@ export function createAndGetWardPatientGrouping(
   const bedLayouts = admissionLocation && filterBeds(admissionLocation);
   const allWardPatientUuids = new Set<string>();
   let wardPatientPendingCount = 0;
-  bedLayouts?.map((bedLayout) => {
+  bedLayouts?.forEach((bedLayout) => {
     const { patients } = bedLayout;
-    patients.map((patient) => {
+    patients.forEach((patient) => {
       const admission = inpatientAdmissionsByPatientUuid.get(patient.uuid);
       allWardPatientUuids.add(patient.uuid);
       if (admission?.currentInpatientLocation?.uuid == currentWardLocation.uuid) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR addresses issues in `ward-view.resource.ts`.

* Replaced `Array.map()` with `Array.forEach()` where iteration is used only for side effects.
* Filtered out `null` and `undefined` values from the merged `inpatientAdmissions` array using a TypeScript type guard.

This improves code readability, avoids unnecessary array creation, and ensures type-safe handling of admissions data.

## Screenshots

Not applicable.

## Related Issue

https://openmrs.atlassian.net/browse/O3-5510

## Other

No breaking changes. This is an internal code quality improvement.
