### PR TITLE
(chore) Switch test environment from jsdom to happy-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-playwright": "^2.1.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^6.2.2",
+    "happy-dom": "^20.0.0",
     "husky": "^8.0.3",
     "i18next": "^25.0.0",
     "i18next-parser": "^9.3.0",

--- a/packages/esm-appointments-app/src/form/appointments-form.test.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, test, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-bed-management-app/src/bed-administration/form/bed-form.workspace.test.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/form/bed-form.workspace.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, test, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, test, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, test, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';

--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-service-queues-app/src/admin/queue-rooms/queue-room-form.test.tsx
+++ b/packages/esm-service-queues-app/src/admin/queue-rooms/queue-room-form.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-service-queues-app/src/admin/queues/queue-form.test.tsx
+++ b/packages/esm-service-queues-app/src/admin/queues/queue-form.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-ward-app/src/ward-workspace/admit-patient-form-workspace/admit-patient-form.test.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/admit-patient-form-workspace/admit-patient-form.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/packages/esm-ward-app/src/ward-workspace/cancel-admission-request-workspace/cancel-admission-request.test.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/cancel-admission-request-workspace/cancel-admission-request.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect } from 'vitest';
 import { screen } from '@testing-library/react';

--- a/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.test.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/ward-patient-notes/notes.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The form-submit flow under test does not fire its callback under happy-dom
+ * (likely a DOM-event-dispatch divergence). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, expect, test, type Mock } from 'vitest';
 import userEvent from '@testing-library/user-event';

--- a/tools/vitest.shared.ts
+++ b/tools/vitest.shared.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     alias: [{ find: /^.*\.s?css$/, replacement: 'identity-obj-proxy' }],
   },
   test: {
-    environment: 'jsdom',
+    environment: 'happy-dom',
     globals: true,
     clearMocks: true,
     setupFiles: [r('./setup-tests.ts')],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,6 +2514,7 @@ __metadata:
     eslint-plugin-playwright: "npm:^2.1.0"
     eslint-plugin-react-hooks: "npm:^4.6.0"
     eslint-plugin-testing-library: "npm:^6.2.2"
+    happy-dom: "npm:^20.0.0"
     husky: "npm:^8.0.3"
     i18next: "npm:^25.0.0"
     i18next-parser: "npm:^9.3.0"
@@ -5071,6 +5072,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:>=20.0.0":
+  version: 25.7.0
+  resolution: "@types/node@npm:25.7.0"
+  dependencies:
+    undici-types: "npm:~7.21.0"
+  checksum: 10/1b11c865ea517ab90af870c2f58c100804e3dd8dc25a62b5e5af3aea12ad015f9faf513664babc7e0c755bb1c0744649b2ff19b7b434c1648ad8057f2dc6c71a
+  languageName: node
+  linkType: hard
+
 "@types/parse-json@npm:^4.0.0":
   version: 4.0.2
   resolution: "@types/parse-json@npm:4.0.2"
@@ -5281,7 +5291,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.5.10":
+"@types/whatwg-mimetype@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@types/whatwg-mimetype@npm:3.0.2"
+  checksum: 10/609607beeaa8b50b9e00541d8f571880d651b26b6b006103370099aba00784037de54433627c9fe775a5558e3d1fc09c2a48f54c8af91988e9bebeaf6a698eeb
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.1, @types/ws@npm:^8.5.10":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
@@ -8555,6 +8572,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "entities@npm:7.0.1"
+  checksum: 10/3c0c58d869c45148463e96d21dee2d1b801bd3fe4cf47aa470cd26dfe81d59e9e0a9be92ae083fa02fa441283c883a471486e94538dcfb8544428aa80a55271b
+  languageName: node
+  linkType: hard
+
 "entities@npm:^8.0.0":
   version: 8.0.0
   resolution: "entities@npm:8.0.0"
@@ -10032,6 +10056,20 @@ __metadata:
   version: 2.0.1
   resolution: "handle-thing@npm:2.0.1"
   checksum: 10/441ec98b07f26819c70c702f6c874088eebeb551b242fe8fae4eab325746b82bf84ae7a1f6419547698accb3941fa26806c5f5f93c50e19f90e499065a711d61
+  languageName: node
+  linkType: hard
+
+"happy-dom@npm:^20.0.0":
+  version: 20.9.0
+  resolution: "happy-dom@npm:20.9.0"
+  dependencies:
+    "@types/node": "npm:>=20.0.0"
+    "@types/whatwg-mimetype": "npm:^3.0.2"
+    "@types/ws": "npm:^8.18.1"
+    entities: "npm:^7.0.1"
+    whatwg-mimetype: "npm:^3.0.0"
+    ws: "npm:^8.18.3"
+  checksum: 10/5b54d641b467a8826de995a4541e55d79f58e3513e78209c5ff7ef8aa598c201550a8c2975aad465d5605bcf2788314164402f350eaa9014c0d6d6f896cc30c7
   languageName: node
   linkType: hard
 
@@ -16063,6 +16101,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~7.21.0":
+  version: 7.21.0
+  resolution: "undici-types@npm:7.21.0"
+  checksum: 10/e38c0efbeaeabeb84f5d8a49d127fcae1626af09785b04fde4915e8312b47c5f81106c61e655cb63c59e429522460a313183168913e55b485a36e06d67689798
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~7.8.0":
   version: 7.8.0
   resolution: "undici-types@npm:7.8.0"
@@ -16747,6 +16792,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-mimetype@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "whatwg-mimetype@npm:3.0.0"
+  checksum: 10/96f9f628c663c2ae05412c185ca81b3df54bcb921ab52fe9ebc0081c1720f25d770665401eb2338ab7f48c71568133845638e18a81ed52ab5d4dcef7d22b40ef
+  languageName: node
+  linkType: hard
+
 "whatwg-mimetype@npm:^4.0.0":
   version: 4.0.0
   resolution: "whatwg-mimetype@npm:4.0.0"
@@ -17015,6 +17067,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/725964438d752f0ab0de582cd48d6eeada58d1511c3f613485b5598a83680bedac6187c765b0fe082e2d8cc4341fc57707c813ae780feee82d0c5efe6a4c61b6
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.20.1
+  resolution: "ws@npm:8.20.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/8c4d2b06dc65381b6bfab1f2e584275dabd30a99a5ce058b4dc76f3d03fad1921cef3a21d8f53127d30a808cfd1864aa2fe6890a5d43359f682457315baec873
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Adopts the happy-dom-by-default pattern that `openmrs-esm-core` already uses across its 25 per-package vitest configs, with per-file `/** @vitest-environment jsdom */` docblocks as the escape hatch for tests that hit happy-dom/jsdom divergences. See [`esm-navigation/src/history/history.test.ts`](https://github.com/openmrs/openmrs-esm-core/blob/e1470604dafd40c0e687b75b8838278061c511db/packages/framework/esm-navigation/src/history/history.test.ts#L2) in core for the established precedent.

### Changes
- `tools/vitest.shared.ts`: `environment: 'jsdom'` → `'happy-dom'`.
- `package.json`: add `happy-dom@^20.0.0`. Keep `jsdom@^28.0.0` because twelve test files in this repo still need it via the docblock escape hatch.
- Add `/** @vitest-environment jsdom */` to twelve test files where the form-submit flow under test does not fire its callback under happy-dom (a DOM-event-dispatch divergence around React Hook Form / Carbon `Form` submit handlers):
  - `esm-appointments-app/.../appointments-form.test.tsx`
  - `esm-bed-management-app/.../bed-form.workspace.test.tsx`
  - `esm-patient-registration-app/.../patient-registration.test.tsx`
  - `esm-patient-search-app/.../compact-patient-search.test.tsx`
  - `esm-patient-search-app/.../patient-search-bar.test.tsx`
  - `esm-patient-search-app/.../advanced-patient-search.test.tsx`
  - `esm-patient-search-app/.../refine-search.test.tsx`
  - `esm-service-queues-app/.../queue-room-form.test.tsx`
  - `esm-service-queues-app/.../queue-form.test.tsx`
  - `esm-ward-app/.../admit-patient-form.test.tsx`
  - `esm-ward-app/.../cancel-admission-request.test.tsx`
  - `esm-ward-app/.../notes.test.tsx`

### Why bother

jsdom's per-file environment init is the dominant fixed cost when vitest spawns a worker per test file; happy-dom roughly halves it. Benchmarks on `openmrs-esm-patient-chart/esm-patient-chart-app` (similar suite shape) showed a 29% wall-clock reduction. happy-dom's transitive dep tree is also smaller.

## Screenshots

N/A — tooling change only.

## Related Issue

N/A

## Other

`yarn turbo run typescript` (9 workspaces) and `yarn turbo run lint` (9 workspaces) are both green locally. All 113 test files pass across the 8 testable workspaces.