### PR TITLE
(fix) O3-5600: Lowercase appointments patient chart dashboard path

### DIFF
--- a/e2e/pages/appointments-page.ts
+++ b/e2e/pages/appointments-page.ts
@@ -6,7 +6,7 @@ export class PatientChartAppointmentsPage {
   readonly appointmentsTable = () => this.page.getByTestId('table');
 
   async goto(uuid: string) {
-    await this.page.goto(`${process.env.E2E_BASE_URL}/spa/patient/${uuid}/chart/Appointments`);
+    await this.page.goto(`${process.env.E2E_BASE_URL}/spa/patient/${uuid}/chart/appointments`);
   }
 }
 

--- a/packages/esm-appointments-app/src/dashboard.meta.ts
+++ b/packages/esm-appointments-app/src/dashboard.meta.ts
@@ -16,6 +16,6 @@ export const patientChartDashboardMeta = {
   slot: 'patient-chart-appointments-dashboard-slot',
   columns: 1,
   title: 'Appointments',
-  path: 'Appointments',
+  path: 'appointments',
   icon: 'omrs-icon-event-schedule',
 } as const;

--- a/packages/esm-appointments-app/src/routes.json
+++ b/packages/esm-appointments-app/src/routes.json
@@ -55,7 +55,7 @@
         "columns": 1,
         "columnSpan": 1,
         "hideDashboardTitle": true,
-        "path": "Appointments",
+        "path": "appointments",
         "slot": "patient-chart-appointments-dashboard-slot",
         "title": "Appointments"
       }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

Changes the patient chart appointments dashboard path from `Appointments` to `appointments` for URL consistency with the dashboard path cleanup in [openmrs-esm-patient-chart#3217](https://github.com/openmrs/openmrs-esm-patient-chart/pull/3217).

This is part of the broader effort to use clean, lowercase, hyphenated URL paths for dashboard slugs across O3. The patient-chart PR includes a legacy alias map that ensures old URLs (like `/chart/Appointments`) continue to resolve correctly, so this change should be merged after that PR lands.

## Screenshots

## Related Issue

https://openmrs.atlassian.net/browse/O3-5600

## Other

Depends on https://github.com/openmrs/openmrs-esm-patient-chart/pull/3217 being merged first (provides the legacy alias map for backward compatibility).