### PR TITLE
(fix) O3-5566: Memoize MultiSelect items to prevent selection reset

### DIFF
--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
@@ -129,10 +129,22 @@ const AppointmentsTable: React.FC<AppointmentsTableProps> = ({ appointments, isL
       .map((appointment) => appointment.uuid);
   }, [appointments, visits]);
 
+  const statusItems = useMemo(
+    () =>
+      Object.values(AppointmentStatus).map((status) => ({
+        id: status,
+        label: t(status),
+      })),
+    [t],
+  );
+
+  const selectedStatusItems = useMemo(
+    () => selectedAppointmentStatuses.map((status) => statusItems.find((item) => item.id === status)).filter(Boolean),
+    [selectedAppointmentStatuses, statusItems],
+  );
   if (isLoading) {
     return <DataTableSkeleton role="progressbar" rowCount={5} />;
   }
-
   return (
     <Layer className={styles.container}>
       <div className={styles.headerContainer}>
@@ -192,14 +204,14 @@ const AppointmentsTable: React.FC<AppointmentsTableProps> = ({ appointments, isL
                   <MultiSelect
                     id="statusMultiSelect"
                     size={responsiveSize}
-                    items={Object.values(AppointmentStatus).map((status) => ({ id: status, label: t(status) }))}
+                    items={statusItems}
                     itemToString={(item) => (item ? item.label : '')}
                     label={t('filterAppointmentsByStatus', 'Filter appointments by status')}
                     onChange={({ selectedItems }) =>
                       setSelectedAppointmentStatuses([...new Set(selectedItems.map((item) => item.id))])
                     }
                     type="inline"
-                    selectedItems={selectedAppointmentStatuses.map((status) => ({ id: status, label: t(status) }))}
+                    selectedItems={selectedStatusItems}
                   />
                   <Button
                     size={responsiveSize}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a conventional commit label.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue in the appointments table where the Carbon MultiSelect component was recreating `items` and `selectedItems` on every render.

Since MultiSelect relies on referential equality to track selected items, recreating these objects caused the selected options to appear to reset or flicker.

To resolve this, both `items` and `selectedItems` are memoized using `useMemo`, ensuring stable references across renders and correct selection behavior.

## Screenshots

N/A (No visual UI changes, but fixes selection stability issue)

## Related Issue
https://openmrs.atlassian.net/browse/O3-5566

## Other

This is a minimal and safe change with no impact on existing functionality beyond fixing the selection inconsistency and improving performance.