### PR TITLE
(fix) O3-5628: Fix inpatient notes not showing up after saving

### DIFF
--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.workspace.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.workspace.tsx
@@ -65,6 +65,7 @@ const WardPatientNotesWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({
       const notePayload: EncounterPayload = {
         patient: patientUuid,
         location: locationUuid,
+        visit: wardPatient.visit?.uuid,
         encounterType: emrConfiguration?.inpatientNoteEncounterType?.uuid,
         encounterProviders: [
           {
@@ -114,6 +115,7 @@ const WardPatientNotesWorkspace: React.FC<WardPatientWorkspaceDefinition> = ({
       providerUuid,
       t,
       closeWorkspace,
+      wardPatient.visit?.uuid,
     ],
   );
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
In the ward app, after submitting an inpatient note for a patient, we should see that note in the notes workspace when we click on the patient card. This stopped working because the note (encounter) was not correctly linked to the patient's visit. This PR fixes it.

Also see correspondence here: https://github.com/openmrs/openmrs-esm-patient-management/pull/2503#discussion_r3119960250

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
