### PR TITLE
(fix) O3-5533: Replace unsafe any types in patient-list-management-app

### DIFF
--- a/packages/esm-patient-list-management-app/src/api/types.ts
+++ b/packages/esm-patient-list-management-app/src/api/types.ts
@@ -38,7 +38,7 @@ export interface PatientListFilter {
 export interface PatientListOption {
   type: string;
   name: string;
-  value: any;
+  value: string | number | boolean;
 }
 
 export interface PatientListMember {
@@ -57,8 +57,8 @@ export interface OpenmrsCohort {
   resourceVersion: string;
   name: string;
   description: string;
-  attributes: Array<any>;
-  links: Array<any>;
+  attributes: Array<OpenmrsResource>;
+  links: Array<{ rel: string; uri: string; resourceAlias?: string }>;
   location: Location | null;
   groupCohort: boolean | null;
   startDate: string | null;
@@ -76,7 +76,7 @@ export interface OpenmrsCohortRef {
 }
 
 export interface OpenmrsCohortMember {
-  attributes: Array<any>;
+  attributes: Array<OpenmrsResource>;
   description: string;
   endDate: string;
   startDate: string;
@@ -88,7 +88,7 @@ export interface OpenmrsCohortMember {
 
 export interface CohortResponse<T> {
   results: Array<T>;
-  error: any;
+  error: Error | null;
   totalCount: number;
 }
 

--- a/packages/esm-patient-list-management-app/src/error-state/error-state.component.tsx
+++ b/packages/esm-patient-list-management-app/src/error-state/error-state.component.tsx
@@ -4,8 +4,15 @@ import { useTranslation } from 'react-i18next';
 import { useLayoutType } from '@openmrs/esm-framework';
 import styles from './error-state.scss';
 
+interface FetchError extends Error {
+  response?: {
+    status?: number;
+    statusText?: string;
+  };
+}
+
 export interface ErrorStateProps {
-  error: any;
+  error: FetchError;
   headerTitle: string;
 }
 

--- a/packages/esm-patient-list-management-app/src/list-details-table/list-details-table.component.tsx
+++ b/packages/esm-patient-list-management-app/src/list-details-table/list-details-table.component.tsx
@@ -130,6 +130,16 @@ interface SearchProps extends InputPropsBase {
   value?: string | number;
 }
 
+interface PatientListPatient {
+  name: string;
+  identifier: string;
+  sex: string;
+  startDate: string;
+  mobile?: string;
+  membershipUuid: string;
+  uuid: string;
+}
+
 interface ListDetailsTableProps {
   autoFocus?: boolean;
   columns: Array<PatientTableColumn>;
@@ -140,7 +150,7 @@ interface ListDetailsTableProps {
   pagination: {
     usePagination: boolean;
     currentPage: number;
-    onChange(props: any): any;
+    onChange(data: { page: number; pageSize: number }): void;
     pageSize: number;
     totalItems: number;
     pagesUnknown?: boolean;
@@ -154,9 +164,10 @@ interface ListDetailsTableProps {
 interface PatientTableColumn {
   key: string;
   header: string;
-  getValue?(patient: any): any;
+  getValue?(patient: PatientListPatient): string | React.ReactNode;
   link?: {
-    getUrl(patient: any): string;
+    getUrl(patient: PatientListPatient): string;
+};
   };
 }
 
@@ -188,7 +199,7 @@ const ListDetailsTable: React.FC<ListDetailsTableProps> = ({
     return debouncedSearchTerm
       ? fuzzy
           .filter(debouncedSearchTerm, patients, {
-            extract: (patient: any) => `${patient.name} ${patient.identifier} ${patient.sex}`,
+            extract: (patient: PatientListPatient) => `${patient.name} ${patient.identifier} ${patient.sex}`,
           })
           .sort((r1, r2) => r1.score - r2.score)
           .map((result) => result.original)


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
Replaces unsafe `any` type declarations in the `esm-patient-list-management-app` 
package with proper TypeScript types, improving type safety and compile-time 
checking across three files:

- **`error-state.component.tsx`**: Introduced a `FetchError` interface to 
  replace `error: any`, modelling the actual response structure used in the 
  component.
- **`api/types.ts`**: Replaced `value: any` in `PatientListOption` with 
  `string | number | boolean`, typed `attributes` arrays with `OpenmrsResource`, 
  typed `links` arrays with a proper link interface, and replaced `error: any` 
  in `CohortResponse` with `Error | null`.
- **`list-details-table.component.tsx`**: Introduced a `PatientListPatient` 
  interface to replace all `patient: any` usages, and properly typed the 
  pagination `onChange` signature with `{ page: number; pageSize: number }`.

## Screenshots
No UI changes were made. This is a type-safety improvement only.

## Related Issue
https://openmrs.atlassian.net/browse/O3-5533
https://issues.openmrs.org/browse/O3-5533

## Other
This contribution is part of the broader O3-5531 initiative to implement 
stricter TypeScript configuration across the O3 Patient Management module.