### PR TITLE
(feat) O3-5624: Add ward app configuration to only show discharge button in certain locations

### DIFF
--- a/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail-config-schema.ts
+++ b/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail-config-schema.ts
@@ -1,7 +1,7 @@
 import { Type } from '@openmrs/esm-framework';
 
 export const dischargeWorkspaceSiderailExtensionConfigSchema = {
-  onlyShowDischargeForLocations: {
+  allowedSessionLocationUuids: {
     _type: Type.Array,
     _default: [],
     _description:
@@ -13,5 +13,5 @@ export const dischargeWorkspaceSiderailExtensionConfigSchema = {
 };
 
 export interface DischargeWorkspaceSiderailConfig {
-  onlyShowDischargeForLocations: string[];
+  allowedSessionLocationUuids: string[];
 }

--- a/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail-config-schema.ts
+++ b/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail-config-schema.ts
@@ -1,0 +1,17 @@
+import { Type } from '@openmrs/esm-framework';
+
+export const dischargeWorkspaceSiderailExtensionConfigSchema = {
+  onlyShowDischargeForLocations: {
+    _type: Type.Array,
+    _default: [],
+    _description:
+      'If not empty, the discharge button will only show for users whose session location is included in this list. If empty, the discharge button will show for all locations.',
+    _elements: {
+      _type: Type.String,
+    },
+  },
+};
+
+export interface DischargeWorkspaceSiderailConfig {
+  onlyShowDischargeForLocations: string[];
+}

--- a/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail.component.tsx
+++ b/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail.component.tsx
@@ -1,17 +1,25 @@
 import React from 'react';
-import { ActionMenuButton2 } from '@openmrs/esm-framework';
+import { ActionMenuButton2, useConfig, useSession } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import { Exit } from '@carbon/react/icons';
+import { type DischargeWorkspaceSiderailConfig } from './discharge-workspace-siderail-config-schema';
 
 export default function PatientDischargeSideRailIcon() {
   const { t } = useTranslation();
-  return (
-    <ActionMenuButton2
-      icon={(props) => <Exit {...props} />}
-      label={t('discharge', 'Discharge')}
-      workspaceToLaunch={{
-        workspaceName: 'patient-discharge-workspace',
-      }}
-    />
-  );
+  const { sessionLocation } = useSession();
+  const { onlyShowDischargeForLocations } = useConfig<DischargeWorkspaceSiderailConfig>();
+
+  if (onlyShowDischargeForLocations.length === 0 || onlyShowDischargeForLocations.includes(sessionLocation?.uuid)) {
+    return (
+      <ActionMenuButton2
+        icon={(props) => <Exit {...props} />}
+        label={t('discharge', 'Discharge')}
+        workspaceToLaunch={{
+          workspaceName: 'patient-discharge-workspace',
+        }}
+      />
+    );
+  } else {
+    return null;
+  }
 }

--- a/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail.component.tsx
+++ b/packages/esm-ward-app/src/action-menu-buttons/discharge-workspace-siderail.component.tsx
@@ -7,19 +7,19 @@ import { type DischargeWorkspaceSiderailConfig } from './discharge-workspace-sid
 export default function PatientDischargeSideRailIcon() {
   const { t } = useTranslation();
   const { sessionLocation } = useSession();
-  const { onlyShowDischargeForLocations } = useConfig<DischargeWorkspaceSiderailConfig>();
+  const { allowedSessionLocationUuids } = useConfig<DischargeWorkspaceSiderailConfig>();
 
-  if (onlyShowDischargeForLocations.length === 0 || onlyShowDischargeForLocations.includes(sessionLocation?.uuid)) {
-    return (
-      <ActionMenuButton2
-        icon={(props) => <Exit {...props} />}
-        label={t('discharge', 'Discharge')}
-        workspaceToLaunch={{
-          workspaceName: 'patient-discharge-workspace',
-        }}
-      />
-    );
-  } else {
+  if (allowedSessionLocationUuids.length > 0 && !allowedSessionLocationUuids.includes(sessionLocation?.uuid)) {
     return null;
   }
+
+  return (
+    <ActionMenuButton2
+      icon={(props) => <Exit {...props} />}
+      label={t('discharge', 'Discharge')}
+      workspaceToLaunch={{
+        workspaceName: 'patient-discharge-workspace',
+      }}
+    />
+  );
 }

--- a/packages/esm-ward-app/src/index.ts
+++ b/packages/esm-ward-app/src/index.ts
@@ -1,5 +1,6 @@
 import {
   defineConfigSchema,
+  defineExtensionConfigSchema,
   getAsyncLifecycle,
   getSyncLifecycle,
   registerBreadcrumbs,
@@ -9,6 +10,7 @@ import { configSchema } from './config-schema';
 import { moduleName } from './constant';
 import { createDashboardLink } from './createDashboardLink';
 import { dashboardMeta } from './dashboard.meta';
+import { dischargeWorkspaceSiderailExtensionConfigSchema } from './action-menu-buttons/discharge-workspace-siderail-config-schema';
 
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
@@ -137,6 +139,7 @@ export const deleteNoteModal = getAsyncLifecycle(
 export function startupApp() {
   registerBreadcrumbs([]);
   defineConfigSchema(moduleName, configSchema);
+  defineExtensionConfigSchema('ward-patient-discharge', dischargeWorkspaceSiderailExtensionConfigSchema);
 
   registerFeatureFlag(
     'bedmanagement-module',

--- a/packages/esm-ward-app/src/routes.json
+++ b/packages/esm-ward-app/src/routes.json
@@ -46,11 +46,6 @@
       "slot": "ward-patient-card-slot"
     },
     {
-      "name": "patient-discharge-siderail-button",
-      "slot": "action-menu-ward-patient-items-slot",
-      "component": "patientDischargeWorkspaceSideRailIcon"
-    },
-    {
       "component": "defaultWardView",
       "name": "default-ward",
       "slot": "default-ward"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR add a way to configure the discharge button in the ward app workspace to only render at certain locations.

Manually tested by configuring my local instance to only show the button at a certain location (mother's dorm in PIH distribution) and verify it shows / hides the button based on the location.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-5624

## Other
<!-- Anything not covered above -->
