### PR TITLE
(fix) O3-5525: Decode URL pathname correctly using decodeURIComponent

### DIFF
--- a/packages/esm-service-queues-app/src/queue-patient-linelists/queue-services-table.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-patient-linelists/queue-services-table.component.tsx
@@ -6,7 +6,7 @@ import QueuePatientBaseTable from './queue-linelist-base-table.component';
 const ServicesTable: React.FC = () => {
   const { t } = useTranslation();
 
-  const currentPathName: string = window.location.pathname.replace('%20', ' ');
+  const currentPathName: string = decodeURIComponent(window.location.pathname);
   let service = currentPathName.split('/')[6];
   let locationUuid = currentPathName.split('/')[8];
   const { serviceQueueEntries, isLoading } = useServiceQueueEntries(service, locationUuid);


### PR DESCRIPTION
## Requirements

* [x] This PR has a title that briefly describes the work done including the ticket number. 
* [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
* [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where URL-encoded spaces (`%20`) in `window.location.pathname` were not being fully decoded.
Previously, the code used: window.location.pathname.replace('%20', ' ');
This only replaces the first occurrence of `%20`, which leads to incorrect parsing when service or location names contain multiple spaces.

This PR replaces the logic with: decodeURIComponent(window.location.pathname);

## Screenshots

N/A (No UI changes)

## Related Issue
https://openmrs.atlassian.net/browse/O3-5525

## Other

* This change improves robustness by handling all URL-encoded characters, not just `%20`.
* Prevents incorrect parsing for multi-word service or location names.
