### PR TITLE
(fix) Add null safety and fallback handling in useAppointmentsCalendar hook

### DIFF
--- a/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
@@ -27,7 +27,7 @@ export const useAppointmentsCalendar = (forDate: string, period: string) => {
   );
   // Transform API response into daily appointment counts grouped by service
 
-  const results: Array<DailyAppointmentsCountByService> = (data?.data ?? []).reduce((acc, service) => {
+   const results = (data?.data ?? []).reduce<DailyAppointmentsCountByService[]>((acc, service) => {
     const serviceName = service.appointmentService.name;
     const serviceUuid = service.appointmentService.uuid;
 

--- a/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
@@ -26,9 +26,8 @@ export const useAppointmentsCalendar = (forDate: string, period: string) => {
     { errorRetryCount: 2 },
   );
   // Transform API response into daily appointment counts grouped by service
-  const safeData = data?.data ?? [];
 
-  const results: Array<DailyAppointmentsCountByService> = safeData.reduce((acc, service) => {
+  const results: Array<DailyAppointmentsCountByService> = (data?.data ?? []).reduce((acc, service) => {
     const serviceName = service.appointmentService.name;
     const serviceUuid = service.appointmentService.uuid;
 

--- a/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
@@ -61,6 +61,8 @@ export const useAppointmentsCalendar = (forDate: string, period: string) => {
 
 function evaluateAppointmentCalendarDates(forDate: string, period: string) {
   if (period === 'daily') {
+   
+    console.warn(`Unhandled period value: ${period}, defaulting to daily`);
     return {
       startDate: dayjs(forDate).startOf('day').format(omrsDateFormat),
       endDate: dayjs(forDate).endOf('day').format(omrsDateFormat),

--- a/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
@@ -81,4 +81,10 @@ function evaluateAppointmentCalendarDates(forDate: string, period: string) {
       endDate: dayjs(forDate).endOf('month').format(omrsDateFormat),
     };
   }
+
+  // Default fallback (THIS is the new part)
+  return {
+    startDate: dayjs(forDate).startOf('day').format(omrsDateFormat),
+    endDate: dayjs(forDate).endOf('day').format(omrsDateFormat),
+  };
 }

--- a/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
@@ -57,7 +57,7 @@ export const useAppointmentsCalendar = (forDate: string, period: string) => {
 
     return acc;
   }, []);
-  return { isLoading, calendarEvents: results ?? [], error };
+  return { isLoading, calendarEvents: results, error };
 };
 
 function evaluateAppointmentCalendarDates(forDate: string, period: string) {

--- a/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentsCalendar.ts
@@ -26,23 +26,38 @@ export const useAppointmentsCalendar = (forDate: string, period: string) => {
     { errorRetryCount: 2 },
   );
   // Transform API response into daily appointment counts grouped by service
-  const results: Array<DailyAppointmentsCountByService> = data?.data.reduce((acc, service) => {
+  const safeData = data?.data ?? [];
+
+  const results: Array<DailyAppointmentsCountByService> = safeData.reduce((acc, service) => {
     const serviceName = service.appointmentService.name;
     const serviceUuid = service.appointmentService.uuid;
-    Object.entries(service.appointmentCountMap).forEach(([key, value]) => {
+
+    Object.entries(service.appointmentCountMap ?? {}).forEach(([key, value]) => {
       const existingEntry = acc.find((entry) => entry.appointmentDate === key);
+
       if (existingEntry) {
-        existingEntry.services.push({ serviceName, serviceUuid, count: value.allAppointmentsCount });
+        existingEntry.services.push({
+          serviceName,
+          serviceUuid,
+          count: value?.allAppointmentsCount ?? 0,
+        });
       } else {
         acc.push({
           appointmentDate: key,
-          services: [{ serviceName, serviceUuid, count: value.allAppointmentsCount }],
+          services: [
+            {
+              serviceName,
+              serviceUuid,
+              count: value?.allAppointmentsCount ?? 0,
+            },
+          ],
         });
       }
     });
+
     return acc;
   }, []);
-  return { isLoading, calendarEvents: results, error };
+  return { isLoading, calendarEvents: results ?? [], error };
 };
 
 function evaluateAppointmentCalendarDates(forDate: string, period: string) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR improves the stability of the appointments calendar hook by handling potential runtime errors caused by undefined or unexpected data.

Changes include:
- Added null safety for API response (`data?.data ?? []`) to prevent crashes during reduce operations
- Safely handled `appointmentCountMap` using a fallback to avoid errors when undefined
- Added optional chaining and default values for `allAppointmentsCount`
- Added a default fallback return in `evaluateAppointmentCalendarDates` to prevent undefined return values

These changes ensure the hook behaves safely even when API data is missing or invalid.

## Screenshots

Not applicable (no UI changes)

## Related Issue

N/A

## Other

This is a small stability improvement focused on preventing edge-case crashes in the appointments calendar logic.