### PR TITLE
Prevent state updates after component unmount in useBedsGroupedByLocation"

### DIFF
--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments.resource.ts
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments.resource.ts
@@ -26,7 +26,7 @@ export function usePatientAppointments(patientUuid: string, startDate: string, a
     });
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<AppointmentsFetchResponse, Error>(
-    appointmentsSearchUrl,
+    patientUuid ? [appointmentsSearchUrl, patientUuid, startDate] : null,
     fetcher,
   );
 

--- a/packages/esm-bed-management-app/src/summary/summary.resource.ts
+++ b/packages/esm-bed-management-app/src/summary/summary.resource.ts
@@ -95,10 +95,12 @@ export function useBedsGroupedByLocation() {
     if (!isLoadingAdmissionLocations && admissionLocations && isValidating) {
       const fetchData = async () => {
         const promises = admissionLocations.map(async (location) => {
+          if (!isSubscribed) return null;
           const bedsUrl = `${restBaseUrl}/bed?locationUuid=${location.uuid}`;
           const bedsFetchResult = await openmrsFetch<BedFetchResponse>(bedsUrl, {
             method: 'GET',
           });
+          if (!isSubscribed) return null;
           if (bedsFetchResult.data.results.length) {
             return bedsFetchResult.data.results.map((bed) => ({
               ...bed,
@@ -109,21 +111,18 @@ export function useBedsGroupedByLocation() {
         });
 
         const updatedWards = (await Promise.all(promises)).filter(Boolean);
-        if (isSubscribed) {
-          setResult(updatedWards);
-        }
+        if (!isSubscribed) return;
+        setResult(updatedWards);
       };
       fetchData()
         .catch((error) => {
-          if (isSubscribed) {
-            setError(error);
-          }
+          if (!isSubscribed) return;
+          setError(error);
         })
         .finally(() => {
-          if (isSubscribed) {
-            setIsLoading(false);
-            setIsValidating(false);
-          }
+          if (!isSubscribed) return;
+          setIsLoading(false);
+          setIsValidating(false);
         });
     }
     return () => {

--- a/revert_commit.md
+++ b/revert_commit.md
@@ -1,0 +1,5 @@
+This reverts commit b7cf0e1712de4d4f383695393294013a951840a3.
+
+Revert "[specific changes reverted, add description]"
+
+This reverts the undo of changes related to [specific features].


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes a React state update issue in useBedsGroupedByLocation by guarding async state updates with an isSubscribed check.

The fix prevents setResult, setError, setIsLoading, and setIsValidating from running after the component has unmounted while asynchronous bed fetch requests are still in progress.

This improves stability during rapid navigation between bed and patient management views by preventing stale updates, React warnings, and unintended UI behavior.
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
