### PR TITLE
(fix) O3-5526: Handle rejected promises in Autosuggest search

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.component.tsx
@@ -47,9 +47,14 @@ export const Autosuggest = <Suggestion = unknown,>({
     onSuggestionSelected(name, undefined);
 
     if (query) {
-      getSearchResults(query).then((suggestions) => {
-        setSuggestions(suggestions);
-      });
+      getSearchResults(query)
+        .then((suggestions) => {
+          setSuggestions(suggestions);
+        })
+        .catch((error) => {
+          console.error('Autosuggest error:', error);
+          setSuggestions([]);
+        });
     } else {
       setSuggestions([]);
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an issue in the Autosuggest component where rejected promises from `getSearchResults` were not handled.

Previously, if the search request failed (e.g., network error or server error), the promise rejection was silently ignored. This resulted in empty suggestions being shown without any indication of failure, making debugging difficult and degrading user experience.

## Changes
- Added `.catch()` to handle rejected promises from `getSearchResults`
- Logged errors using `console.error` for better debugging
- Ensured safe fallback by resetting suggestions to an empty array

## Screenshots
N/A (No UI changes)

## Related Issue
https://openmrs.atlassian.net/browse/O3-5526

## Other
This change improves error handling and prevents silent failures in the Autosuggest component, aligning with best practices for handling asynchronous operations in React.