### PR TITLE
(fix) O3-5631: Guard null on encounters data access in patient registration hooks

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration-hooks.ts
@@ -315,7 +315,7 @@ function useInitialEncounters(patientUuid: string, patientToEdit: fhir.Patient) 
       : null,
     openmrsFetch,
   );
-  const obs = data?.data.results.sort(latestFirstEncounter)?.at(0)?.obs;
+  const obs = data?.data?.results.sort(latestFirstEncounter)?.at(0)?.obs;
   const encounters = obs
     ?.map(({ concept, value }) => ({
       [(concept as OpenmrsResource).uuid]: typeof value === 'object' ? value?.uuid : value,


### PR DESCRIPTION
## Requirements

* [x] This PR has a title that briefly describes the work done
* [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below
* [ ] My work includes tests or is validated by existing tests

## Summary

Fixes a null dereference bug in patient-registration-hooks.ts where `data?.data.results` only guarded `data` but not `data.data`. If the API returns a malformed or empty response, `data.data` can be undefined, causing a TypeError that crashes the entire patient edit form.

Fix applied: `data?.data.results` → `data?.data?.results`

## Screenshots
N/A — no UI changes.

## Related Issue
https://openmrs.atlassian.net/browse/O3-5631

## Other
This change improves stability by preventing crashes when API responses are malformed or incomplete.
