### PR TITLE
(fix) O3-5545: Fix calendar prev/next buttons not updating the displayed month

### DIFF
--- a/packages/esm-appointments-app/src/calendar/appointments-calendar-view.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/appointments-calendar-view.component.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import dayjs from 'dayjs';
-import { useParams } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import dayjs, { type Dayjs } from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { useAppointmentsCalendar } from '../hooks/useAppointmentsCalendar';
 import AppointmentsHeader from '../header/appointments-header.component';
@@ -11,13 +10,23 @@ import { useSelectedDate } from '../hooks/useSelectedDate';
 const AppointmentsCalendarView: React.FC = () => {
   const { t } = useTranslation();
   const selectedDate = useSelectedDate();
-  const { calendarEvents } = useAppointmentsCalendar(dayjs(selectedDate).toISOString(), 'monthly');
+  const [calendarSelectedDate, setCalendarSelectedDate] = useState<Dayjs>(dayjs(selectedDate));
+
+  useEffect(() => {
+    setCalendarSelectedDate(dayjs(selectedDate));
+  }, [selectedDate]);
+
+  const { calendarEvents } = useAppointmentsCalendar(calendarSelectedDate.toISOString(), 'monthly');
 
   return (
     <div data-testid="appointments-calendar">
       <AppointmentsHeader title={t('calendar', 'Calendar')} />
       <CalendarHeader />
-      <MonthlyCalendarView events={calendarEvents} />
+      <MonthlyCalendarView
+        events={calendarEvents}
+        calendarSelectedDate={calendarSelectedDate}
+        setCalendarSelectedDate={setCalendarSelectedDate}
+      />
     </div>
   );
 };

--- a/packages/esm-appointments-app/src/calendar/appointments-calendar-view.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/appointments-calendar-view.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import dayjs, { type Dayjs } from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { useAppointmentsCalendar } from '../hooks/useAppointmentsCalendar';
@@ -11,10 +11,6 @@ const AppointmentsCalendarView: React.FC = () => {
   const { t } = useTranslation();
   const selectedDate = useSelectedDate();
   const [calendarSelectedDate, setCalendarSelectedDate] = useState<Dayjs>(dayjs(selectedDate));
-
-  useEffect(() => {
-    setCalendarSelectedDate(dayjs(selectedDate));
-  }, [selectedDate]);
 
   const { calendarEvents } = useAppointmentsCalendar(calendarSelectedDate.toISOString(), 'monthly');
 

--- a/packages/esm-appointments-app/src/calendar/appointments-calendar-view.test.tsx
+++ b/packages/esm-appointments-app/src/calendar/appointments-calendar-view.test.tsx
@@ -1,23 +1,55 @@
 import React from 'react';
+import dayjs from 'dayjs';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
-import AppointmentsCalendarView from './appointments-calendar-view.component';
 import { BrowserRouter } from 'react-router-dom';
+import AppointmentsCalendarView from './appointments-calendar-view.component';
+import { useAppointmentsCalendar } from '../hooks/useAppointmentsCalendar';
+
+jest.mock('../hooks/useAppointmentsCalendar', () => ({
+  useAppointmentsCalendar: jest.fn().mockReturnValue({ calendarEvents: [], isLoading: false, error: null }),
+}));
+
+const mockUseAppointmentsCalendar = jest.mocked(useAppointmentsCalendar);
+
+function renderCalendar() {
+  return render(
+    <BrowserRouter>
+      <AppointmentsCalendarView />
+    </BrowserRouter>,
+  );
+}
+
+function latestRequestedDate() {
+  const lastCall = mockUseAppointmentsCalendar.mock.calls.at(-1);
+  return dayjs(lastCall?.[0]);
+}
 
 describe('Appointment calendar view', () => {
-  it('renders appointments in calendar view from appointments list', async () => {
-    render(
-      <BrowserRouter>
-        <AppointmentsCalendarView />
-      </BrowserRouter>,
-    );
+  it('renders the calendar view with Prev and Next controls', () => {
+    renderCalendar();
+    expect(screen.getByTestId('appointments-calendar')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /previous month/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next month/i })).toBeInTheDocument();
+  });
 
-    const expectedTableRows = [
-      /John Wilson 30-Aug-2021 03:35 03:35 Dr James Cook Outpatient Walk in appointments/,
-      /Neil Amstrong 10-Sept-2021 03:50 03:50 Dr James Cook Outpatient Some additional notes/,
-    ];
+  it('advances the calendar by one month when Next is clicked', async () => {
+    const user = userEvent.setup();
+    renderCalendar();
+    const initialDate = latestRequestedDate();
 
-    expectedTableRows.forEach((row) => {
-      expect(screen.queryByRole('row', { name: new RegExp(row, 'i') })).not.toBeInTheDocument();
-    });
+    await user.click(screen.getByRole('button', { name: /next month/i }));
+
+    expect(latestRequestedDate().diff(initialDate, 'month')).toBe(1);
+  });
+
+  it('rewinds the calendar by one month when Prev is clicked', async () => {
+    const user = userEvent.setup();
+    renderCalendar();
+    const initialDate = latestRequestedDate();
+
+    await user.click(screen.getByRole('button', { name: /previous month/i }));
+
+    expect(initialDate.diff(latestRequestedDate(), 'month')).toBe(1);
   });
 });

--- a/packages/esm-appointments-app/src/calendar/monthly/days-of-week.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/days-of-week.component.tsx
@@ -8,7 +8,7 @@ import styles from './days-of-week.scss';
 // t('MON', 'MON');
 // t('TUE', 'TUE');
 // t('WED', 'WED');
-// t('THUR', 'THUR');
+// t('THU', 'THU');
 // t('FRI', 'FRI');
 // t('SAT', 'SAT');
 // t('SUN', 'SUN');

--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-calendar-view.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-calendar-view.component.tsx
@@ -1,29 +1,72 @@
-import React from 'react';
-import dayjs from 'dayjs';
+import React, { useCallback } from 'react';
 import isBetween from 'dayjs/plugin/isBetween';
+import dayjs, { type Dayjs } from 'dayjs';
+import { Button } from '@carbon/react';
+import { formatDate } from '@openmrs/esm-framework';
+import { useTranslation } from 'react-i18next';
 import { type DailyAppointmentsCountByService } from '../../types';
 import { monthDays } from '../../helpers';
+import DaysOfWeekCard from './days-of-week.component';
 import MonthlyViewWorkload from './monthly-workload-view.component';
-import MonthlyHeader from './monthly-header.component';
-import { useSelectedDate } from '../../hooks/useSelectedDate';
 import styles from '../appointments-calendar-view-view.scss';
+import headerStyles from './monthly-header.scss';
 
 dayjs.extend(isBetween);
 
+const DAYS_IN_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THUR', 'FRI', 'SAT'];
+
 interface MonthlyCalendarViewProps {
   events: Array<DailyAppointmentsCountByService>;
+  calendarSelectedDate: Dayjs;
+  setCalendarSelectedDate: React.Dispatch<React.SetStateAction<Dayjs>>;
 }
 
-const MonthlyCalendarView: React.FC<MonthlyCalendarViewProps> = ({ events }) => {
-  const selectedDate = useSelectedDate();
+const MonthlyCalendarView: React.FC<MonthlyCalendarViewProps> = ({
+  events,
+  calendarSelectedDate,
+  setCalendarSelectedDate,
+}) => {
+  const { t } = useTranslation();
+
+  const handleSelectPrevMonth = useCallback(() => {
+    setCalendarSelectedDate((prev) => prev.subtract(1, 'month'));
+  }, [setCalendarSelectedDate]);
+
+  const handleSelectNextMonth = useCallback(() => {
+    setCalendarSelectedDate((prev) => prev.add(1, 'month'));
+  }, [setCalendarSelectedDate]);
 
   return (
     <div className={styles.calendarViewContainer}>
-      <MonthlyHeader />
+      <>
+        <div className={headerStyles.container}>
+          <Button
+            aria-label={t('previousMonth', 'Previous month')}
+            kind="tertiary"
+            onClick={handleSelectPrevMonth}
+            size="sm">
+            {t('prev', 'Prev')}
+          </Button>
+          <span>{formatDate(calendarSelectedDate.toDate(), { day: false, time: false, noToday: true })}</span>
+          <Button aria-label={t('nextMonth', 'Next month')} kind="tertiary" onClick={handleSelectNextMonth} size="sm">
+            {t('next', 'Next')}
+          </Button>
+        </div>
+        <div className={headerStyles.workLoadCard}>
+          {DAYS_IN_WEEK.map((day) => (
+            <DaysOfWeekCard key={day} dayOfWeek={day} />
+          ))}
+        </div>
+      </>
       <div className={styles.wrapper}>
         <div className={styles.monthlyCalendar}>
-          {monthDays(dayjs(selectedDate)).map((dateTime, i) => (
-            <MonthlyViewWorkload key={i} dateTime={dateTime} events={events} />
+          {monthDays(calendarSelectedDate).map((dateTime, i) => (
+            <MonthlyViewWorkload
+              key={i}
+              dateTime={dateTime}
+              events={events}
+              calendarSelectedDate={calendarSelectedDate}
+            />
           ))}
         </div>
       </div>

--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-calendar-view.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-calendar-view.component.tsx
@@ -1,19 +1,13 @@
 import React, { useCallback } from 'react';
 import isBetween from 'dayjs/plugin/isBetween';
 import dayjs, { type Dayjs } from 'dayjs';
-import { Button } from '@carbon/react';
-import { formatDate } from '@openmrs/esm-framework';
-import { useTranslation } from 'react-i18next';
 import { type DailyAppointmentsCountByService } from '../../types';
 import { monthDays } from '../../helpers';
-import DaysOfWeekCard from './days-of-week.component';
+import MonthlyHeader from './monthly-header.component';
 import MonthlyViewWorkload from './monthly-workload-view.component';
 import styles from '../appointments-calendar-view-view.scss';
-import headerStyles from './monthly-header.scss';
 
 dayjs.extend(isBetween);
-
-const DAYS_IN_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THUR', 'FRI', 'SAT'];
 
 interface MonthlyCalendarViewProps {
   events: Array<DailyAppointmentsCountByService>;
@@ -26,8 +20,6 @@ const MonthlyCalendarView: React.FC<MonthlyCalendarViewProps> = ({
   calendarSelectedDate,
   setCalendarSelectedDate,
 }) => {
-  const { t } = useTranslation();
-
   const handleSelectPrevMonth = useCallback(() => {
     setCalendarSelectedDate((prev) => prev.subtract(1, 'month'));
   }, [setCalendarSelectedDate]);
@@ -38,26 +30,11 @@ const MonthlyCalendarView: React.FC<MonthlyCalendarViewProps> = ({
 
   return (
     <div className={styles.calendarViewContainer}>
-      <>
-        <div className={headerStyles.container}>
-          <Button
-            aria-label={t('previousMonth', 'Previous month')}
-            kind="tertiary"
-            onClick={handleSelectPrevMonth}
-            size="sm">
-            {t('prev', 'Prev')}
-          </Button>
-          <span>{formatDate(calendarSelectedDate.toDate(), { day: false, time: false, noToday: true })}</span>
-          <Button aria-label={t('nextMonth', 'Next month')} kind="tertiary" onClick={handleSelectNextMonth} size="sm">
-            {t('next', 'Next')}
-          </Button>
-        </div>
-        <div className={headerStyles.workLoadCard}>
-          {DAYS_IN_WEEK.map((day) => (
-            <DaysOfWeekCard key={day} dayOfWeek={day} />
-          ))}
-        </div>
-      </>
+      <MonthlyHeader
+        calendarSelectedDate={calendarSelectedDate}
+        onSelectPrevMonth={handleSelectPrevMonth}
+        onSelectNextMonth={handleSelectNextMonth}
+      />
       <div className={styles.wrapper}>
         <div className={styles.monthlyCalendar}>
           {monthDays(calendarSelectedDate).map((dateTime, i) => (

--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-header.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-header.component.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
-import { formatDate } from '@openmrs/esm-framework';
+import { formatDate, navigate } from '@openmrs/esm-framework';
 import DaysOfWeekCard from './days-of-week.component';
 import styles from './monthly-header.scss';
+import { spaHomePage } from '../../constants';
 import { useSelectedDate } from '../../hooks/useSelectedDate';
 
 const DAYS_IN_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THUR', 'FRI', 'SAT'];
@@ -12,16 +13,19 @@ const DAYS_IN_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THUR', 'FRI', 'SAT'];
 const MonthlyHeader: React.FC = () => {
   const { t } = useTranslation();
   const selectedDate = useSelectedDate();
-
-  const [calendarSelectedDate, setCalendarSelectedDate] = useState(dayjs(selectedDate));
+  const calendarSelectedDate = dayjs(selectedDate);
 
   const handleSelectPrevMonth = useCallback(() => {
-    setCalendarSelectedDate(calendarSelectedDate.subtract(1, 'month'));
-  }, [calendarSelectedDate, setCalendarSelectedDate]);
+    navigate({
+      to: `${spaHomePage}/appointments/calendar/${calendarSelectedDate.subtract(1, 'month').format('YYYY-MM-DD')}`,
+    });
+  }, [calendarSelectedDate]);
 
   const handleSelectNextMonth = useCallback(() => {
-    setCalendarSelectedDate(calendarSelectedDate.add(1, 'month'));
-  }, [calendarSelectedDate, setCalendarSelectedDate]);
+    navigate({
+      to: `${spaHomePage}/appointments/calendar/${calendarSelectedDate.add(1, 'month').format('YYYY-MM-DD')}`,
+    });
+  }, [calendarSelectedDate]);
 
   return (
     <>

--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-header.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-header.component.tsx
@@ -1,44 +1,34 @@
-import React, { useCallback } from 'react';
-import dayjs from 'dayjs';
+import React from 'react';
+import { type Dayjs } from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
-import { formatDate, navigate } from '@openmrs/esm-framework';
+import { formatDate } from '@openmrs/esm-framework';
 import DaysOfWeekCard from './days-of-week.component';
 import styles from './monthly-header.scss';
-import { spaHomePage } from '../../constants';
-import { useSelectedDate } from '../../hooks/useSelectedDate';
 
-const DAYS_IN_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THUR', 'FRI', 'SAT'];
+const DAYS_IN_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
-const MonthlyHeader: React.FC = () => {
+interface MonthlyHeaderProps {
+  calendarSelectedDate: Dayjs;
+  onSelectPrevMonth: () => void;
+  onSelectNextMonth: () => void;
+}
+
+const MonthlyHeader: React.FC<MonthlyHeaderProps> = ({
+  calendarSelectedDate,
+  onSelectPrevMonth,
+  onSelectNextMonth,
+}) => {
   const { t } = useTranslation();
-  const selectedDate = useSelectedDate();
-  const calendarSelectedDate = dayjs(selectedDate);
-
-  const handleSelectPrevMonth = useCallback(() => {
-    navigate({
-      to: `${spaHomePage}/appointments/calendar/${calendarSelectedDate.subtract(1, 'month').format('YYYY-MM-DD')}`,
-    });
-  }, [calendarSelectedDate]);
-
-  const handleSelectNextMonth = useCallback(() => {
-    navigate({
-      to: `${spaHomePage}/appointments/calendar/${calendarSelectedDate.add(1, 'month').format('YYYY-MM-DD')}`,
-    });
-  }, [calendarSelectedDate]);
 
   return (
     <>
       <div className={styles.container}>
-        <Button
-          aria-label={t('previousMonth', 'Previous month')}
-          kind="tertiary"
-          onClick={handleSelectPrevMonth}
-          size="sm">
+        <Button aria-label={t('previousMonth', 'Previous month')} kind="tertiary" onClick={onSelectPrevMonth} size="sm">
           {t('prev', 'Prev')}
         </Button>
-        <span>{formatDate(new Date(selectedDate), { day: false, time: false, noToday: true })}</span>
-        <Button aria-label={t('nextMonth', 'Next month')} kind="tertiary" onClick={handleSelectNextMonth} size="sm">
+        <span>{formatDate(calendarSelectedDate.toDate(), { day: false, time: false, noToday: true })}</span>
+        <Button aria-label={t('nextMonth', 'Next month')} kind="tertiary" onClick={onSelectNextMonth} size="sm">
           {t('next', 'Next')}
         </Button>
       </div>

--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view-expanded.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view-expanded.component.tsx
@@ -8,7 +8,12 @@ interface MonthlyWorkloadViewExpandedProps extends MonthlyWorkloadViewProps {
   count: number;
 }
 
-const MonthlyWorkloadViewExpanded: React.FC<MonthlyWorkloadViewExpandedProps> = ({ count, events, dateTime }) => {
+const MonthlyWorkloadViewExpanded: React.FC<MonthlyWorkloadViewExpandedProps> = ({
+  count,
+  events,
+  dateTime,
+  calendarSelectedDate,
+}) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const popoverRef = useRef(null);
@@ -38,7 +43,12 @@ const MonthlyWorkloadViewExpanded: React.FC<MonthlyWorkloadViewExpandedProps> = 
         {t('countMore', '{{count}} more', { count })}
       </button>
       <PopoverContent>
-        <MonthlyWorkloadView events={events} dateTime={dateTime} showAllServices={true} />
+        <MonthlyWorkloadView
+          events={events}
+          dateTime={dateTime}
+          calendarSelectedDate={calendarSelectedDate}
+          showAllServices={true}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-workload-view.component.tsx
@@ -7,18 +7,22 @@ import { spaHomePage } from '../../constants';
 import { isSameMonth } from '../../helpers';
 import { type DailyAppointmentsCountByService } from '../../types';
 import MonthlyWorkloadViewExpanded from './monthly-workload-view-expanded.component';
-import { useSelectedDate } from '../../hooks/useSelectedDate';
 import styles from './monthly-view-workload.scss';
 
 export interface MonthlyWorkloadViewProps {
   events: Array<DailyAppointmentsCountByService>;
   dateTime: Dayjs;
+  calendarSelectedDate: Dayjs;
   showAllServices?: boolean;
 }
 
-const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({ dateTime, events, showAllServices = false }) => {
+const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({
+  dateTime,
+  events,
+  calendarSelectedDate,
+  showAllServices = false,
+}) => {
   const layout = useLayoutType();
-  const selectedDate = useSelectedDate();
 
   const currentData = useMemo(
     () =>
@@ -52,7 +56,7 @@ const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({ dateTime, eve
     <div
       onClick={() => navigateToAppointmentsByDate('')}
       className={classNames(
-        styles[isSameMonth(dateTime, dayjs(selectedDate)) ? 'monthly-cell' : 'monthly-cell-disabled'],
+        styles[isSameMonth(dateTime, calendarSelectedDate) ? 'monthly-cell' : 'monthly-cell-disabled'],
         showAllServices
           ? {}
           : {
@@ -60,7 +64,7 @@ const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({ dateTime, eve
               [styles.largeDesktop]: layout !== 'small-desktop',
             },
       )}>
-      {isSameMonth(dateTime, dayjs(selectedDate)) && (
+      {isSameMonth(dateTime, calendarSelectedDate) && (
         <div>
           <span className={classNames(styles.totals)}>
             {currentData?.services ? (
@@ -94,6 +98,7 @@ const MonthlyWorkloadView: React.FC<MonthlyWorkloadViewProps> = ({ dateTime, eve
                   count={currentData.services.length - (layout === 'small-desktop' ? 2 : 4)}
                   events={events}
                   dateTime={dateTime}
+                  calendarSelectedDate={calendarSelectedDate}
                 />
               ) : (
                 ''

--- a/packages/esm-appointments-app/translations/en.json
+++ b/packages/esm-appointments-app/translations/en.json
@@ -162,7 +162,7 @@
   "serviceUnavailable": "Appointment time is outside of service hours",
   "status": "Status",
   "SUN": "SUN",
-  "THUR": "THUR",
+  "THU": "THU",
   "time": "Time",
   "today": "Today",
   "todaysAppointment": "Today's Appointments",


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

The Prev and Next buttons were updating a local `calendarSelectedDate` state inside `MonthlyHeader`, while the calendar grid and data fetching read `selectedDate` from `useSelectedDate()`. The two sources fell out of sync, so clicking Prev/Next changed the label but not the view.

**Fix:** Lift the month state up to `AppointmentsCalendarView` and pass the navigation handlers down to `MonthlyHeader`. The calendar now has a single source of truth for the displayed month, and the route-driven `selectedDate` continues to control the appointments table's date filter without unintended coupling between the two.

## Screenshots
Before

https://github.com/user-attachments/assets/2655e978-5956-4833-82e6-3dda0e53c85c

After

https://github.com/user-attachments/assets/75c1312c-1451-4276-97e3-7e04c526be10

## Related Issue
https://openmrs.atlassian.net/browse/O3-5545


## Other


