### PR TITLE
(fix) O3-5564: Correct useMemo dependency in useSelectedDate

### DIFF
--- a/packages/esm-appointments-app/src/hooks/useSelectedDate.ts
+++ b/packages/esm-appointments-app/src/hooks/useSelectedDate.ts
@@ -20,5 +20,5 @@ export function useSelectedDate() {
       }
     }
     return dayjs().startOf('day').format('YYYY-MM-DD');
-  }, [params]);
+  }, [params.date]);
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a conventional commit label.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an issue in `useSelectedDate` where `useMemo` depended on the entire `params` object returned by useParams.

Since `useParams()` returns a new object on every render, this caused `useMemo` to recompute on every render, defeating memoization.

The dependency has been updated from `[params]` to `[params.date]`, ensuring memoization works correctly and recomputation only occurs when the relevant parameter changes.

## Screenshots
N/A (No UI changes)

## Related Issue
https://openmrs.atlassian.net/browse/O3-5564
## Other
This is a minimal fix with no functional changes beyond correcting memoization behavior.