### PR TITLE
(fix) O3-5528: Use SPA navigation instead of history.back in cancelRegistration

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-utils.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-utils.ts
@@ -1,5 +1,5 @@
 import camelCase from 'lodash-es/camelCase';
-import { parseDate } from '@openmrs/esm-framework';
+import { parseDate , navigate } from '@openmrs/esm-framework';
 import {
   type Encounter,
   type FormValues,
@@ -16,7 +16,7 @@ export function scrollIntoView(viewId: string) {
 }
 
 export function cancelRegistration() {
-  window.history.back();
+  navigate({ to: `${window.getOpenmrsSpaBase()}home` });
 }
 
 export function getFormValuesFromFhirPatient(patient: fhir.Patient) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR replaces the use of `window.history.back()` in `cancelRegistration` with the OpenMRS SPA navigation utility.
Using `window.history.back()` bypasses the SPA routing system and depends on the browser history stack, which can lead to unpredictable navigation and may take users outside the application.
Replaced `window.history.back()` with `navigate()` from `@openmrs/esm-framework`
Ensures consistent and controlled navigation within the SPA

## Validation
Manually tested navigation from patient registration page
Verified that cancel action routes to the home page consistently
Confirmed no navigation outside the SPA

## Screenshots
N/A (No UI changes)

## Related Issue
https://openmrs.atlassian.net/browse/O3-5528

## Other
This change aligns navigation behavior with OpenMRS frontend best practices and improves reliability of user flow.
