### PR TITLE
(fix) O3-5484: Enable monthly calendar navigation between months

### DIFF
--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-header.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-header.component.tsx
@@ -1,27 +1,29 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
-import { formatDate } from '@openmrs/esm-framework';
+import { formatDate, navigate } from '@openmrs/esm-framework';
 import DaysOfWeekCard from './days-of-week.component';
 import styles from './monthly-header.scss';
 import { useSelectedDate } from '../../hooks/useSelectedDate';
+import { spaHomePage } from '../../constants';
 
 const DAYS_IN_WEEK = ['SUN', 'MON', 'TUE', 'WED', 'THUR', 'FRI', 'SAT'];
 
 const MonthlyHeader: React.FC = () => {
   const { t } = useTranslation();
   const selectedDate = useSelectedDate();
-
-  const [calendarSelectedDate, setCalendarSelectedDate] = useState(dayjs(selectedDate));
+  const calendarSelectedDate = dayjs(selectedDate);
 
   const handleSelectPrevMonth = useCallback(() => {
-    setCalendarSelectedDate(calendarSelectedDate.subtract(1, 'month'));
-  }, [calendarSelectedDate, setCalendarSelectedDate]);
+    const previousMonthDate = calendarSelectedDate.subtract(1, 'month');
+    navigate({ to: `${spaHomePage}/appointments/calendar/${previousMonthDate}` });
+  }, [calendarSelectedDate]);
 
   const handleSelectNextMonth = useCallback(() => {
-    setCalendarSelectedDate(calendarSelectedDate.add(1, 'month'));
-  }, [calendarSelectedDate, setCalendarSelectedDate]);
+    const nextMonthDate = calendarSelectedDate.add(1, 'month');
+    navigate({ to: `${spaHomePage}/appointments/calendar/${nextMonthDate}` });
+  }, [calendarSelectedDate]);
 
   return (
     <>

--- a/packages/esm-appointments-app/src/calendar/monthly/monthly-header.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/monthly/monthly-header.component.tsx
@@ -17,12 +17,12 @@ const MonthlyHeader: React.FC = () => {
 
   const handleSelectPrevMonth = useCallback(() => {
     const previousMonthDate = calendarSelectedDate.subtract(1, 'month');
-    navigate({ to: `${spaHomePage}/appointments/calendar/${previousMonthDate}` });
+    navigate({ to: `${spaHomePage}/appointments/calendar/${previousMonthDate.format('YYYY-MM-DD')}` });
   }, [calendarSelectedDate]);
 
   const handleSelectNextMonth = useCallback(() => {
     const nextMonthDate = calendarSelectedDate.add(1, 'month');
-    navigate({ to: `${spaHomePage}/appointments/calendar/${nextMonthDate}` });
+    navigate({ to: `${spaHomePage}/appointments/calendar/${nextMonthDate.format('YYYY-MM-DD')}` });
   }, [calendarSelectedDate]);
 
   return (

--- a/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import useSWR from 'swr';
 import { omrsDateFormat } from '../constants';
 import { type DailyAppointmentsCountByService } from '../types';
+import { useMemo } from 'react';
 
 interface AppointmentCountMapEntry {
   allAppointmentsCount: number;
@@ -25,22 +26,32 @@ export const useAppointmentsCalendar = (forDate: string, period: string) => {
     openmrsFetch,
     { errorRetryCount: 2 },
   );
-  const results: Array<DailyAppointmentsCountByService> = data?.data.reduce((acc, service) => {
-    const serviceName = service.appointmentService.name;
-    const serviceUuid = service.appointmentService.uuid;
-    Object.entries(service.appointmentCountMap).forEach(([key, value]) => {
-      const existingEntry = acc.find((entry) => entry.appointmentDate === key);
-      if (existingEntry) {
-        existingEntry.services.push({ serviceName, serviceUuid, count: value.allAppointmentsCount });
-      } else {
-        acc.push({
-          appointmentDate: key,
-          services: [{ serviceName, serviceUuid, count: value.allAppointmentsCount }],
+
+  const results: Array<DailyAppointmentsCountByService> = useMemo(() => {
+    if (!data?.data) return [];
+    const map = new Map<string, DailyAppointmentsCountByService>();
+    for (const service of data.data) {
+      const { name: serviceName, uuid: serviceUuid } = service.appointmentService;
+
+      for (const [date, value] of Object.entries(service.appointmentCountMap)) {
+        if (!map.has(date)) {
+          map.set(date, {
+            appointmentDate: date,
+            services: [],
+          });
+        }
+
+        map.get(date)?.services.push({
+          serviceName,
+          serviceUuid,
+          count: value.allAppointmentsCount,
         });
       }
-    });
-    return acc;
-  }, []);
+    }
+
+    return Array.from(map.values());
+  }, [data]);
+
   return { isLoading, calendarEvents: results, error };
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR is fixing the (Prev, Next) to display the next and previous calendar month

## Summary

This PR fixes a critical bug in the monthly calendar view that made the "Prev" and "Next" navigation buttons non-functional. Clicking these buttons did not update the displayed month, making it impossible to navigate through the calendar.

**Root Cause:** The component maintained a disconnected local state for month navigation while the calendar grid relied on global URL parameters. This state mismatch prevented route updates when navigation buttons were clicked.

**Solution:**
- Removed local state management (`useState`) and replaced it with route-based navigation
- Updated `handleSelectPrevMonth` and `handleSelectNextMonth` to use `navigate()` from `@openmrs/esm-framework`
- Calendar now properly updates the URL (e.g., `/appointments/calendar/date`) when navigation buttons are clicked
- Grid re-renders automatically with the new month's data

## Screenshots

N/A

## Related Issue

[Issue link](https://openmrs.atlassian.net/jira/software/c/projects/O3/issues?jql=project%20%3D%20O3%20AND%20textfields%20~%20%22useAppointmentscal%2A%22%20ORDER%20BY%20cf%5B10019%5D%20ASC&selectedIssue=O3-5484)

## Other

- Files changed: `packages/esm-appointments-app/src/calendar/monthly/monthly-header.component.tsx`
- This is a prerequisite fix before implementing the view switcher and additional calendar view types