### PR TITLE
(fix) Use local time format for forDate in useAppointmentList

### DIFF
--- a/packages/esm-appointments-app/src/hooks/useAppointmentList.ts
+++ b/packages/esm-appointments-app/src/hooks/useAppointmentList.ts
@@ -2,10 +2,11 @@ import dayjs from 'dayjs';
 import useSWR from 'swr';
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { type AppointmentsFetchResponse } from '../types';
+import { omrsDateFormat } from '../constants';
 import { useSelectedDate } from './useSelectedDate';
 
 export const useAppointmentList = (date: string) => {
-  const startOfDay = dayjs(date).startOf('day').toISOString();
+  const startOfDay = dayjs(date).startOf('day').format(omrsDateFormat);
   const searchUrl = `${restBaseUrl}/appointments?forDate=${startOfDay}`;
 
   const { data, ...rest } = useSWR<AppointmentsFetchResponse, Error>(searchUrl, openmrsFetch);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

`useAppointmentList` was sending `forDate` as a UTC ISO timestamp via `dayjs(date).startOf('day').toISOString()`. For users in timezones east of UTC this produces the *previous* calendar day. At UTC+3, selecting 2026-04-18 produces `2026-04-17T21:00:00.000Z`.

The backend's `convertToLocalDateFromUTC` parses `forDate` with a `SimpleDateFormat` pattern that has no timezone token, so it reads the literal date/time digits and queries the wrong day. As a result, the daily appointments list can come back empty even when appointments exist for the selected date.

Format the value with `omrsDateFormat` (`YYYY-MM-DDTHH:mm:ss.SSSZZ`) so the sent string reflects local midnight (e.g. `2026-04-18T00:00:00.000+0300`) and the backend reads the intended date.

## Screenshots

### Before

https://github.com/user-attachments/assets/fa175488-a4d7-4417-aa2c-2029a660816f

### After

https://github.com/user-attachments/assets/e53f5e8b-bbfd-43a0-b27f-8021b597a725

## Related Issue

<!-- https://issues.openmrs.org/browse/O3- -->

## Other
