### PR TITLE
(fix) O3-5546: Prevent mutation in reduce by replacing Object.assign with object spread

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
@@ -320,7 +320,7 @@ function useInitialEncounters(patientUuid: string, patientToEdit: fhir.Patient) 
     ?.map(({ concept, value }) => ({
       [(concept as OpenmrsResource).uuid]: typeof value === 'object' ? value?.uuid : value,
     }))
-    .reduce((accu, curr) => Object.assign(accu, curr), {});
+    .reduce((accu, curr) => ({ ...accu, ...curr }), {});
 
   return { data: encounters, isLoading, error };
 }

--- a/packages/esm-service-queues-app/src/current-visit/visit-details/vitals.component.tsx
+++ b/packages/esm-service-queues-app/src/current-visit/visit-details/vitals.component.tsx
@@ -22,8 +22,11 @@ const Vitals: React.FC<VitalsComponentProps> = ({ vitals, patientUuid, visitType
   const { data: conceptUnits, conceptMetadata } = useVitalsConceptMetadata();
 
   const vitalsToDisplay = vitals.reduce(
-    (previousVital, currentVital) => Object.assign(previousVital, currentVital),
-    {},
+    (mergedVitals, currentVital) => ({
+      ...mergedVitals,
+      ...currentVital,
+    }),
+    {} as Record<string, any>,
   );
 
   return (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. The title follows the conventional commit format.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes unintended object mutation caused by the use of `Object.assign` inside `reduce`.

`Object.assign(target, source)` mutates the target object in place. In the vitals aggregation logic, this led to mutation of objects derived from the original `vitals` array, potentially corrupting source data and causing unpredictable behavior.

Additionally, `Object.assign` was used with the accumulator in `reduce`, which, although initialized as an empty object, still relies on mutation and reduces code clarity.

The implementation replaces `Object.assign` with object spread syntax (`{ ...acc, ...curr }`) to ensure immutability and prevent side effects.

## Screenshots
N/A (No UI changes)

## Related Issue
https://openmrs.atlassian.net/browse/O3-5546

## Other
- Prevents unintended mutation of source data (critical in vitals case)
- Improves code safety and predictability
- Aligns with modern best practices (immutability)
- No functional changes introduced