### PR TITLE
fix: add null guard for startedAt in QueueDuration component

### DIFF
--- a/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
+++ b/packages/esm-service-queues-app/src/hooks/useQueueEntries.ts
@@ -13,6 +13,12 @@ type QueueEntryResponse = FetchResponse<{
   }>;
   totalCount: number;
 }>;
+// // TODO (GSoC 2026 - Performance): This repString causes severe over-fetching.
+// For each patient, it fetches full concept objects for status/priority (including
+// names, descriptions, mappings), full encounter arrays with obs/diagnoses, and
+// a duplicated previousQueueEntry — none of which the queue table renders.
+// The queue table only needs ~9 flat fields (see cells/columns.resource.ts).
+// Fix: Replace with a new QueueEntryListingRestController returning a flat DTO.
 
 const queueEntryBaseUrl = `${restBaseUrl}/queue-entry`;
 

--- a/packages/esm-service-queues-app/src/queue-table/components/queue-duration.component.tsx
+++ b/packages/esm-service-queues-app/src/queue-table/components/queue-duration.component.tsx
@@ -22,6 +22,14 @@ function DurationString({ startedAt, endedAt }: { startedAt: Date; endedAt: Date
     return () => clearInterval(handle);
   }, []);
 
+  // --- NEW GUARD CLAUSE START ---
+  // If startedAt is missing, we cannot calculate a duration.
+  // Returning a placeholder (--) prevents the 'diff' calculation from failing.
+  if (!startedAt) {
+    return <span>--</span>;
+  }
+  // --- NEW GUARD CLAUSE END ---
+
   const totalMinutes = dayjs(endedTime ?? currentTime).diff(startedAt, 'minutes');
   const hours = Math.trunc(totalMinutes / 60);
   const minutes = Math.trunc(totalMinutes % 60);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary

While performing a technical audit of the esm-service-queues-app for GSoC 2026, I identified a potential UI crash/invalid rendering in the QueueDuration component.
Currently, if a QueueEntry is initialized or fetched without a valid startedAt timestamp, the dayjs().diff() calculation can return NaN or invalid strings. This PR adds a defensive guard clause to the DurationString sub-component to return a placeholder (--) when the timestamp is missing, ensuring UI stability.

## Screenshots
This is a logic-level fix to prevent invalid text (NaN) from appearing in the Duration column of the Service Queue table.

## Related Issue
Jira access currently pending approval (Requested March 30, 2026). This fix addresses a stability edge-case found during GSoC proposal research for the 'Service Queues Improvements' project

## Other
This fix was tested locally against the dev3 environment to ensure the component renders the placeholder correctly when startedAt is null."
