### PR TITLE
fix: handle undefined appointmentCountMap in useAppointmentsCalendar

### DIFF
--- a/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
@@ -28,6 +28,8 @@ export const useAppointmentsCalendar = (forDate: string, period: string) => {
   const results: Array<DailyAppointmentsCountByService> = data?.data.reduce((acc, service) => {
     const serviceName = service.appointmentService.name;
     const serviceUuid = service.appointmentService.uuid;
+    // Convert appointment count map into structured calendar data
+    if (!service.appointmentCountMap) return;
     Object.entries(service.appointmentCountMap).forEach(([key, value]) => {
       const existingEntry = acc.find((entry) => entry.appointmentDate === key);
       if (existingEntry) {


### PR DESCRIPTION
## Summary

This PR adds a safeguard to handle cases where `appointmentCountMap` may be undefined in the `useAppointmentsCalendar` hook.

Currently, the code assumes that `appointmentCountMap` is always available. Adding this check prevents potential runtime errors and improves the robustness of the data processing logic.

## Screenshots

Not applicable (no UI changes).

## Related Issue

N/A

## Other

- Added a null/undefined check before processing `appointmentCountMap`
- Improves code stability and maintainability