### PR TITLE
(feat) O3-5620: Show inpatient note edit history

### DIFF
--- a/e2e/pages/ward-page.ts
+++ b/e2e/pages/ward-page.ts
@@ -80,6 +80,37 @@ export class WardPage {
       .click();
   }
 
+  async selectBedForAdmission(bedNumber: string) {
+    await this.page.getByText(`${bedNumber} · Empty`).click();
+  }
+
+  async confirmAdmission() {
+    await this.page.getByRole('button', { name: 'Admit', exact: true }).click();
+  }
+
+  ////////////////////////////////////////
+  // Edit inpatients notes / View edit history
+
+  async selectEditNoteOption() {
+    await this.page.getByRole('button', { name: 'Options' }).click();
+    await this.page.getByRole('menuitem', { name: /^edit$/i }).click();
+  }
+
+  async fillEditNote(note: string) {
+    await this.page.getByRole('textbox', { name: /edit note/i }).fill(note);
+  }
+
+  async clickSaveEditButton() {
+    await this.page.getByRole('button', { name: 'Save edit' }).click();
+  }
+
+  async selectViewEditHistoryOption() {
+    await this.page.getByRole('button', { name: 'Options' }).click();
+    await this.page.getByRole('menuitem', { name: /view edit history/i }).click();
+  }
+
+  ////////////////////////////////////////
+
   async expectAdmissionSuccessNotification(patientName: string, bedNumber: string) {
     await this.page
       .getByText(new RegExp(`${patientName}\\s+has been successfully admitted and assigned to bed ${bedNumber}`, 'i'))

--- a/e2e/specs/ward-patient-notes.spec.ts
+++ b/e2e/specs/ward-patient-notes.spec.ts
@@ -131,7 +131,7 @@ test('Add a patient note to an inpatient admission', async ({ page, api }) => {
 
   await test.step('Then I should see the modal showing the edit history with 2 versions', async () => {
     await expect(page.getByText('Note edit history')).toBeVisible();
-    // await expect(page.getByText('Sample patient note - edited')).toBeVisible();
+    await expect(page.getByRole('dialog').getByText('Sample patient note - edited')).toBeVisible();
     await expect(page.getByText('Sample patient note', { exact: true })).toBeVisible();
   });
 });

--- a/e2e/specs/ward-patient-notes.spec.ts
+++ b/e2e/specs/ward-patient-notes.spec.ts
@@ -54,11 +54,11 @@ test('Add a patient note to an inpatient admission', async ({ page, api }) => {
   });
 
   await test.step('And I select the bed for admission', async () => {
-    await page.getByText(`${bed.bedNumber} · Empty`).click();
+    await wardPage.selectBedForAdmission(bed.bedNumber);
   });
 
   await test.step('And I confirm admission by clicking "Admit"', async () => {
-    await page.getByRole('button', { name: 'Admit', exact: true }).click();
+    await wardPage.confirmAdmission();
   });
 
   await test.step('Then I should see a success message confirming the admission success', async () => {
@@ -91,6 +91,48 @@ test('Add a patient note to an inpatient admission', async ({ page, api }) => {
 
   await test.step('Then I should see a success message confirming the note was saved', async () => {
     await expect(page.getByText(/patient note saved/i)).toBeVisible();
+  });
+
+  await test.step('And when I click on the patient card to open the patient workspace', async () => {
+    await wardPage.clickPatientCard(fullName);
+  });
+
+  await test.step('Then I click the "Patient note" button in the siderail to open the patient note workspace again', async () => {
+    await wardPage.clickPatientNotesButton();
+  });
+
+  await test.step('Then I should see the note there', async () => {
+    await expect(page.getByText('Sample patient note')).toBeVisible();
+  });
+
+  await test.step('And when I click on the note overflow menu and select "Edit"', async () => {
+    await wardPage.selectEditNoteOption();
+  });
+
+  await test.step('Then I edit the note to "Sample patient note - edited"', async () => {
+    await wardPage.fillEditNote('Sample patient note - edited');
+  });
+
+  await test.step('And I save the edited note', async () => {
+    await wardPage.clickSaveEditButton();
+  });
+
+  await test.step('Then I should see a success message confirming the note was saved', async () => {
+    await expect(page.getByText(/patient note saved/i)).toBeVisible();
+  });
+
+  await test.step('Then I should see the note with a "Last edited by" line', async () => {
+    await expect(page.getByText(/last edited by/i)).toBeVisible();
+  });
+
+  await test.step('And when I click on the note overflow menu and select "View edit history"', async () => {
+    await wardPage.selectViewEditHistoryOption();
+  });
+
+  await test.step('Then I should see the modal showing the edit history with 2 versions', async () => {
+    await expect(page.getByText('Note edit history')).toBeVisible();
+    // await expect(page.getByText('Sample patient note - edited')).toBeVisible();
+    await expect(page.getByText('Sample patient note', { exact: true })).toBeVisible();
   });
 });
 

--- a/packages/esm-ward-app/src/index.ts
+++ b/packages/esm-ward-app/src/index.ts
@@ -134,6 +134,11 @@ export const deleteNoteModal = getAsyncLifecycle(
   options,
 );
 
+export const noteHistoryModal = getAsyncLifecycle(
+  () => import('./ward-workspace/ward-patient-notes/history/note-history.modal'),
+  options,
+);
+
 export function startupApp() {
   registerBreadcrumbs([]);
   defineConfigSchema(moduleName, configSchema);

--- a/packages/esm-ward-app/src/routes.json
+++ b/packages/esm-ward-app/src/routes.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.openmrs.org/routes.schema.json",
   "backendDependencies": {
-    "webservices.rest": ">=2.2.0",
+    "webservices.rest": ">3.3.0 <4.0.0",
     "emrapi": ">=2.0.0 <4.0.0"
   },
   "optionalBackendDependencies": {
@@ -70,6 +70,10 @@
     {
       "name": "delete-note-modal",
       "component": "deleteNoteModal"
+    },
+    {
+      "name": "note-history-modal",
+      "component": "noteHistoryModal"
     }
   ],
   "workspaces2": [

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note-history.modal.scss
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note-history.modal.scss
@@ -1,5 +1,3 @@
-@use '@carbon/layout';
-
 .versionTile {
   background-color: #fff;
 }

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note-history.modal.scss
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note-history.modal.scss
@@ -1,0 +1,5 @@
+@use '@carbon/layout';
+
+.versionTile {
+  background-color: #fff;
+}

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note-history.modal.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note-history.modal.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { useTranslation } from 'react-i18next';
+import { ModalHeader, ModalBody } from '@carbon/react';
+import { type PatientNote } from '../types';
+import styles from './styles.scss';
+import modalStyles from './note-history.modal.scss';
+
+interface NoteHistoryModalProps {
+  close: () => void;
+  note: PatientNote;
+}
+
+const NoteHistoryModal: React.FC<NoteHistoryModalProps> = ({ close, note }) => {
+  const { t } = useTranslation();
+
+  const formatDate = (datetime: string) => dayjs(datetime).format('D MMM YYYY, HH:mm');
+
+  const versions = [
+    { note: note.encounterNote, recordedAt: note.lastEditedAt, recordedBy: note.lastEditedBy },
+    ...note.editHistory.map((v) => ({ note: v.note, recordedAt: v.recordedAt, recordedBy: v.recordedBy })),
+  ];
+
+  return (
+    <>
+      <ModalHeader closeModal={close}>{t('noteEditHistory', 'Note edit history')}</ModalHeader>
+      <ModalBody>
+        <div className={styles.notesContainer}>
+          {versions.map((v, i) => (
+            <div key={i} className={`${styles.noteTile} ${modalStyles.versionTile}`}>
+              <div className={styles.noteBody}>{v.note}</div>
+              <div className={styles.noteProviderName}>
+                {t('writtenBy', 'Written by: {{name}}, {{date}}', {
+                  name: v.recordedBy,
+                  date: formatDate(v.recordedAt),
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </ModalBody>
+    </>
+  );
+};
+
+export default NoteHistoryModal;

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note-history.modal.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note-history.modal.tsx
@@ -5,6 +5,7 @@ import { ModalHeader, ModalBody } from '@carbon/react';
 import { type PatientNote } from '../types';
 import styles from './styles.scss';
 import modalStyles from './note-history.modal.scss';
+import classNames from 'classnames';
 
 interface NoteHistoryModalProps {
   close: () => void;
@@ -27,7 +28,7 @@ const NoteHistoryModal: React.FC<NoteHistoryModalProps> = ({ close, note }) => {
       <ModalBody>
         <div className={styles.notesContainer}>
           {versions.map((v, i) => (
-            <div key={i} className={`${styles.noteTile} ${modalStyles.versionTile}`}>
+            <div key={i} className={classNames(styles.noteTile, modalStyles.versionTile)}>
               <div className={styles.noteBody}>{v.note}</div>
               <div className={styles.noteProviderName}>
                 {t('writtenBy', 'Written by: {{name}}, {{date}}', {

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note.component.tsx
@@ -108,18 +108,20 @@ const InPatientNote: React.FC<InPatientNoteProps> = ({ note, mutatePatientNotes,
                   }}
                 />
               )}
-              <OverflowMenuItem
-                aria-label={t('viewEditHistory', 'View edit history')}
-                id={'view-history-' + note.encounterUuid}
-                className={styles.menuItem}
-                itemText={t('viewEditHistory', 'View edit history')}
-                onClick={() => {
-                  const dispose = showModal('note-history-modal', {
-                    close: () => dispose(),
-                    note,
-                  });
-                }}
-              />
+              {note.isEdited && (
+                <OverflowMenuItem
+                  aria-label={t('viewEditHistory', 'View edit history')}
+                  id={'view-history-' + note.encounterUuid}
+                  className={styles.menuItem}
+                  itemText={t('viewEditHistory', 'View edit history')}
+                  onClick={() => {
+                    const dispose = showModal('note-history-modal', {
+                      close: () => dispose(),
+                      note,
+                    });
+                  }}
+                />
+              )}
               <OverflowMenuItem
                 aria-label={getCoreTranslation('delete')}
                 id={'delete-note-' + note.encounterUuid}

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note.component.tsx
@@ -55,10 +55,6 @@ interface InPatientNoteProps {
  */
 const InPatientNote: React.FC<InPatientNoteProps> = ({ note, mutatePatientNotes, promptBeforeClosing }) => {
   const { t } = useTranslation();
-  const formattedDate = note.encounterNoteRecordedAt
-    ? dayjs(note.encounterNoteRecordedAt).format('dddd, D MMM YYYY')
-    : '';
-  const formattedTime = note.encounterNoteRecordedAt ? dayjs(note.encounterNoteRecordedAt).format('HH:mm') : '';
   const [editMode, setEditMode] = useState(false);
   const [editedNote, setEditedNote] = useState(note.encounterNote);
   const isTablet = !isDesktop(useLayoutType());
@@ -98,9 +94,6 @@ const InPatientNote: React.FC<InPatientNoteProps> = ({ note, mutatePatientNotes,
     <div className={styles.noteTile}>
       <Stack gap={4}>
         <div className={styles.noteHeader}>
-          <span className={styles.noteDateAndTime}>
-            {formattedDate}, {formattedTime}
-          </span>
           {isInpatientNoteEncounter && (
             <OverflowMenu className={styles.overflowMenu} flipped>
               {!editMode && note.obsUuid && (
@@ -112,6 +105,19 @@ const InPatientNote: React.FC<InPatientNoteProps> = ({ note, mutatePatientNotes,
                   itemText={getCoreTranslation('edit')}
                   onClick={() => {
                     setEditMode(true);
+                  }}
+                />
+              )}
+              {note.isEdited && (
+                <OverflowMenuItem
+                  id={'view-history-' + note.encounterUuid}
+                  className={styles.menuItem}
+                  itemText={t('viewEditHistory', 'View edit history')}
+                  onClick={() => {
+                    const dispose = showModal('note-history-modal', {
+                      close: () => dispose(),
+                      note,
+                    });
                   }}
                 />
               )}
@@ -161,7 +167,20 @@ const InPatientNote: React.FC<InPatientNoteProps> = ({ note, mutatePatientNotes,
         ) : (
           <>
             <div className={styles.noteBody}>{note.encounterNote}</div>
-            <div className={styles.noteProviderName}>{note.encounterProvider}</div>
+            <div className={styles.noteProviderName}>
+              {t('writtenBy', 'Written by: {{name}}, {{date}}', {
+                name: note.encounterProvider,
+                date: dayjs(note.encounterNoteRecordedAt).format('D MMM YYYY, HH:mm'),
+              })}
+            </div>
+            {note.isEdited && note.lastEditedBy && (
+              <div className={styles.noteEditedBy}>
+                {t('lastEditedBy', 'Last edited by: {{name}}, {{date}}', {
+                  name: note.lastEditedBy,
+                  date: dayjs(note.lastEditedAt).format('D MMM YYYY, HH:mm'),
+                })}
+              </div>
+            )}
           </>
         )}
       </Stack>

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/note.component.tsx
@@ -108,19 +108,18 @@ const InPatientNote: React.FC<InPatientNoteProps> = ({ note, mutatePatientNotes,
                   }}
                 />
               )}
-              {note.isEdited && (
-                <OverflowMenuItem
-                  id={'view-history-' + note.encounterUuid}
-                  className={styles.menuItem}
-                  itemText={t('viewEditHistory', 'View edit history')}
-                  onClick={() => {
-                    const dispose = showModal('note-history-modal', {
-                      close: () => dispose(),
-                      note,
-                    });
-                  }}
-                />
-              )}
+              <OverflowMenuItem
+                aria-label={t('viewEditHistory', 'View edit history')}
+                id={'view-history-' + note.encounterUuid}
+                className={styles.menuItem}
+                itemText={t('viewEditHistory', 'View edit history')}
+                onClick={() => {
+                  const dispose = showModal('note-history-modal', {
+                    close: () => dispose(),
+                    note,
+                  });
+                }}
+              />
               <OverflowMenuItem
                 aria-label={getCoreTranslation('delete')}
                 id={'delete-note-' + note.encounterUuid}
@@ -143,6 +142,7 @@ const InPatientNote: React.FC<InPatientNoteProps> = ({ note, mutatePatientNotes,
             <Stack gap={3}>
               <TextArea
                 className={styles.textArea}
+                id="editNote"
                 rows={6}
                 value={editedNote}
                 onChange={(e) => setEditedNote(e.target.value)}
@@ -159,7 +159,7 @@ const InPatientNote: React.FC<InPatientNoteProps> = ({ note, mutatePatientNotes,
                   {t('cancel', 'Cancel')}
                 </Button>
                 <Button onClick={onSave} kind={'primary'} size={isTablet ? 'lg' : 'sm'}>
-                  {isSaving ? <InlineLoading description={t('saving', 'Saving...')} /> : t('save', 'Save')}
+                  {isSaving ? <InlineLoading description={t('saving', 'Saving...')} /> : t('saveEdit', 'Save edit')}
                 </Button>
               </div>
             </Stack>

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/notes-container.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/notes-container.component.tsx
@@ -1,30 +1,26 @@
 import React from 'react';
 import { InlineNotification } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { useConfig, useEmrConfiguration, type PatientUuid } from '@openmrs/esm-framework';
-import { usePatientNotes } from '../notes.resource';
 import InPatientNote, { InPatientNoteSkeleton } from './note.component';
-import { type WardConfigObject } from '../../../config-schema';
+import { type PatientNote } from '../types';
 import styles from './styles.scss';
 
 interface PatientNotesHistoryProps {
-  patientUuid: PatientUuid;
-  visitUuid: string;
+  patientNotes: Array<PatientNote>;
+  mutatePatientNotes: () => void;
+  isLoading: boolean;
+  errorFetchingPatientNotes: Error;
   promptBeforeClosing(hasUnsavedChanges: boolean): void;
 }
 
-const PatientNotesHistory: React.FC<PatientNotesHistoryProps> = ({ patientUuid, visitUuid, promptBeforeClosing }) => {
+const PatientNotesHistory: React.FC<PatientNotesHistoryProps> = ({
+  patientNotes,
+  mutatePatientNotes,
+  isLoading,
+  errorFetchingPatientNotes,
+  promptBeforeClosing,
+}) => {
   const { t } = useTranslation();
-  const { emrConfiguration, isLoadingEmrConfiguration } = useEmrConfiguration();
-  const config = useConfig<WardConfigObject>();
-
-  const { patientNotes, mutatePatientNotes, isLoadingPatientNotes, errorFetchingPatientNotes } = usePatientNotes(
-    patientUuid,
-    visitUuid,
-    [emrConfiguration?.consultFreeTextCommentsConcept.uuid, ...config.additionalInpatientNotesConceptUuids],
-  );
-
-  const isLoading = isLoadingPatientNotes || isLoadingEmrConfiguration;
 
   if (!isLoading && patientNotes.length === 0 && !errorFetchingPatientNotes) return null;
 

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/notes-container.test.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/notes-container.test.tsx
@@ -1,22 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { emrConfigurationMock } from '__mocks__';
-import { getDefaultsFromConfigSchema, useConfig, useEmrConfiguration } from '@openmrs/esm-framework';
-import { configSchema, type WardConfigObject } from '../../../config-schema';
+import { useEmrConfiguration } from '@openmrs/esm-framework';
 import { type PatientNote } from '../types';
-import { usePatientNotes } from '../notes.resource';
 import PatientNotesHistory from './notes-container.component';
 
-const mockUseConfig = jest.mocked(useConfig<WardConfigObject>);
-
 const mockedUseEmrConfiguration = jest.mocked(useEmrConfiguration);
-const mockedUsePatientNotes = jest.mocked(usePatientNotes);
-
-jest.mock('../notes.resource', () => ({
-  usePatientNotes: jest.fn(),
-}));
-
-const mockPatientUuid = 'sample-patient-uuid';
 
 const mockPatientNotes: PatientNote[] = [
   {
@@ -67,51 +56,34 @@ const mockEditedPatientNote: PatientNote = {
   ],
 };
 
+const defaultProps = {
+  patientNotes: [],
+  mutatePatientNotes: jest.fn(),
+  isLoading: false,
+  errorFetchingPatientNotes: null,
+  promptBeforeClosing: jest.fn(),
+};
+
 describe('PatientNotesHistory', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    mockUseConfig.mockReturnValue(getDefaultsFromConfigSchema<WardConfigObject>(configSchema));
-  });
-
-  test('displays loading skeletons when loading', () => {
     mockedUseEmrConfiguration.mockReturnValue({
       emrConfiguration: emrConfigurationMock,
       mutateEmrConfiguration: jest.fn(),
       isLoadingEmrConfiguration: false,
       errorFetchingEmrConfiguration: null,
     });
+  });
 
-    mockedUsePatientNotes.mockReturnValue({
-      patientNotes: [],
-      isLoadingPatientNotes: true,
-      errorFetchingPatientNotes: undefined,
-      mutatePatientNotes: jest.fn(),
-    });
-
-    render(<PatientNotesHistory patientUuid={mockPatientUuid} promptBeforeClosing={jest.fn()} visitUuid={''} />);
-
+  test('displays loading skeletons when loading', () => {
+    render(<PatientNotesHistory {...defaultProps} isLoading={true} />);
     expect(screen.getAllByTestId('in-patient-note-skeleton')).toHaveLength(4);
   });
 
   test('displays patient notes when available', () => {
-    mockedUseEmrConfiguration.mockReturnValue({
-      emrConfiguration: emrConfigurationMock,
-      mutateEmrConfiguration: jest.fn(),
-      isLoadingEmrConfiguration: false,
-      errorFetchingEmrConfiguration: null,
-    });
-
-    mockedUsePatientNotes.mockReturnValue({
-      patientNotes: mockPatientNotes,
-      isLoadingPatientNotes: false,
-      errorFetchingPatientNotes: undefined,
-      mutatePatientNotes: jest.fn(),
-    });
-
-    render(<PatientNotesHistory patientUuid={mockPatientUuid} promptBeforeClosing={jest.fn()} visitUuid={''} />);
+    render(<PatientNotesHistory {...defaultProps} patientNotes={mockPatientNotes} />);
 
     expect(screen.getByText('History')).toBeInTheDocument();
-
     expect(screen.getByText('Patient shows improvement with current medication.')).toBeInTheDocument();
     expect(screen.getByText(/Dr\. John Doe/)).toBeInTheDocument();
     expect(screen.getByText('Blood pressure is slightly elevated. Consider adjusting medication.')).toBeInTheDocument();
@@ -119,21 +91,7 @@ describe('PatientNotesHistory', () => {
   });
 
   test('displays "Last edited by" for an edited note', () => {
-    mockedUseEmrConfiguration.mockReturnValue({
-      emrConfiguration: emrConfigurationMock,
-      mutateEmrConfiguration: jest.fn(),
-      isLoadingEmrConfiguration: false,
-      errorFetchingEmrConfiguration: null,
-    });
-
-    mockedUsePatientNotes.mockReturnValue({
-      patientNotes: [mockEditedPatientNote],
-      isLoadingPatientNotes: false,
-      errorFetchingPatientNotes: undefined,
-      mutatePatientNotes: jest.fn(),
-    });
-
-    render(<PatientNotesHistory patientUuid={mockPatientUuid} promptBeforeClosing={jest.fn()} visitUuid={''} />);
+    render(<PatientNotesHistory {...defaultProps} patientNotes={[mockEditedPatientNote]} />);
 
     expect(screen.getByText('Updated: Patient is recovering well.')).toBeInTheDocument();
     expect(screen.getByText(/Last edited by:.*Dr\. Jane Smith/)).toBeInTheDocument();

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/notes-container.test.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/notes-container.test.tsx
@@ -27,6 +27,10 @@ const mockPatientNotes: PatientNote[] = [
     obsUuid: 'obsUuid1',
     conceptUuid: 'concept1',
     encounterTypeUuid: 'inpatientNoteEncounterTypeUuid',
+    isEdited: false,
+    lastEditedBy: '',
+    lastEditedAt: '2024-08-01T12:34:56Z',
+    editHistory: [],
   },
   {
     encounterUuid: 'note-2',
@@ -36,8 +40,32 @@ const mockPatientNotes: PatientNote[] = [
     obsUuid: 'obsUuid2',
     conceptUuid: 'concept1',
     encounterTypeUuid: 'inpatientNoteEncounterTypeUuid',
+    isEdited: false,
+    lastEditedBy: '',
+    lastEditedAt: '2024-08-02T14:22:00Z',
+    editHistory: [],
   },
 ];
+
+const mockEditedPatientNote: PatientNote = {
+  encounterUuid: 'note-3',
+  encounterNote: 'Updated: Patient is recovering well.',
+  encounterNoteRecordedAt: '2024-08-03T09:00:00Z',
+  encounterProvider: 'Dr. John Doe',
+  obsUuid: 'obsUuid3',
+  conceptUuid: 'concept1',
+  encounterTypeUuid: 'inpatientNoteEncounterTypeUuid',
+  isEdited: true,
+  lastEditedBy: 'Dr. Jane Smith',
+  lastEditedAt: '2024-08-04T11:00:00Z',
+  editHistory: [
+    {
+      note: 'Original: Patient is stable.',
+      recordedAt: '2024-08-03T09:00:00Z',
+      recordedBy: 'Dr. John Doe',
+    },
+  ],
+};
 
 describe('PatientNotesHistory', () => {
   beforeEach(() => {
@@ -85,8 +113,29 @@ describe('PatientNotesHistory', () => {
     expect(screen.getByText('History')).toBeInTheDocument();
 
     expect(screen.getByText('Patient shows improvement with current medication.')).toBeInTheDocument();
-    expect(screen.getByText('Dr. John Doe')).toBeInTheDocument();
+    expect(screen.getByText(/Dr\. John Doe/)).toBeInTheDocument();
     expect(screen.getByText('Blood pressure is slightly elevated. Consider adjusting medication.')).toBeInTheDocument();
-    expect(screen.getByText('Dr. Jane Smith')).toBeInTheDocument();
+    expect(screen.getByText(/Dr\. Jane Smith/)).toBeInTheDocument();
+  });
+
+  test('displays "Last edited by" for an edited note', () => {
+    mockedUseEmrConfiguration.mockReturnValue({
+      emrConfiguration: emrConfigurationMock,
+      mutateEmrConfiguration: jest.fn(),
+      isLoadingEmrConfiguration: false,
+      errorFetchingEmrConfiguration: null,
+    });
+
+    mockedUsePatientNotes.mockReturnValue({
+      patientNotes: [mockEditedPatientNote],
+      isLoadingPatientNotes: false,
+      errorFetchingPatientNotes: undefined,
+      mutatePatientNotes: jest.fn(),
+    });
+
+    render(<PatientNotesHistory patientUuid={mockPatientUuid} promptBeforeClosing={jest.fn()} visitUuid={''} />);
+
+    expect(screen.getByText('Updated: Patient is recovering well.')).toBeInTheDocument();
+    expect(screen.getByText(/Last edited by:.*Dr\. Jane Smith/)).toBeInTheDocument();
   });
 });

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/styles.scss
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/styles.scss
@@ -78,3 +78,7 @@
   margin-top: layout.$spacing-02;
   color: $text-02;
 }
+
+.menuItem {
+  max-width: none;
+}

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/styles.scss
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/styles.scss
@@ -29,7 +29,7 @@
 
 .noteHeader {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
 }
 
@@ -71,4 +71,10 @@
   display: flex;
   gap: layout.$spacing-02;
   justify-content: flex-end;
+}
+
+.noteEditedBy {
+  font-size: 0.75rem;
+  margin-top: layout.$spacing-02;
+  color: $text-02;
 }

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/styles.scss
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/history/styles.scss
@@ -80,5 +80,8 @@
 }
 
 .menuItem {
+.menuItem {
   max-width: none;
+  max-inline-size: none;
+}
 }

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.resource.ts
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.resource.ts
@@ -26,7 +26,7 @@ export function editPatientNote(obsUuid: string, note: string) {
 
 export function usePatientNotes(patientUuid: string, visitUuid: string, conceptUuids: Array<string>): UsePatientNotes {
   const customRepresentation =
-    'custom:(uuid,patient:(uuid),obs:(uuid,concept:(uuid),obsDatetime,value:(uuid),previousVersions:(value,obsDatetime,creator),creator),encounterType,' +
+    'custom:(uuid,encounterDatetime,patient:(uuid),obs:(uuid,concept:(uuid),dateCreated,value:(uuid),previousVersions:(value,dateCreated,creator),creator),encounterType,' +
     'encounterProviders:(uuid,provider:(uuid,person:(uuid,display)))';
   const encountersApiUrl = `${restBaseUrl}/encounter?patient=${patientUuid}&visit=${visitUuid}&v=${customRepresentation}`;
 
@@ -45,18 +45,16 @@ export function usePatientNotes(patientUuid: string, visitUuid: string, conceptU
                     encounterUuid: encounter.uuid,
                     obsUuid: obs.uuid,
                     encounterNote: obs ? obs.value : '',
-                    encounterNoteRecordedAt: obs.previousVersions?.length
-                      ? obs.previousVersions[obs.previousVersions.length - 1].obsDatetime
-                      : obs.obsDatetime,
+                    encounterNoteRecordedAt: encounter.encounterDatetime,
                     encounterProvider: encounter.encounterProviders.map((ep) => ep.provider.person.display).join(', '),
                     conceptUuid: obs.concept.uuid,
                     encounterTypeUuid: encounter.encounterType.uuid,
                     isEdited: (obs.previousVersions?.length ?? 0) > 0,
                     lastEditedBy: obs.creator?.person?.display ?? obs.creator?.display ?? '',
-                    lastEditedAt: obs.obsDatetime,
+                    lastEditedAt: obs.dateCreated,
                     editHistory: (obs.previousVersions ?? []).map((v) => ({
                       note: v.value as string,
-                      recordedAt: v.obsDatetime,
+                      recordedAt: v.dateCreated,
                       recordedBy: v.creator?.person?.display ?? v.creator?.display ?? '',
                     })),
                   });

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.resource.ts
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.resource.ts
@@ -26,7 +26,7 @@ export function editPatientNote(obsUuid: string, note: string) {
 
 export function usePatientNotes(patientUuid: string, visitUuid: string, conceptUuids: Array<string>): UsePatientNotes {
   const customRepresentation =
-    'custom:(uuid,patient:(uuid),obs:(uuid,concept:(uuid),obsDatetime,value:(uuid)),encounterType,' +
+    'custom:(uuid,patient:(uuid),obs:(uuid,concept:(uuid),obsDatetime,value:(uuid),previousVersions:(value,obsDatetime,creator),creator),encounterType,' +
     'encounterProviders:(uuid,provider:(uuid,person:(uuid,display)))';
   const encountersApiUrl = `${restBaseUrl}/encounter?patient=${patientUuid}&visit=${visitUuid}&v=${customRepresentation}`;
 
@@ -45,10 +45,20 @@ export function usePatientNotes(patientUuid: string, visitUuid: string, conceptU
                     encounterUuid: encounter.uuid,
                     obsUuid: obs.uuid,
                     encounterNote: obs ? obs.value : '',
-                    encounterNoteRecordedAt: obs ? obs.obsDatetime : '',
+                    encounterNoteRecordedAt: obs.previousVersions?.length
+                      ? obs.previousVersions[obs.previousVersions.length - 1].obsDatetime
+                      : obs.obsDatetime,
                     encounterProvider: encounter.encounterProviders.map((ep) => ep.provider.person.display).join(', '),
                     conceptUuid: obs.concept.uuid,
                     encounterTypeUuid: encounter.encounterType.uuid,
+                    isEdited: (obs.previousVersions?.length ?? 0) > 0,
+                    lastEditedBy: obs.creator?.person?.display ?? obs.creator?.display ?? '',
+                    lastEditedAt: obs.obsDatetime,
+                    editHistory: (obs.previousVersions ?? []).map((v) => ({
+                      note: v.value as string,
+                      recordedAt: v.obsDatetime,
+                      recordedBy: v.creator?.person?.display ?? v.creator?.display ?? '',
+                    })),
                   });
                 }
                 return acc;

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.workspace.tsx
@@ -65,6 +65,7 @@ const WardPatientNotesWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({
       const notePayload: EncounterPayload = {
         patient: patientUuid,
         location: locationUuid,
+        visit: wardPatient.visit?.uuid,
         encounterType: emrConfiguration?.inpatientNoteEncounterType?.uuid,
         encounterProviders: [
           {
@@ -114,6 +115,7 @@ const WardPatientNotesWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({
       providerUuid,
       t,
       closeWorkspace,
+      wardPatient.visit?.uuid,
     ],
   );
 

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.workspace.tsx
@@ -10,14 +10,16 @@ import {
   ResponsiveWrapper,
   showSnackbar,
   translateFrom,
+  useConfig,
   useSession,
   Workspace2,
 } from '@openmrs/esm-framework';
 import { moduleName } from '../../constant';
-import { createPatientNote } from './notes.resource';
+import { createPatientNote, usePatientNotes } from './notes.resource';
 import useEmrConfiguration from '../../hooks/useEmrConfiguration';
 import styles from './notes.scss';
 import { type WardPatientWorkspaceDefinition, type EncounterPayload } from '../../types';
+import { type WardConfigObject } from '../../config-schema';
 import WardPatientWorkspaceBanner from '../patient-banner/patient-banner.component';
 import PatientNotesHistory from './history/notes-container.component';
 
@@ -35,9 +37,17 @@ const WardPatientNotesWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({
   closeWorkspace,
 }) => {
   const patientUuid = wardPatient.patient.uuid;
+  const visitUuid = wardPatient?.visit?.uuid;
   const { emrConfiguration, isLoadingEmrConfiguration, errorFetchingEmrConfiguration } = useEmrConfiguration();
+  const config = useConfig<WardConfigObject>();
   const { t } = useTranslation();
   const session = useSession();
+
+  const { patientNotes, mutatePatientNotes, isLoadingPatientNotes, errorFetchingPatientNotes } = usePatientNotes(
+    patientUuid,
+    visitUuid,
+    [emrConfiguration?.consultFreeTextCommentsConcept?.uuid, ...config.additionalInpatientNotesConceptUuids],
+  );
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasEditChanges, setHasEditChanges] = useState(false);
@@ -65,7 +75,7 @@ const WardPatientNotesWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({
       const notePayload: EncounterPayload = {
         patient: patientUuid,
         location: locationUuid,
-        visit: wardPatient.visit?.uuid,
+        visit: visitUuid,
         encounterType: emrConfiguration?.inpatientNoteEncounterType?.uuid,
         encounterProviders: [
           {
@@ -93,6 +103,7 @@ const WardPatientNotesWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({
             subtitle: t('patientNoteNowVisible', 'It should be now visible in the notes history'),
             title: t('visitNoteSaved', 'Patient note saved'),
           });
+          mutatePatientNotes();
           await closeWorkspace({ discardUnsavedChanges: true });
           closeWorkspaceGroup2();
         })
@@ -111,11 +122,12 @@ const WardPatientNotesWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({
       emrConfiguration?.consultFreeTextCommentsConcept?.uuid,
       emrConfiguration?.inpatientNoteEncounterType?.uuid,
       locationUuid,
+      mutatePatientNotes,
       patientUuid,
       providerUuid,
       t,
       closeWorkspace,
-      wardPatient.visit?.uuid,
+      visitUuid,
     ],
   );
 
@@ -186,8 +198,10 @@ const WardPatientNotesWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({
       </Form>
 
       <PatientNotesHistory
-        patientUuid={patientUuid}
-        visitUuid={wardPatient?.visit?.uuid}
+        patientNotes={patientNotes}
+        mutatePatientNotes={mutatePatientNotes}
+        isLoading={isLoadingPatientNotes || isLoadingEmrConfiguration}
+        errorFetchingPatientNotes={errorFetchingPatientNotes}
         promptBeforeClosing={setHasEditChanges}
       />
     </Workspace2>

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/types.ts
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/types.ts
@@ -1,4 +1,4 @@
-import { type Concept, type OpenmrsResource } from '@openmrs/esm-framework';
+import { type Obs, type Concept, type OpenmrsResource } from '@openmrs/esm-framework';
 
 export interface RESTPatientNote extends OpenmrsResource {
   uuid: string;
@@ -19,6 +19,14 @@ export interface PatientNote {
   encounterProvider: string;
   conceptUuid: string;
   encounterTypeUuid: string;
+  isEdited: boolean;
+  lastEditedBy: string;
+  lastEditedAt: string;
+  editHistory: Array<{
+    note: string;
+    recordedAt: string;
+    recordedBy: string;
+  }>;
 }
 
 export interface UsePatientNotes {
@@ -38,4 +46,20 @@ export interface ObsData {
     value?: string | any;
   }>;
   obsDatetime: string;
+  creator?: { display: string; person?: { display: string } };
+  previousVersions?: Array<
+    Obs & {
+      creator: Provider;
+    }
+  >;
+}
+
+export interface Provider {
+  uuid: string;
+  display: string;
+  comments: string;
+  response?: string;
+  person: OpenmrsResource;
+  location: string;
+  serviceType: string;
 }

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/types.ts
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/types.ts
@@ -49,9 +49,10 @@ export interface ObsData {
   creator?: { display: string; person?: { display: string } };
   previousVersions?: Array<
     Obs & {
-      creator: Provider;
+      creator: { display: string; person?: { display: string } };
     }
   >;
+  dateCreated: string;
 }
 
 export interface Provider {

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/types.ts
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/types.ts
@@ -54,13 +54,3 @@ export interface ObsData {
   >;
   dateCreated: string;
 }
-
-export interface Provider {
-  uuid: string;
-  display: string;
-  comments: string;
-  response?: string;
-  person: OpenmrsResource;
-  location: string;
-  serviceType: string;
-}

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -118,6 +118,7 @@
   "previousPage": "Previous page",
   "proceedWithPatientDischarge": "Proceed with patient discharge",
   "save": "Save",
+  "saveEdit": "Save edit",
   "saving": "Saving...",
   "searchLocations": "Search locations",
   "seconds_one": "{{count}} second",

--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -62,6 +62,7 @@
   "invalidLocationSpecified": "Invalid location specified",
   "invalidWardLocation": "Invalid ward location: {{location}}",
   "labelColon": "{{label}}:",
+  "lastEditedBy": "Last edited by: {{name}}, {{date}}",
   "male": "Male",
   "manage": "Manage",
   "minutes_one": "{{count}} minutes",
@@ -78,6 +79,7 @@
   "noPendingAdmissionRequests": "No pending admission requests",
   "note": "Note",
   "noteDeletedSuccessfully": "Note deleted successfully",
+  "noteEditHistory": "Note edit history",
   "notes": "Notes",
   "notesRequiredForCancellingRequest": "Notes required for cancelling admission or transfer request",
   "orderBasket": "Order basket",
@@ -137,8 +139,10 @@
   "typeOfTransfer": "Type of transfer",
   "unknown": "Unknown",
   "unknownError": "An unknown error occurred",
+  "viewEditHistory": "View edit history",
   "visitNoteSaved": "Patient note saved",
   "wardClinicalNotePlaceholder": "Write any notes here",
   "wardPatient": "Ward patient",
-  "wards": "Wards"
+  "wards": "Wards",
+  "writtenBy": "Written by: {{name}}, {{date}}"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds a new feature to view the inpatient notes edit history.

## Screenshots
<!-- Required if you are making UI changes. -->
[Screencast from 2026-04-21 10-46-45.webm](https://github.com/user-attachments/assets/4c6dbecd-85a0-4512-87d5-93e722f34004)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-5620

## Other
<!-- Anything not covered above -->
