### PR TITLE
(fix) O3-5527: Avoid duplicate DOM ids in Autosuggest component

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/autosuggest/autosuggest.component.tsx
@@ -72,7 +72,7 @@ export const Autosuggest = <Suggestion = unknown,>({
       <label className="cds--label">{labelText}</label>
       <Layer className={classNames({ [styles.invalid]: invalid })}>
         <Search
-          id="autosuggest"
+          id={searchProps.id ?? `autosuggest-${name}`}
           onChange={handleChange}
           onClear={handleClear}
           ref={searchBox}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an issue in the Autosuggest component where a hardcoded `id="autosuggest"` was used for the `<Search>` element.

When multiple Autosuggest components are rendered on the same page (e.g., in patient registration or relationships section), this results in duplicate DOM ids, which violates HTML standards.

This can lead to:
- Accessibility issues (incorrect label associations and screen reader behavior)
- Incorrect DOM lookups (e.g., `document.getElementById` returns only the first match)
- Potential UI inconsistencies

## Screenshots
N/A (No visible UI changes)

## Related Issue
https://openmrs.atlassian.net/browse/O3-5527

## Other
N/A