### PR TITLE
(fix) O3-5633: Use patient UUID instead of queue entry UUID in service queue linelist

### DIFF
--- a/packages/esm-service-queues-app/src/service-queues.resource.ts
+++ b/packages/esm-service-queues-app/src/service-queues.resource.ts
@@ -177,7 +177,7 @@ export function useServiceQueueEntries(service: string, locationUuid: string) {
     returnDate: visitQueueEntry.queueEntry.startedAt,
     visitType: visitQueueEntry.visit?.visitType?.display,
     gender: visitQueueEntry.queueEntry.patient ? visitQueueEntry?.queueEntry?.patient?.person?.gender : '--',
-    patientUuid: visitQueueEntry.queueEntry ? visitQueueEntry?.queueEntry.uuid : '--',
+    patientUuid: visitQueueEntry.queueEntry?.patient?.uuid ?? '--',
   });
 
   const mappedServiceQueueEntries = data?.data?.results?.map(mapServiceQueueEntryProperties);

--- a/packages/esm-service-queues-app/src/service-queues.resource.ts
+++ b/packages/esm-service-queues-app/src/service-queues.resource.ts
@@ -177,7 +177,7 @@ export function useServiceQueueEntries(service: string, locationUuid: string) {
     returnDate: visitQueueEntry.queueEntry.startedAt,
     visitType: visitQueueEntry.visit?.visitType?.display,
     gender: visitQueueEntry.queueEntry.patient ? visitQueueEntry?.queueEntry?.patient?.person?.gender : '--',
-    patientUuid: visitQueueEntry.queueEntry?.patient?.uuid ?? '--',
+    patientUuid: visitQueueEntry.queueEntry.patient.uuid,
   });
 
   const mappedServiceQueueEntries = data?.data?.results?.map(mapServiceQueueEntryProperties);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (N/A — This is a data mapping bug fix, no UI design changes)
- [x] My work includes tests or is validated by existing tests.

## Summary

The `mapServiceQueueEntryProperties` function in `service-queues.resource.ts` incorrectly maps the `patientUuid` field to the queue entry's own UUID (`visitQueueEntry.queueEntry.uuid`) instead of the patient's actual UUID (`visitQueueEntry.queueEntry.patient.uuid`).

This causes the patient name link in the **Service Queue Line List** table to navigate to `/patient/<QUEUE_ENTRY_UUID>/chart` - a non-existent patient chart page - instead of the correct `/patient/<PATIENT_UUID>/chart`.

### Root Cause

A copy-paste error in `mapServiceQueueEntryProperties`. The sibling function `mapVisitQueueEntryProperties` in the same file correctly uses `queueEntry.patient.uuid`.

### Fix

Single-line change:

```diff
- patientUuid: visitQueueEntry.queueEntry ? visitQueueEntry?.queueEntry.uuid : '--',
+ patientUuid: visitQueueEntry.queueEntry?.patient?.uuid ?? '--',
```

Screenshots
N/A - No UI changes. This is a data mapping fix that corrects the UUID passed to the existing ConfigurableLink component.

Related Issue
https://issues.openmrs.org/browse/O3-5633

Other
N/A