### PR TITLE
(fix) O3-4569: Layout overflow in 'Clear Queue' modal and in 'Add Provider queue room' component

### DIFF
--- a/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.modal.tsx
+++ b/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Button, ButtonSkeleton, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
@@ -16,7 +16,17 @@ const ClearQueueEntriesModal: React.FC<ClearQueueEntriesModalProps> = ({ queueEn
   const { t } = useTranslation();
   const { mutateQueueEntries } = useMutateQueueEntries();
   const [isSubmitting, setIsSubmitting] = useState(false);
-
+  useEffect(() => {
+    const modalContainer = document.querySelector('.cds--modal-container');
+    if (modalContainer) {
+      modalContainer.classList.add('clear-queue-modal-container');
+    }
+    return () => {
+      if (modalContainer) {
+        modalContainer.classList.remove('clear-queue-modal-container');
+      }
+    };
+  }, []);
   const handleClearQueueBatchRequest = useCallback(() => {
     setIsSubmitting(true);
     batchClearQueueEntries(queueEntries).then(

--- a/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.scss
+++ b/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.scss
@@ -10,3 +10,17 @@
 .clearQueueButton:hover {
   color: $danger;
 }
+
+@media (max-width: 41.9375rem) {
+  :global(.cds--modal-container) {
+    position: fixed !important;
+    top: 0 !important;
+    bottom: 0 !important;
+    left: 50% !important;
+    margin: auto 0 auto -42% !important;
+    width: 84% !important;
+    max-height: 90% !important;
+    height: fit-content !important;
+    grid-template-rows: auto auto auto !important;
+  }
+}

--- a/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.scss
+++ b/packages/esm-service-queues-app/src/modals/clear-queue-entries-modal/clear-queue-entries.scss
@@ -12,7 +12,7 @@
 }
 
 @media (max-width: 41.9375rem) {
-  :global(.cds--modal-container) {
+  :global(.clear-queue-modal-container) {
     position: fixed !important;
     top: 0 !important;
     bottom: 0 !important;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including 
      the ticket number (fix) O3-4569 with conventional commit label
- [x] My work is based on designs, which are used in our project for UI consistance

## Summary
Problem Statement:

- When the screen width falls below 670px, the Service Queues page exhibited horizontal overflow and inconsistent UI, making it unresponsive.

Solution:

- clear-queue-entries.scss — Modal centered and properly sized below 42rem, mirroring Carbon's own behaviour at larger breakpoints

## Screenshots
<img width="1037" height="777" alt="image" src="https://github.com/user-attachments/assets/755380e8-f353-4245-8796-74e7043a7b8d" />

## Related Issue
https://openmrs.atlassian.net/browse/O3-4569

## Other
Open to feedback on code structure or approach. 
Happy to make any changes requested.
