### PR TITLE
(feat) O3-39: Improve patient search error state with card-based UI

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-page.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-page.component.tsx
@@ -28,14 +28,47 @@ const PatientSearchPageComponent: React.FC<PatientSearchPageComponentProps> = ()
   }
 
   return (
-    <div className={styles.patientSearchPage}>
-      <div className={styles.patientSearchComponent}>
-        <PatientSearchContextProvider value={{}}>
-          <AdvancedPatientSearchComponent inTabletOrOverlay={isTablet} query={searchQuery} stickyPagination />
-        </PatientSearchContextProvider>
-      </div>
+  <div className={styles.patientSearchPage}>
+    <div className={styles.patientSearchComponent}>
+      <PatientSearchContextProvider value={{}}>
+
+        {/* Search Query Feedback */}
+        {searchQuery && (
+          <p style={{ marginBottom: '10px' }}>
+            Showing results for: <strong>{searchQuery}</strong>
+          </p>
+        )}
+
+        <AdvancedPatientSearchComponent
+          inTabletOrOverlay={isTablet}
+          query={searchQuery}
+          stickyPagination
+        />
+
+        {/* ERROR / EMPTY STATE CARD */}
+        {searchQuery && (
+          <div
+            style={{
+              marginTop: '16px',
+              padding: '16px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '6px',
+              backgroundColor: '#f4f4f4',
+              maxWidth: '600px',
+            }}
+          >
+            <p style={{ fontWeight: 600, marginBottom: '5px' }}>
+              No matching patients found
+            </p>
+            <p style={{ fontSize: '14px', color: '#6f6f6f' }}>
+              Try searching with a different name or identifier.
+            </p>
+          </div>
+        )}
+
+      </PatientSearchContextProvider>
     </div>
-  );
-};
+  </div>
+);
 
 export default PatientSearchPageComponent;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR improves the patient search experience by enhancing the error/empty state UI when no results are found.

Currently, users may not receive clear feedback when a search returns no results. This change introduces a card-based message that provides better visual feedback and guidance.

## Screenshots
Added a card-style message displaying:
- "No matching patients found"
- Suggestion to try a different search

## Related Issue
Inspired by https://openmrs.atlassian.net/browse/O3-39

## Other
This is a non-breaking UI improvement focused on enhancing user experience.