### PR TITLE
(feat) O3-5714: Improve performance with multi-paged patient search results

### DIFF
--- a/packages/esm-patient-search-app/package.json
+++ b/packages/esm-patient-search-app/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@carbon/react": "^1.83.0",
+    "@tanstack/react-virtual": "^3.13.6",
     "classnames": "^2.3.2",
     "lodash-es": "^4.17.15",
     "react-hook-form": "^7.54.0"

--- a/packages/esm-patient-search-app/src/compact-patient-search.extension.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search.extension.tsx
@@ -7,6 +7,7 @@ import { useInfinitePatientSearch } from './patient-search.resource';
 import { PatientSearchContextProvider } from './patient-search-context';
 import useArrowNavigation from './hooks/useArrowNavigation';
 import PatientSearch from './compact-patient-search/patient-search.component';
+import { type CompactPatientBannerHandle } from './compact-patient-search/compact-patient-banner.component';
 import styles from './compact-patient-search.scss';
 
 interface CompactPatientSearchProps {
@@ -25,7 +26,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
   const config = useConfig<PatientSearchConfig>();
   const searchContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const bannerContainerRef = useRef(null);
+  const bannerRef = useRef<CompactPatientBannerHandle>(null);
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const showSearchResults = useMemo(() => !!searchTerm?.trim(), [searchTerm]);
   const patientSearchResponse = useInfinitePatientSearch(searchTerm, config.includeDead, showSearchResults);
@@ -72,17 +73,12 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
   );
 
   useEffect(() => {
-    if (bannerContainerRef.current && focusedResult > -1) {
-      bannerContainerRef.current.children?.[focusedResult]?.focus();
-      bannerContainerRef.current.children?.[focusedResult]?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'end',
-        inline: 'nearest',
-      });
-    } else if (bannerContainerRef.current && inputRef.current && focusedResult === -1) {
+    if (focusedResult > -1) {
+      bannerRef.current?.focusSearchResult(focusedResult);
+    } else if (bannerRef.current && inputRef.current && focusedResult === -1) {
       handleFocusToInput();
     }
-  }, [focusedResult, bannerContainerRef, handleFocusToInput]);
+  }, [focusedResult, handleFocusToInput]);
 
   return (
     <div className={styles.patientSearchBar} ref={searchContainerRef}>
@@ -110,7 +106,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
             patientClickSideEffect: handleClear,
           }}>
           <div className={styles.floatingSearchResultsContainer}>
-            <PatientSearch query={searchTerm} ref={bannerContainerRef} {...patientSearchResponse} />
+            <PatientSearch query={searchTerm} ref={bannerRef} {...patientSearchResponse} />
           </div>
         </PatientSearchContextProvider>
       )}

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -1,5 +1,7 @@
-import React, { forwardRef, useCallback, useMemo } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
+import { Loading } from '@carbon/react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   ConfigurableLink,
   getPatientName,
@@ -8,11 +10,33 @@ import {
   PatientPhoto,
   useConfig,
 } from '@openmrs/esm-framework';
-import type { SearchedPatient } from '../types';
 import { type PatientSearchConfig } from '../config-schema';
+import Loader from './loader.component';
 import { usePatientSearchContext } from '../patient-search-context';
 import { mapToFhirPatient } from '../utils/fhir-mapper';
+import type { SearchedPatient } from '../types';
 import styles from './compact-patient-banner.scss';
+
+// OpenMRS base assumption
+const remInPixels = 16;
+
+// Estimated row height used before a row is measured. Rows are measured individually and may grow
+// (roughly 5.625rem–7.5rem), so this only needs to be close.
+const estimatedRowHeight = 5.625 * remInPixels;
+
+// Rows rendered above and below the viewport. With the ~4-row viewport this keeps roughly 16
+// patients mounted as a scroll buffer. This is independent of pagination: see the fetch trigger,
+// which keys off the visible range, so buffering more rows doesn't pull an extra page over the wire.
+const overscan = 6;
+
+// Start loading the next page when the visible range reaches within this many rows of the end, so
+// the next page arrives just before the user hits the bottom rather than stalling there.
+const fetchLookAhead = 2;
+
+export interface CompactPatientBannerHandle {
+  /** Scroll the result at `index` into view and move focus to it (for arrow-key navigation). */
+  focusSearchResult: (index: number) => void;
+}
 
 interface ClickablePatientContainerProps {
   children: React.ReactNode;
@@ -21,28 +45,160 @@ interface ClickablePatientContainerProps {
 
 interface CompactPatientBannerProps {
   patients: Array<SearchedPatient>;
+  hasMore?: boolean;
+  isValidating?: boolean;
+  /** Loads the next page; called when the last result scrolls into view. */
+  fetchMore?: () => void;
+  /**
+   * Virtualize the list, mounting only the rows near the viewport. Defaults to `true`.
+   * Pass `false` for an already-bounded list  so every row stays mounted and never
+   * flickers to a skeleton.
+   */
+  virtualize?: boolean;
 }
 
-const CompactPatientBanner = forwardRef<HTMLDivElement, CompactPatientBannerProps>(({ patients }, ref) => {
-  const fhirMappedPatients: Array<fhir.Patient> = useMemo(() => {
-    return patients.map(mapToFhirPatient);
-  }, [patients]);
+/**
+ * Renders the patient search results as a list of compact banners. By default the list is
+ * virtualized and infinitely-scrolling, mounting only the rows near the viewport.
+ */
+const CompactPatientBanner = forwardRef<CompactPatientBannerHandle, CompactPatientBannerProps>(
+  ({ patients, hasMore = false, isValidating = false, fetchMore, virtualize = true }, ref) => {
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+    const [pendingFocusIndex, setPendingFocusIndex] = useState<number | null>(null);
+    // Rows we've already shown as real banners, so a resumed scroll doesn't replace the rows that
+    // are still on screen with skeletons
+    const seenIndices = useRef<Set<number>>(new Set());
 
-  const renderPatient = useCallback((patient: fhir.Patient) => {
-    const patientName = getPatientName(patient);
+    // When not virtualizing, give the virtualizer no items so it stays inert (no scroll management,
+    // no virtual rows) — the full list is rendered directly below instead.
+    const virtualizer = useVirtualizer({
+      count: virtualize ? patients.length : 0,
+      getScrollElement: () => scrollContainerRef.current,
+      estimateSize: () => estimatedRowHeight,
+      overscan,
+    });
+
+    const virtualItems = virtualizer.getVirtualItems();
+
+    // Load the next page once the visible range reaches within `fetchLookAhead` rows of the end. We
+    // key off the visible range (not the rendered/overscan window) so the buffer of mounted rows
+    // above can grow without dragging the next page over the wire ahead of time.
+    const lastVisibleIndex = virtualizer.range?.endIndex ?? -1;
+    useEffect(() => {
+      if (virtualize && lastVisibleIndex >= patients.length - 1 - fetchLookAhead && hasMore && !isValidating) {
+        fetchMore?.();
+      }
+    }, [virtualize, lastVisibleIndex, patients.length, hasMore, isValidating, fetchMore]);
+
+    // Once the list settles, record the rows that rendered as real banners (only the virtualized
+    // list swaps in skeletons, so this bookkeeping is unnecessary otherwise).
+    useEffect(() => {
+      if (virtualize && !virtualizer.isScrolling) {
+        for (const item of virtualItems) {
+          seenIndices.current.add(item.index);
+        }
+      }
+    }, [virtualize, virtualizer.isScrolling, virtualItems]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        // The row may not be mounted yet; focus it once it renders (see effect below).
+        focusSearchResult: (index: number) => setPendingFocusIndex(index),
+      }),
+      [],
+    );
+
+    useEffect(() => {
+      if (pendingFocusIndex === null) {
+        return;
+      }
+      if (pendingFocusIndex >= patients.length) {
+        // The list shrank (e.g. the query changed) and the target row no longer exists; stop here so
+        // we don't re-run scrollToIndex on every render chasing a row that will never render.
+        setPendingFocusIndex(null);
+        return;
+      }
+      const row = scrollContainerRef.current?.querySelector<HTMLElement>(`[data-index="${pendingFocusIndex}"]`);
+      const focusable = row?.querySelector<HTMLElement>('a, button');
+      if (focusable) {
+        // Keep this row a real banner so focus isn't lost when it would otherwise revert to a
+        // skeleton. Use the native focus scroll (rather than the virtualizer's) to bring it into
+        // view — the two fight each other and leave the row partly out of view.
+        seenIndices.current.add(pendingFocusIndex);
+        focusable.focus();
+        setPendingFocusIndex(null);
+      } else {
+        // The row isn't rendered yet (a jump beyond the overscan window). Scroll it into range and
+        // let this effect retry when the rendered rows change.
+        virtualizer.scrollToIndex(pendingFocusIndex, { align: 'auto' });
+      }
+    }, [pendingFocusIndex, patients.length, virtualItems, virtualizer]);
 
     return (
-      <ClickablePatientContainer key={patient.id} patient={patient}>
-        <div className={styles.patientAvatar}>
-          <PatientPhoto patientUuid={patient.id} patientName={patientName} />
-        </div>
-        <PatientBannerPatientInfo patient={patient} />
-      </ClickablePatientContainer>
+      // The bounding height is also set inline so the virtualizer always measures a 22rem viewport.
+      // Otherwise, the virtualizer will detect the wrong height and won't scroll properly.
+      <div ref={scrollContainerRef} className={styles.virtualScrollContainer} style={{ maxBlockSize: '22rem' }}>
+        {virtualize ? (
+          <div style={{ blockSize: virtualizer.getTotalSize() }}>
+            {virtualItems.map((virtualRow) => {
+              // Show the skeleton only for rows we haven't shown yet
+              const showSkeleton =
+                virtualizer.isScrolling &&
+                !seenIndices.current.has(virtualRow.index) &&
+                virtualRow.index !== pendingFocusIndex;
+              return (
+                <div
+                  key={virtualRow.key}
+                  data-index={virtualRow.index}
+                  ref={virtualizer.isScrolling ? undefined : virtualizer.measureElement}
+                  className={styles.virtualRow}
+                  style={
+                    virtualizer.isScrolling
+                      ? { blockSize: virtualRow.size, transform: `translateY(${virtualRow.start}px)` }
+                      : { transform: `translateY(${virtualRow.start}px)` }
+                  }>
+                  {showSkeleton ? <Loader /> : <CompactPatientBannerRow patient={patients[virtualRow.index]} />}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          // Bounded list: every row stays mounted (the `data-index` wrapper lets arrow-key focus find
+          // it, exactly as in the virtualized branch).
+          patients.map((patient, index) => (
+            <div key={patient.uuid} data-index={index}>
+              <CompactPatientBannerRow patient={patient} />
+            </div>
+          ))
+        )}
+        {hasMore && (
+          <div className={styles.loadingIcon}>
+            <Loading withOverlay={false} small />
+          </div>
+        )}
+      </div>
     );
-  }, []);
+  },
+);
 
-  return <div ref={ref}>{fhirMappedPatients.map(renderPatient)}</div>;
+// Memoized so the banner subtree (photo, info, and its secondary lookups) doesn't re-render on
+// every scroll frame: `patient` references are stable across renders and when new pages append, so
+// only genuinely-changed rows re-render.
+const CompactPatientBannerRow = React.memo(({ patient }: { patient: SearchedPatient }) => {
+  const fhirPatient = useMemo(() => mapToFhirPatient(patient), [patient]);
+  const patientName = getPatientName(fhirPatient);
+
+  return (
+    <ClickablePatientContainer patient={fhirPatient}>
+      <div className={styles.patientAvatar}>
+        <PatientPhoto patientUuid={fhirPatient.id} patientName={patientName} />
+      </div>
+      <PatientBannerPatientInfo patient={fhirPatient} />
+    </ClickablePatientContainer>
+  );
 });
+CompactPatientBannerRow.displayName = 'CompactPatientBannerRow';
 
 const ClickablePatientContainer = ({ patient, children }: ClickablePatientContainerProps) => {
   const { nonNavigationSelectPatientAction, patientClickSideEffect } = usePatientSearchContext();
@@ -52,14 +208,13 @@ const ClickablePatientContainer = ({ patient, children }: ClickablePatientContai
   if (nonNavigationSelectPatientAction) {
     return (
       <button
-        className={classNames(styles.patientSearchResult, styles.patientSearchResultButton, {
-          [styles.deceased]: isDeceased,
-        })}
+        className={classNames(styles.patientSearchResult, styles.patientSearchResultButton)}
         key={patient.id}
         onClick={() => {
           nonNavigationSelectPatientAction(patient.id, patient);
           patientClickSideEffect?.(patient.id, patient);
-        }}>
+        }}
+        {...(isDeceased ? { 'data-deceased': 'true' } : null)}>
         {children}
       </button>
     );
@@ -67,14 +222,13 @@ const ClickablePatientContainer = ({ patient, children }: ClickablePatientContai
 
   return (
     <ConfigurableLink
-      className={classNames(styles.patientSearchResult, {
-        [styles.deceased]: isDeceased,
-      })}
+      className={classNames(styles.patientSearchResult)}
       key={patient.id}
       onBeforeNavigate={() => patientClickSideEffect?.(patient.id, patient)}
       to={interpolateString(config.search.patientChartUrl, {
         patientUuid: patient.id,
-      })}>
+      })}
+      {...(isDeceased ? { 'data-deceased': 'true' } : null)}>
       {children}
     </ConfigurableLink>
   );

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -65,9 +65,9 @@ const CompactPatientBanner = forwardRef<CompactPatientBannerHandle, CompactPatie
   ({ patients, hasMore = false, isValidating = false, fetchMore, virtualize = true }, ref) => {
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const [pendingFocusIndex, setPendingFocusIndex] = useState<number | null>(null);
-    // Rows we've already shown as real banners, so a resumed scroll doesn't replace the rows that
-    // are still on screen with skeletons
-    const seenIndices = useRef<Set<number>>(new Set());
+    // Patients we've already shown as real banners, so a resumed scroll doesn't replace rows still
+    // on screen with skeletons.
+    const seenPatientUuids = useRef<Set<string>>(new Set());
 
     // When not virtualizing, give the virtualizer no items so it stays inert (no scroll management,
     // no virtual rows) — the full list is rendered directly below instead.
@@ -76,6 +76,7 @@ const CompactPatientBanner = forwardRef<CompactPatientBannerHandle, CompactPatie
       getScrollElement: () => scrollContainerRef.current,
       estimateSize: () => estimatedRowHeight,
       overscan,
+      getItemKey: (index) => patients[index]?.uuid ?? index,
     });
 
     const virtualItems = virtualizer.getVirtualItems();
@@ -95,10 +96,13 @@ const CompactPatientBanner = forwardRef<CompactPatientBannerHandle, CompactPatie
     useEffect(() => {
       if (virtualize && !virtualizer.isScrolling) {
         for (const item of virtualItems) {
-          seenIndices.current.add(item.index);
+          const uuid = patients[item.index]?.uuid;
+          if (uuid) {
+            seenPatientUuids.current.add(uuid);
+          }
         }
       }
-    }, [virtualize, virtualizer.isScrolling, virtualItems]);
+    }, [virtualize, virtualizer.isScrolling, virtualItems, patients]);
 
     useImperativeHandle(
       ref,
@@ -125,7 +129,10 @@ const CompactPatientBanner = forwardRef<CompactPatientBannerHandle, CompactPatie
         // Keep this row a real banner so focus isn't lost when it would otherwise revert to a
         // skeleton. Use the native focus scroll (rather than the virtualizer's) to bring it into
         // view — the two fight each other and leave the row partly out of view.
-        seenIndices.current.add(pendingFocusIndex);
+        const uuid = patients[pendingFocusIndex]?.uuid;
+        if (uuid) {
+          seenPatientUuids.current.add(uuid);
+        }
         focusable.focus();
         setPendingFocusIndex(null);
       } else {
@@ -133,7 +140,7 @@ const CompactPatientBanner = forwardRef<CompactPatientBannerHandle, CompactPatie
         // let this effect retry when the rendered rows change.
         virtualizer.scrollToIndex(pendingFocusIndex, { align: 'auto' });
       }
-    }, [pendingFocusIndex, patients.length, virtualItems, virtualizer]);
+    }, [pendingFocusIndex, patients, virtualItems, virtualizer]);
 
     return (
       // The bounding height is also set inline so the virtualizer always measures a 22rem viewport.
@@ -142,10 +149,10 @@ const CompactPatientBanner = forwardRef<CompactPatientBannerHandle, CompactPatie
         {virtualize ? (
           <div style={{ blockSize: virtualizer.getTotalSize() }}>
             {virtualItems.map((virtualRow) => {
-              // Show the skeleton only for rows we haven't shown yet
+              // Show the skeleton only for patients we haven't shown yet
               const showSkeleton =
                 virtualizer.isScrolling &&
-                !seenIndices.current.has(virtualRow.index) &&
+                !seenPatientUuids.current.has(patients[virtualRow.index]?.uuid) &&
                 virtualRow.index !== pendingFocusIndex;
               return (
                 <div

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.component.tsx
@@ -221,7 +221,7 @@ const ClickablePatientContainer = ({ patient, children }: ClickablePatientContai
           nonNavigationSelectPatientAction(patient.id, patient);
           patientClickSideEffect?.(patient.id, patient);
         }}
-        {...(isDeceased ? { 'data-deceased': 'true' } : null)}>
+        {...(isDeceased ? { 'data-deceased': 'true' } : {})}>
         {children}
       </button>
     );
@@ -235,7 +235,7 @@ const ClickablePatientContainer = ({ patient, children }: ClickablePatientContai
       to={interpolateString(config.search.patientChartUrl, {
         patientUuid: patient.id,
       })}
-      {...(isDeceased ? { 'data-deceased': 'true' } : null)}>
+      {...(isDeceased ? { 'data-deceased': 'true' } : {})}>
       {children}
     </ConfigurableLink>
   );

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.scss
@@ -1,8 +1,32 @@
 @use '@carbon/layout';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
-.patientSearchResult,
-.deceased.patientSearchResult {
+.virtualScrollContainer {
+  inline-size: 100%;
+  overflow-y: auto;
+}
+
+.virtualScrollContainer > div {
+  inline-size: 100%;
+  position: relative;
+}
+
+.virtualRow {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  inline-size: 100%;
+  overflow: hidden;
+}
+
+.loadingIcon {
+  padding: layout.$spacing-05 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.patientSearchResult {
   text-decoration: none;
   display: flex;
   align-items: center;

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-banner.test.tsx
@@ -8,6 +8,19 @@ import { configSchema, type PatientSearchConfig } from '../config-schema';
 import { PatientSearchContext } from '../patient-search-context';
 import CompactPatientBanner from './compact-patient-banner.component';
 
+// The virtualizer measures a 0px scroll element under happy-dom, so it would render no rows.
+// Stub it to render every row, letting the result assertions run.
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, key: index, start: index * 90, size: 90 })),
+    getTotalSize: () => count * 90,
+    scrollToIndex: () => {},
+    measureElement: () => {},
+    isScrolling: false,
+  }),
+}));
+
 const mockUseConfig = vi.mocked(useConfig<PatientSearchConfig>);
 
 const birthdate = '1990-01-01T00:00:00.000+0000';

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -1,14 +1,15 @@
 import React, { useCallback, useRef, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { navigate, interpolateString, useConfig, useSession, useDebounce, showSnackbar } from '@openmrs/esm-framework';
+import { navigate, interpolateString, useConfig, useDebounce, showSnackbar } from '@openmrs/esm-framework';
 import { type PatientSearchConfig } from '../config-schema';
-import { type SearchedPatient } from '../types';
+import { type CompactPatientBannerHandle } from './compact-patient-banner.component';
 import { useRecentlyViewedPatients, useInfinitePatientSearch, useRestPatients } from '../patient-search.resource';
 import { PatientSearchContextProvider } from '../patient-search-context';
 import useArrowNavigation from '../hooks/useArrowNavigation';
 import PatientSearch from './patient-search.component';
 import PatientSearchBar from '../patient-search-bar/patient-search-bar.component';
 import RecentlySearchedPatients from './recently-searched-patients.component';
+import { type SearchedPatient } from '../types';
 import styles from './compact-patient-search.scss';
 
 interface CompactPatientSearchProps {
@@ -27,7 +28,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
   const { t } = useTranslation();
 
   const searchContainerRef = useRef<HTMLDivElement>(null);
-  const bannerContainerRef = useRef(null);
+  const bannerRef = useRef<CompactPatientBannerHandle>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
@@ -36,11 +37,6 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
 
   const config = useConfig<PatientSearchConfig>();
   const { showRecentlySearchedPatients } = config.search;
-
-  const {
-    user,
-    sessionLocation: { uuid: currentLocation },
-  } = useSession();
 
   const patientSearchResponse = useInfinitePatientSearch(debouncedSearchTerm, config.includeDead);
   const { data: searchedPatients } = patientSearchResponse;
@@ -90,7 +86,7 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
   );
 
   const handlePatientSelection = useCallback(
-    (evt, index: number, patients: Array<SearchedPatient>) => {
+    (evt: KeyboardEvent, index: number, patients: Array<SearchedPatient>) => {
       evt.preventDefault();
       if (patients) {
         addViewedPatientAndCloseSearchResults(patients[index].uuid);
@@ -103,8 +99,9 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
     },
     [addViewedPatientAndCloseSearchResults, config.search.patientChartUrl],
   );
+
   const focusedResult = useArrowNavigation(
-    !recentPatients ? (searchedPatients?.length ?? 0) : (recentPatients?.length ?? 0),
+    hasSearchTerm ? (searchedPatients?.length ?? 0) : (recentPatients?.length ?? 0),
     handlePatientSelection,
     handleFocusToInput,
     -1,
@@ -112,17 +109,12 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
   );
 
   useEffect(() => {
-    if (bannerContainerRef.current && focusedResult > -1) {
-      bannerContainerRef.current.children?.[focusedResult]?.focus();
-      bannerContainerRef.current.children?.[focusedResult]?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'end',
-        inline: 'nearest',
-      });
-    } else if (bannerContainerRef.current && searchInputRef.current && focusedResult === -1) {
+    if (focusedResult > -1) {
+      bannerRef.current?.focusSearchResult(focusedResult);
+    } else if (bannerRef.current && searchInputRef.current && focusedResult === -1) {
       handleFocusToInput();
     }
-  }, [focusedResult, bannerContainerRef, handleFocusToInput]);
+  }, [focusedResult, handleFocusToInput]);
 
   useEffect(() => {
     if (fetchError) {
@@ -176,23 +168,21 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
           onClear={handleClear}
           ref={searchInputRef}
         />
-
         {!isSearchPage && hasSearchTerm && (
           <div
             className={styles.floatingSearchResultsContainer}
             data-testid="floatingSearchResultsContainer"
             data-tutorial-target="floating-search-results-container">
-            <PatientSearch query={debouncedSearchTerm} ref={bannerContainerRef} {...patientSearchResponse} />
+            <PatientSearch query={debouncedSearchTerm} ref={bannerRef} {...patientSearchResponse} />
           </div>
         )}
-
         {!isSearchPage && !hasSearchTerm && showRecentlySearchedPatients && (
           <div
             className={styles.floatingSearchResultsContainer}
             data-testid="floatingSearchResultsContainer"
             data-tutorial-target="floating-search-results-container">
             <RecentlySearchedPatients
-              ref={bannerContainerRef}
+              ref={bannerRef}
               {...recentPatientSearchResponse}
               isLoading={recentPatientSearchResponse.isLoading || isLoadingPatients}
             />

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
@@ -12,16 +12,59 @@ import { getDefaultsFromConfigSchema, navigate, useConfig, useSession } from '@o
 import { renderWithRouter } from 'tools';
 import { mockSession } from '__mocks__';
 import { configSchema, type PatientSearchConfig } from '../config-schema';
+import { type SearchedPatient } from '../types';
+import { useInfinitePatientSearch, useRecentlyViewedPatients, useRestPatients } from '../patient-search.resource';
+import useArrowNavigation from '../hooks/useArrowNavigation';
 import CompactPatientSearchComponent from './compact-patient-search.component';
+
+// The data hooks are mocked so each test can dictate the exact result counts without standing up
+// SWR/network behaviour, and the result-list children are stubbed so these tests stay focused on
+// what the page hands to arrow-key navigation rather than how the lists render.
+vi.mock('../patient-search.resource');
+vi.mock('../hooks/useArrowNavigation', () => ({ default: vi.fn(() => -1) }));
+vi.mock('./patient-search.component', async () => ({
+  default: (await import('react')).forwardRef(() => null),
+}));
+vi.mock('./recently-searched-patients.component', async () => ({
+  default: (await import('react')).forwardRef(() => null),
+}));
 
 const mockUseConfig = vi.mocked(useConfig<PatientSearchConfig>);
 const mockUseSession = vi.mocked(useSession);
 const mockNavigate = vi.mocked(navigate);
+const mockUseInfinitePatientSearch = vi.mocked(useInfinitePatientSearch);
+const mockUseRestPatients = vi.mocked(useRestPatients);
+const mockUseRecentlyViewedPatients = vi.mocked(useRecentlyViewedPatients);
+const mockUseArrowNavigation = vi.mocked(useArrowNavigation);
+
+const buildPatients = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({ uuid: `patient-${index}` })) as unknown as Array<SearchedPatient>;
+
+const buildSearchResponse = (data: Array<SearchedPatient>) => ({
+  data,
+  isLoading: false,
+  fetchError: null,
+  hasMore: false,
+  isValidating: false,
+  setPage: vi.fn(),
+  currentPage: 1,
+  totalResults: data.length,
+});
 
 describe('CompactPatientSearchComponent', () => {
   beforeEach(() => {
     mockUseConfig.mockReturnValue(getDefaultsFromConfigSchema(configSchema));
     mockUseSession.mockReturnValue(mockSession.data);
+    mockUseInfinitePatientSearch.mockReturnValue(buildSearchResponse([]));
+    mockUseRestPatients.mockReturnValue(buildSearchResponse([]));
+    mockUseRecentlyViewedPatients.mockReturnValue({
+      error: null,
+      isLoadingPatients: false,
+      recentlyViewedPatientUuids: [],
+      updateRecentlyViewedPatients: vi.fn(),
+      mutateUserProperties: vi.fn(),
+    });
+    mockUseArrowNavigation.mockReturnValue(-1);
   });
 
   it('renders a compact search bar', () => {
@@ -88,5 +131,27 @@ describe('CompactPatientSearchComponent', () => {
     await user.click(searchButton);
 
     expect(mockNavigate).toHaveBeenCalledWith({ to: expect.stringMatching(/.*\/search\?query=John/) });
+  });
+
+  // Arrow-key navigation must walk the list that is actually on screen, so the count it receives has
+  // to track the displayed results. Recently-viewed patients linger in their hook (keepPreviousData)
+  // after a search starts; if navigation were sized off that stale list it would clamp partway down
+  // the search results.
+  it('sizes arrow-key navigation to the search results while a search is active, even when recently-viewed patients are still cached', () => {
+    mockUseInfinitePatientSearch.mockReturnValue(buildSearchResponse(buildPatients(10)));
+    mockUseRestPatients.mockReturnValue(buildSearchResponse(buildPatients(7)));
+
+    renderWithRouter(<CompactPatientSearchComponent isSearchPage={false} initialSearchTerm="John" />);
+
+    expect(mockUseArrowNavigation.mock.calls.at(-1)?.[0]).toBe(10);
+  });
+
+  it('sizes arrow-key navigation to the recently-viewed patients when no search is active', () => {
+    mockUseInfinitePatientSearch.mockReturnValue(buildSearchResponse([]));
+    mockUseRestPatients.mockReturnValue(buildSearchResponse(buildPatients(7)));
+
+    renderWithRouter(<CompactPatientSearchComponent isSearchPage={false} initialSearchTerm="" />);
+
+    expect(mockUseArrowNavigation.mock.calls.at(-1)?.[0]).toBe(7);
   });
 });

--- a/packages/esm-patient-search-app/src/compact-patient-search/loader.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/loader.component.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { SkeletonIcon, SkeletonText } from '@carbon/react';
 import styles from './compact-patient-banner.scss';
 
-export const Loader = () => {
+// Memoized: the skeleton is static, so it never needs to re-render as the list scrolls.
+export const Loader = React.memo(() => {
   return (
     <div className={styles.patientSearchResult} data-testid="search-skeleton">
       <div className={styles.patientAvatar}>
@@ -17,6 +18,7 @@ export const Loader = () => {
       </div>
     </div>
   );
-};
+});
+Loader.displayName = 'Loader';
 
 export default Loader;

--- a/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
@@ -66,7 +66,6 @@ const PatientSearch = forwardRef<CompactPatientBannerHandle, PatientSearchProps>
                 revalidateOnFocus: false,
                 revalidateOnReconnect: false,
                 dedupingInterval: 180_000, // 3 minutes
-                keepPreviousData: true,
               }}>
               <CompactPatientBanner
                 ref={ref}

--- a/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/patient-search.component.tsx
@@ -1,55 +1,25 @@
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Layer, Loading, Tile } from '@carbon/react';
+import { Layer, Tile } from '@carbon/react';
 import { EmptyCardIllustration } from '@openmrs/esm-framework';
 import { type PatientSearchResponse } from '../types';
-import CompactPatientBanner from './compact-patient-banner.component';
+import CompactPatientBanner, { type CompactPatientBannerHandle } from './compact-patient-banner.component';
 import Loader from './loader.component';
 import styles from './patient-search.scss';
+import { SWRConfig } from 'swr';
 
 interface PatientSearchProps extends PatientSearchResponse {
   query: string;
 }
 
-const PatientSearch = React.forwardRef<HTMLDivElement, PatientSearchProps>(
+const PatientSearch = forwardRef<CompactPatientBannerHandle, PatientSearchProps>(
   ({ data: searchResults, fetchError, hasMore, isLoading, isValidating, setPage, totalResults }, ref) => {
     const { t } = useTranslation();
-    const observer = useRef(null);
 
-    const loadingIconRef = useCallback(
-      (node: HTMLDivElement | null) => {
-        if (isValidating) {
-          return;
-        }
-        if (observer.current) {
-          observer.current.disconnect();
-        }
-        observer.current = new IntersectionObserver(
-          (entries) => {
-            if (entries[0].isIntersecting && hasMore) {
-              setPage((page) => page + 1);
-            }
-          },
-          {
-            threshold: 0.75,
-          },
-        );
-        if (node) {
-          observer.current.observe(node);
-        }
-      },
-      [isValidating, hasMore, setPage],
-    );
+    const fetchMore = useCallback(() => setPage((page) => page + 1), [setPage]);
 
-    useEffect(() => {
-      return () => {
-        if (observer.current) {
-          observer.current.disconnect();
-        }
-      };
-    }, []);
-
-    if (isLoading) {
+    // Only show the full skeleton when there is nothing to show
+    if (isLoading && !searchResults?.length) {
       return (
         <div className={styles.searchResultsContainer} role="progressbar">
           {[...Array(5)].map((_, index) => (
@@ -89,12 +59,23 @@ const PatientSearch = React.forwardRef<HTMLDivElement, PatientSearchProps>(
                 count: totalResults,
               })}
             </p>
-            <CompactPatientBanner patients={searchResults} ref={ref} />
-            {hasMore && (
-              <div className={styles.loadingIcon} ref={loadingIconRef}>
-                <Loading withOverlay={false} small />
-              </div>
-            )}
+            {/* Set SWRConfig to minimize revalidations of, e.g., the patient photo */}
+            <SWRConfig
+              value={{
+                revalidateIfStale: false,
+                revalidateOnFocus: false,
+                revalidateOnReconnect: false,
+                dedupingInterval: 180_000, // 3 minutes
+                keepPreviousData: true,
+              }}>
+              <CompactPatientBanner
+                ref={ref}
+                patients={searchResults}
+                hasMore={hasMore}
+                isValidating={isValidating}
+                fetchMore={fetchMore}
+              />
+            </SWRConfig>
           </div>
         </div>
       );

--- a/packages/esm-patient-search-app/src/compact-patient-search/patient-search.scss
+++ b/packages/esm-patient-search-app/src/compact-patient-search/patient-search.scss
@@ -18,7 +18,6 @@
 
 .searchResults {
   width: 100%;
-  max-height: 22rem;
 }
 
 .loadingIcon {

--- a/packages/esm-patient-search-app/src/compact-patient-search/patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/patient-search.test.tsx
@@ -8,6 +8,19 @@ import { configSchema } from '../config-schema';
 import { type SearchedPatient } from '../types';
 import PatientSearch from './patient-search.component';
 
+// The virtualizer measures a 0px scroll element under happy-dom, so it would render no rows.
+// Stub it to render every row, letting the result assertions run.
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, key: index, start: index * 90, size: 90 })),
+    getTotalSize: () => count * 90,
+    scrollToIndex: () => {},
+    measureElement: () => {},
+    isScrolling: false,
+  }),
+}));
+
 const defaultProps = {
   currentPage: 0,
   data: [],
@@ -32,6 +45,31 @@ describe('PatientSearch', () => {
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
     expect(screen.queryByText(/recent search result/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps showing existing results (no skeleton) while a new query is loading', () => {
+    const birthdate = '1990-01-01T00:00:00.000+0000';
+    const existingResults: Array<SearchedPatient> = [
+      {
+        attributes: [],
+        identifiers: [],
+        person: {
+          age: dayjs().diff(birthdate, 'years'),
+          addresses: [],
+          birthdate,
+          dead: false,
+          deathDate: null,
+          gender: 'M',
+          personName: { display: 'Smith, John Doe', givenName: 'John', middleName: 'Doe', familyName: 'Smith' },
+        },
+        uuid: 'test-patient-uuid',
+      },
+    ];
+
+    renderPatientSearch({ isLoading: true, data: existingResults, totalResults: 1 });
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByText(/1 search result/i)).toBeInTheDocument();
   });
 
   it('renders an empty state when there are no matching search results', () => {

--- a/packages/esm-patient-search-app/src/compact-patient-search/recently-searched-patients.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/recently-searched-patients.component.tsx
@@ -1,49 +1,17 @@
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { InlineLoading, Layer, Loading, Tile } from '@carbon/react';
+import { InlineLoading, Layer, Tile } from '@carbon/react';
 import { EmptyCardIllustration } from '@openmrs/esm-framework';
-import type { PatientSearchResponse } from '../types';
-import CompactPatientBanner from './compact-patient-banner.component';
+import CompactPatientBanner, { type CompactPatientBannerHandle } from './compact-patient-banner.component';
 import Loader from './loader.component';
+import type { PatientSearchResponse } from '../types';
 import styles from './patient-search.scss';
 
-const RecentlySearchedPatients = React.forwardRef<HTMLDivElement, PatientSearchResponse>(
+const RecentlySearchedPatients = forwardRef<CompactPatientBannerHandle, PatientSearchResponse>(
   ({ data: searchResults, fetchError, hasMore, isLoading, isValidating, setPage }, ref) => {
     const { t } = useTranslation();
-    const observer = useRef(null);
 
-    const loadingIconRef = useCallback(
-      (node: HTMLDivElement | null) => {
-        if (isValidating) {
-          return;
-        }
-        if (observer.current) {
-          observer.current.disconnect();
-        }
-        observer.current = new IntersectionObserver(
-          (entries) => {
-            if (entries[0].isIntersecting && hasMore) {
-              setPage((page) => page + 1);
-            }
-          },
-          {
-            threshold: 0.75,
-          },
-        );
-        if (node) {
-          observer.current.observe(node);
-        }
-      },
-      [isValidating, hasMore, setPage],
-    );
-
-    useEffect(() => {
-      return () => {
-        if (observer.current) {
-          observer.current.disconnect();
-        }
-      };
-    }, []);
+    const fetchMore = useCallback(() => setPage((page) => page + 1), [setPage]);
 
     if (!searchResults && isLoading) {
       return (
@@ -92,12 +60,14 @@ const RecentlySearchedPatients = React.forwardRef<HTMLDivElement, PatientSearchR
                 </span>
               )}
             </div>
-            <CompactPatientBanner patients={searchResults} ref={ref} />
-            {hasMore && (
-              <div className={styles.loadingIcon} ref={loadingIconRef}>
-                <Loading withOverlay={false} small />
-              </div>
-            )}
+            <CompactPatientBanner
+              ref={ref}
+              patients={searchResults}
+              hasMore={hasMore}
+              isValidating={isValidating}
+              fetchMore={fetchMore}
+              virtualize={false}
+            />
           </div>
         </div>
       );

--- a/packages/esm-patient-search-app/src/compact-patient-search/recently-searched-patients.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/recently-searched-patients.test.tsx
@@ -8,6 +8,19 @@ import { configSchema, type PatientSearchConfig } from '../config-schema';
 import { PatientSearchContext } from '../patient-search-context';
 import RecentlySearchedPatients from './recently-searched-patients.component';
 
+// The virtualizer measures a 0px scroll element under happy-dom, so it would render no rows.
+// Stub it to render every row, letting the result assertions run.
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, key: index, start: index * 90, size: 90 })),
+    getTotalSize: () => count * 90,
+    scrollToIndex: () => {},
+    measureElement: () => {},
+    isScrolling: false,
+  }),
+}));
+
 const defaultProps = {
   currentPage: 0,
   data: [],

--- a/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
+++ b/packages/esm-patient-search-app/src/hooks/useArrowNavigation.tsx
@@ -3,7 +3,7 @@ import { type SearchedPatient } from '../types';
 
 const useArrowNavigation = (
   totalResults: number,
-  enterCallback: (evt: React.MouseEvent<HTMLAnchorElement>, index: number, patients?: Array<SearchedPatient>) => void,
+  enterCallback: (evt: KeyboardEvent, index: number, patients?: Array<SearchedPatient>) => void,
   resetFocusCallback: () => void,
   initalFocusedResult: number = -1,
   containerRef?: RefObject<HTMLElement>,
@@ -11,7 +11,7 @@ const useArrowNavigation = (
   const [focusedResult, setFocusedResult] = useState(initalFocusedResult);
 
   const handleKeyPress = useCallback(
-    (e) => {
+    (e: KeyboardEvent) => {
       if (containerRef?.current && !containerRef.current.contains(document.activeElement)) {
         return;
       }

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
@@ -38,7 +38,8 @@ const PatientSearchComponent: React.FC<PatientSearchComponentProps> = ({
   }, [query, goTo]);
 
   const searchResultsView = useMemo(() => {
-    if (isLoading) {
+    // Only show the full skeleton when there is nothing to show
+    if (isLoading && !results?.length) {
       return <LoadingState />;
     }
 

--- a/packages/esm-patient-search-app/src/patient-search.resource.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { vi, describe, it, beforeEach, expect } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import { useInfinitePatientSearch } from './patient-search.resource';
+
+const mockOpenmrsFetch = vi.mocked(openmrsFetch);
+
+const queryOf = (url: string) => new URL(url, 'http://localhost').searchParams.get('q') ?? '';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+
+const pageOfResults = (query: string) =>
+  Promise.resolve({
+    data: {
+      results: Array.from({ length: 10 }, (_, i) => ({
+        uuid: `${query}-${i}`,
+        person: { personName: { display: query } },
+      })),
+      links: [{ rel: 'next' }],
+      totalCount: 100,
+    },
+  } as unknown as FetchResponse);
+
+describe('useInfinitePatientSearch', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockOpenmrsFetch.mockReset();
+    mockOpenmrsFetch.mockImplementation((url: string) => pageOfResults(queryOf(url)));
+  });
+
+  // Regression test for O3-5714: without `keepPreviousData`, a query change resets
+  // `data` to undefined while the new request is in flight, which made the view
+  // swap in its loading skeleton and unmount/remount the entire banner list on
+  // every keystroke. With `keepPreviousData`, the prior results stay in `data`
+  // until the new ones arrive, so the banner subtree is never torn down.
+  it('keeps the previously loaded results while a new query is being fetched', async () => {
+    const { result, rerender } = renderHook(({ q }: { q: string }) => useInfinitePatientSearch(q, false, true, 10), {
+      wrapper,
+      initialProps: { q: 'Jo' },
+    });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(10));
+    expect(result.current.data?.[0].uuid).toBe('Jo-0');
+
+    // The next query's request never resolves, so the only way `data` can stay
+    // populated is `keepPreviousData` holding onto the previous results.
+    mockOpenmrsFetch.mockImplementation(() => new Promise(() => {}));
+    rerender({ q: 'Jos' });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(result.current.data).toHaveLength(10);
+    expect(result.current.data?.[0].uuid).toBe('Jo-0');
+  });
+});

--- a/packages/esm-patient-search-app/src/patient-search.resource.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.test.tsx
@@ -58,4 +58,28 @@ describe('useInfinitePatientSearch', () => {
     expect(result.current.data).toHaveLength(10);
     expect(result.current.data?.[0].uuid).toBe('Jo-0');
   });
+
+  // Once the search is cleared, `keepPreviousData` keeps the last query's results in the SWR cache,
+  // but the hook must not keep surfacing them: consumers size arrow-key navigation off `data`, so
+  // returning stale results would let a keypress select a patient that is no longer on screen.
+  it('stops surfacing results once the search is no longer active', async () => {
+    const { result, rerender } = renderHook(
+      ({ q, searching }: { q: string; searching: boolean }) => useInfinitePatientSearch(q, false, searching, 10),
+      { wrapper, initialProps: { q: 'Jo', searching: true } },
+    );
+
+    await waitFor(() => expect(result.current.data).toHaveLength(10));
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.totalResults).toBe(100);
+
+    rerender({ q: '', searching: false });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.totalResults).toBe(0);
+  });
 });

--- a/packages/esm-patient-search-app/src/patient-search.resource.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.tsx
@@ -78,7 +78,7 @@ export function useInfinitePatientSearch(
     [searchQuery, customRepresentation, includeDead, resultsToFetch],
   );
 
-  const shouldFetch = isSearching && searchQuery;
+  const shouldFetch = isSearching && Boolean(searchQuery);
 
   const { data, isLoading, isValidating, setSize, error, size } = useSWRInfinite<InfinitePatientSearchResponse, Error>(
     shouldFetch ? getUrl : null,
@@ -89,23 +89,24 @@ export function useInfinitePatientSearch(
   // Filter out null patients and patients with null person property to prevent errors
   // when components access patient.person properties. This filtering happens at the source
   // (in the hook) to ensure all consumers receive clean, valid data.
-  const mappedData =
-    data
-      ?.flatMap((res) => res.data?.results ?? [])
-      ?.filter((patient): patient is SearchedPatient => patient !== null && patient.person !== null) ?? null;
+  const mappedData = shouldFetch
+    ? (data
+        ?.flatMap((res) => res.data?.results ?? [])
+        ?.filter((patient): patient is SearchedPatient => patient !== null && patient.person !== null) ?? null)
+    : null;
 
   return useMemo(
     () => ({
       data: mappedData,
       isLoading,
       fetchError: error,
-      hasMore: data?.at(-1)?.data?.links?.some((link) => link.rel === 'next') ?? false,
+      hasMore: shouldFetch ? (data?.at(-1)?.data?.links?.some((link) => link.rel === 'next') ?? false) : false,
       isValidating,
       setPage: setSize,
       currentPage: size,
-      totalResults: data?.[0]?.data?.totalCount ?? 0,
+      totalResults: shouldFetch ? (data?.[0]?.data?.totalCount ?? 0) : 0,
     }),
-    [mappedData, isLoading, error, data, isValidating, setSize, size],
+    [shouldFetch, mappedData, isLoading, error, data, isValidating, setSize, size],
   );
 }
 

--- a/packages/esm-patient-search-app/src/patient-search.resource.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.tsx
@@ -83,6 +83,7 @@ export function useInfinitePatientSearch(
   const { data, isLoading, isValidating, setSize, error, size } = useSWRInfinite<InfinitePatientSearchResponse, Error>(
     shouldFetch ? getUrl : null,
     openmrsFetch,
+    { keepPreviousData: true },
   );
 
   // Filter out null patients and patients with null person property to prevent errors

--- a/packages/esm-service-queues-app/src/patient-banner-extension/patient-banner-queue-entry-status.extension.tsx
+++ b/packages/esm-service-queues-app/src/patient-banner-extension/patient-banner-queue-entry-status.extension.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
 import { type ConfigObject, isDesktop, showModal, useConfig, useLayoutType } from '@openmrs/esm-framework';
@@ -12,40 +12,53 @@ interface PatientBannerQueueEntryStatusProps {
 }
 
 const PatientBannerQueueEntryStatus: React.FC<PatientBannerQueueEntryStatusProps> = ({ patientUuid, renderedFrom }) => {
-  const { t } = useTranslation();
-  const layout = useLayoutType();
-  const { queueEntries } = useQueueEntries({ patient: patientUuid, isEnded: false });
-
   const isPatientChart = renderedFrom === 'patient-chart';
 
-  const queueEntry = queueEntries?.[0];
-  const config = useConfig<ConfigObject>();
-
-  if (!isPatientChart || !queueEntry) {
+  if (!isPatientChart) {
     return null;
   }
 
-  return (
-    <div className={styles.queueEntryStatusContainer}>
-      <span>{queueEntry.queue.name}</span>
-      <QueuePriority
-        priority={queueEntry.priority}
-        priorityComment={queueEntry.priorityComment}
-        priorityConfigs={config?.priorityConfigs}
-      />
-      <Button
-        kind="ghost"
-        size={isDesktop(layout) ? 'sm' : 'lg'}
-        onClick={() => {
-          const dispose = showModal('move-queue-entry-modal', {
-            closeModal: () => dispose(),
-            queueEntry,
-          });
-        }}>
-        {t('move', 'Move')}
-      </Button>
-    </div>
-  );
+  return <PatientBannerQueueEntryStatusInner patientUuid={patientUuid} />;
 };
+
+const PatientBannerQueueEntryStatusInner: React.FC<Pick<PatientBannerQueueEntryStatusProps, 'patientUuid'>> =
+  React.memo(({ patientUuid }) => {
+    const { t } = useTranslation();
+    const layout = useLayoutType();
+    const { queueEntries } = useQueueEntries(
+      { patient: patientUuid, isEnded: false },
+      'custom:(uuid,display,priority,priorityComment,queue)',
+    );
+
+    const queueEntry = queueEntries?.[0];
+    const config = useConfig<ConfigObject>();
+
+    if (!queueEntry) {
+      return null;
+    }
+
+    return (
+      <div className={styles.queueEntryStatusContainer}>
+        <span>{queueEntry.queue.name}</span>
+        <QueuePriority
+          priority={queueEntry.priority}
+          priorityComment={queueEntry.priorityComment}
+          priorityConfigs={config?.priorityConfigs}
+        />
+        <Button
+          kind="ghost"
+          size={isDesktop(layout) ? 'sm' : 'lg'}
+          onClick={() => {
+            const dispose = showModal('move-queue-entry-modal', {
+              closeModal: () => dispose(),
+              queueEntry,
+            });
+          }}>
+          {t('move', 'Move')}
+        </Button>
+      </div>
+    );
+  });
+PatientBannerQueueEntryStatusInner.displayName = 'PatientBannerQueueEntryStatusInner';
 
 export default PatientBannerQueueEntryStatus;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,6 +2565,7 @@ __metadata:
   resolution: "@openmrs/esm-patient-search-app@workspace:packages/esm-patient-search-app"
   dependencies:
     "@carbon/react": "npm:^1.83.0"
+    "@tanstack/react-virtual": "npm:^3.13.6"
     classnames: "npm:^2.3.2"
     lodash-es: "npm:^4.17.15"
     openmrs: "npm:next"
@@ -4429,6 +4430,25 @@ __metadata:
   dependencies:
     "@swc/counter": "npm:^0.1.3"
   checksum: 10/f6741450224892d12df43e5ca7f3cc0287df644dcd672626eb0cc2a3a8e3e875f4b29eb11336f37c7240cf6e010ba59eb3a79f4fb8bee5cbd168dfc1326ff369
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-virtual@npm:^3.13.6":
+  version: 3.13.26
+  resolution: "@tanstack/react-virtual@npm:3.13.26"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.16.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/76373506b3ab0a7870299099f994398ab7ec06b889e27f056e6bcaf26984cbedb7b763f9d3965249f3699780c43c21fd245048a320e06fe1cdae48859a9c5f2f
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.16.0":
+  version: 3.16.0
+  resolution: "@tanstack/virtual-core@npm:3.16.0"
+  checksum: 10/e55c70b5d3f68894804f645fe67738bbcca5d5ced333f96c2bda0d4c6f3198e5f97a3a18021b1491e850a2b4a64bdaafab250a6ee8bb1f312e6d5179656c35d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Several notable fixes for the compact-patient-search component:

* Previously, each call to `useSWRInfinite()` was, in essence, returning new copies of existing data, which lead to unnecessary re-renders. This has been fixed by setting `keepPreviousData` to `true`
* Previously, when `useSWRInfinite()` set `isLoading` to `true`, all results were replaced with placeholder. Since this gets set to `true` even when, e.g., loading a second page of results, this resulted in unnecessary unmounts and recreations, which was both a memory leak and lead to a stampede of requests.
* All search results were previously rendered and retained. This leads to stampedes of secondary queries (e.g., for patient photos, queue status, visit status, etc.). Instead, this PR moves us to using list virtualization so that roughly 10-18 items are retained in a React query. Large scrolls backwards or forwards have some slight glitches as components are re-rendered, but the easiest way to fix this is in the components rendering the secondary queries themselves.
* Recent patients, however, are not virtualized at all, as we rely on this being a limited list that is safe to load.
* A mistake in the call to `useArrowNavigation()` resulted in the arrow keys only being usable for up to the number of `recentPatients`
* This PR adds additional component-level memoization where it makes sense to speed up rendering. In addition, in the context of search results, we re-tune SWR to more aggressively cache so that there's less need to re-try, e.g., patient photo queries
* Additionally, this PR makes two fixes the service queues banner tag. First, if it is rendered outside the patient chart, a wrapper component is used so no query needs to be issued. Second, the query that was used overfetched data, especially as the queue details in the modal are basically reloaded, so the representation has been updated to minimize the data requested. This is one of the biggest contributing components.

## Screenshots
<!-- Required if you are making UI changes. -->

<img width="743" height="436" alt="Patient Search Screenshot" src="https://github.com/user-attachments/assets/fae9b3ab-e713-499d-b5d3-b0a027cb476a" />

This illustrates the trade-off here. Note the white patches while rows are reloading:

<img width="1409" height="898" alt="patient-search" src="https://github.com/user-attachments/assets/b9277acf-ac3a-4a3a-976a-b10b211da1cf" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-5714

## Other
<!-- Anything not covered above -->

Follow-ups: 

* ~~New billing PAID bill needs same wrapper treatment as queues app~~ [PR 749](https://github.com/openmrs/openmrs-esm-billing-app/pull/749)
* Active Visit tag needs SWR tweak
* Might do small rework on central components in styleguide
