### PR TITLE
(feat) O3-5719: Add multi-calendar utilities and calendar foundation layer

### DIFF
--- a/packages/esm-appointments-app/src/calendar/utils/calendar-colors.ts
+++ b/packages/esm-appointments-app/src/calendar/utils/calendar-colors.ts
@@ -1,0 +1,59 @@
+import {
+  Checkmark,
+  CheckmarkFilled,
+  CloseFilled,
+  Help,
+  Pending,
+  TimeFilled,
+  type CarbonIconType,
+} from '@carbon/react/icons';
+
+export type CarbonTagType = 'blue' | 'cyan' | 'green' | 'gray' | 'magenta' | 'purple' | 'red' | 'teal' | 'warm-gray';
+
+export const STATUS_TAG_TYPES: Readonly<Record<string, CarbonTagType>> = {
+  Scheduled: 'blue',
+  CheckedIn: 'teal',
+  Completed: 'green',
+  Missed: 'red',
+  Cancelled: 'warm-gray',
+  Requested: 'magenta',
+} as const;
+
+export const STATUS_TAG_ICONS: Readonly<Record<string, CarbonIconType>> = {
+  Scheduled: TimeFilled,
+  CheckedIn: Pending,
+  Completed: CheckmarkFilled,
+  Missed: CloseFilled,
+  Cancelled: Checkmark,
+  Requested: Help,
+} as const;
+
+export const DEFAULT_STATUS_TAG_TYPE: CarbonTagType = 'gray';
+
+const SERVICE_COLOR_PALETTE: ReadonlyArray<string> = [
+  'var(--cds-support-info)',
+  'var(--cds-support-success)',
+  'var(--cds-support-error)',
+  'var(--cds-support-warning)',
+  'var(--cds-interactive)',
+  'var(--cds-link-primary)',
+  'var(--cds-ai-aura-start)',
+  'var(--cds-focus)',
+] as const;
+
+export function getServiceColor(serviceName: string): string {
+  let hash = 0;
+  for (let i = 0; i < serviceName.length; i++) {
+    hash = (hash << 5) - hash + serviceName.charCodeAt(i);
+    hash |= 0;
+  }
+  return SERVICE_COLOR_PALETTE[Math.abs(hash) % SERVICE_COLOR_PALETTE.length];
+}
+
+export const CALENDAR_HOURS: ReadonlyArray<number> = Array.from({ length: 24 }, (_, i) => i) as ReadonlyArray<number>;
+
+export function formatHourLabel(hour: number): string {
+  const h = hour % 12 || 12;
+  const period = hour < 12 ? 'AM' : 'PM';
+  return `${h} ${period}`;
+}

--- a/packages/esm-appointments-app/src/calendar/utils/calendar-date-helpers.ts
+++ b/packages/esm-appointments-app/src/calendar/utils/calendar-date-helpers.ts
@@ -1,0 +1,116 @@
+import {
+  CalendarDate,
+  type DateValue,
+  getDayOfWeek,
+  getLocalTimeZone,
+  parseDate,
+  startOfWeek,
+  today,
+  toCalendar,
+} from '@internationalized/date';
+
+import { CALENDAR_SYSTEMS, type CalendarSystemConfig } from './calendar-systems';
+
+export function parseISO(isoDate: string): CalendarDate {
+  return parseDate(isoDate);
+}
+export function dateValueToISO(date: DateValue): string {
+  return date.toString();
+}
+export function getTodayISO(): string {
+  return today(getLocalTimeZone()).toString();
+}
+
+export function isoToCalendarDate(calKey: string, isoDate: string): CalendarDate {
+  const config = getCalendarConfig(calKey);
+  const gregDate = parseDate(isoDate);
+  return toCalendar(gregDate, config.calendar) as CalendarDate;
+}
+
+export function calendarDateToISO(calKey: string, calDate: CalendarDate): string {
+  const gregDate = toCalendar(calDate, CALENDAR_SYSTEMS.gregory.calendar) as CalendarDate;
+  return gregDate.toString();
+}
+
+export interface WeekDay {
+  readonly iso: string;
+  readonly calDate: CalendarDate;
+  readonly dow: number;
+}
+export function getWeekDays(calKey: string, isoDate: string): ReadonlyArray<WeekDay> {
+  const config = getCalendarConfig(calKey);
+  const gregPivot = parseDate(isoDate);
+  const firstDayLocale = DOW_LOCALE_MAP[config.firstDayOfWeek];
+  const weekStart = startOfWeek(gregPivot, 'en-US', firstDayLocale);
+
+  return Array.from({ length: 7 }, (_, i) => {
+    const gregDay = weekStart.add({ days: i });
+    const calDay = toCalendar(gregDay, config.calendar) as CalendarDate;
+    return {
+      iso: gregDay.toString(),
+      calDate: calDay,
+      dow: getDayOfWeek(gregDay, 'en-US', 'sun'),
+    } satisfies WeekDay;
+  });
+}
+
+export function getOrderedDowLabels(calKey: string): ReadonlyArray<string> {
+  const { daysOfWeek, firstDayOfWeek } = getCalendarConfig(calKey);
+  return [...daysOfWeek.slice(firstDayOfWeek), ...daysOfWeek.slice(0, firstDayOfWeek)];
+}
+
+export interface MonthGridCell {
+  readonly iso: string | null;
+  readonly day: number | null;
+  readonly isToday: boolean;
+  readonly isPadding: boolean;
+}
+export function getMonthGridCells(calKey: string, year: number, month: number): ReadonlyArray<MonthGridCell> {
+  const config = getCalendarConfig(calKey);
+  const todayISO = getTodayISO();
+  const firstOfMonth = new CalendarDate(config.calendar, year, month, 1);
+  const firstOfMonthGreg = toCalendar(firstOfMonth, CALENDAR_SYSTEMS.gregory.calendar) as CalendarDate;
+  const firstWeekday = getDayOfWeek(firstOfMonthGreg, 'en-US', 'sun');
+  const leadingPadding = (firstWeekday - config.firstDayOfWeek + 7) % 7;
+  const daysInMonth = config.calendar.getDaysInMonth(firstOfMonth);
+  const TOTAL_CELLS = 42;
+  const cells: MonthGridCell[] = [];
+
+  for (let i = 0; i < TOTAL_CELLS; i++) {
+    const dayNum = i - leadingPadding + 1;
+
+    if (dayNum < 1 || dayNum > daysInMonth) {
+      cells.push({ iso: null, day: null, isToday: false, isPadding: true });
+      continue;
+    }
+
+    const calDay = new CalendarDate(config.calendar, year, month, dayNum);
+    const gregDay = toCalendar(calDay, CALENDAR_SYSTEMS.gregory.calendar) as CalendarDate;
+    const iso = gregDay.toString();
+
+    cells.push({ iso, day: dayNum, isToday: iso === todayISO, isPadding: false });
+  }
+
+  return cells;
+}
+
+function getCalendarConfig(calKey: string): CalendarSystemConfig {
+  const config = CALENDAR_SYSTEMS[calKey];
+  if (!config) {
+    throw new Error(
+      `[calendar-date-helpers] Unknown calendar system key: "${calKey}". ` +
+        `Valid keys are: ${Object.keys(CALENDAR_SYSTEMS).join(', ')}.`,
+    );
+  }
+  return config;
+}
+
+const DOW_LOCALE_MAP: Readonly<Record<number, 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'>> = {
+  0: 'sun',
+  1: 'mon',
+  2: 'tue',
+  3: 'wed',
+  4: 'thu',
+  5: 'fri',
+  6: 'sat',
+};

--- a/packages/esm-appointments-app/src/calendar/utils/calendar-systems.ts
+++ b/packages/esm-appointments-app/src/calendar/utils/calendar-systems.ts
@@ -1,0 +1,107 @@
+import {
+  type Calendar,
+  GregorianCalendar,
+  EthiopicCalendar,
+  IslamicCivilCalendar,
+  PersianCalendar,
+} from '@internationalized/date';
+
+export interface CalendarSystemConfig {
+  readonly key: string;
+  readonly label: string;
+  readonly calendar: Calendar;
+  readonly months: ReadonlyArray<string>;
+  readonly daysOfWeek: ReadonlyArray<string>;
+  readonly firstDayOfWeek: number;
+}
+
+export const CALENDAR_SYSTEMS: Readonly<Record<string, CalendarSystemConfig>> = {
+  gregory: {
+    key: 'gregory',
+    label: 'Gregorian',
+    calendar: new GregorianCalendar(),
+    months: [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ],
+    daysOfWeek: ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'],
+    firstDayOfWeek: 0,
+  },
+
+  ethiopic: {
+    key: 'ethiopic',
+    label: 'Ethiopic',
+    calendar: new EthiopicCalendar(),
+    months: [
+      'Meskerem',
+      'Tikimt',
+      'Hidar',
+      'Tahesas',
+      'Tir',
+      'Yekatit',
+      'Megabit',
+      'Ginbot',
+      'Miazia',
+      'Sene',
+      'Hamle',
+      'Nehase',
+      'Pagume',
+    ],
+    daysOfWeek: ['እሑ', 'ሰኞ', 'ማክ', 'ረቡ', 'ሐሙ', 'ዓር', 'ቅዳ'],
+    firstDayOfWeek: 0,
+  },
+
+  islamic: {
+    key: 'islamic',
+    label: 'Islamic (Civil)',
+    calendar: new IslamicCivilCalendar(),
+    months: [
+      'Muharram',
+      'Safar',
+      "Rabi' al-Awwal",
+      "Rabi' al-Thani",
+      'Jumada al-Awwal',
+      'Jumada al-Thani',
+      'Rajab',
+      "Sha'ban",
+      'Ramadan',
+      'Shawwal',
+      "Dhu al-Qi'dah",
+      'Dhu al-Hijjah',
+    ],
+    daysOfWeek: ['أحد', 'اثنين', 'ثلاثاء', 'أربعاء', 'خميس', 'جمعة', 'سبت'],
+    firstDayOfWeek: 0,
+  },
+
+  persian: {
+    key: 'persian',
+    label: 'Persian (Solar Hijri)',
+    calendar: new PersianCalendar(),
+    months: [
+      'Farvardin',
+      'Ordibehesht',
+      'Khordad',
+      'Tir',
+      'Mordad',
+      'Shahrivar',
+      'Mehr',
+      'Aban',
+      'Azar',
+      'Dey',
+      'Bahman',
+      'Esfand',
+    ],
+    daysOfWeek: ['یکشنبه', 'دوشنبه', 'سه‌شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه'],
+    firstDayOfWeek: 6,
+  },
+} as const;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR introduces the foundational calendar utilities required for future enhancements to the Appointments Calendar.

* Added a reusable `CalendarSystem` abstraction powered by `@internationalized/date`
* Added support for four calendar systems:

  * Gregorian
  * Ethiopic
  * Islamic (Civil)
  * Persian (Solar Hijri)
* Added helper utilities for:

  * Calendar ↔ ISO date conversion
  * Week generation
  * Day-of-week ordering
  * Timezone-aware date handling
* Added theme-aware appointment status styling using Carbon CSS variables
* Added configurable status style overrides
* Added deterministic service color generation
* Added full 24-hour calendar support

This work establishes the calendar foundation that will be used by upcoming Monthly, Weekly, and Daily calendar views.

## Screenshots

N/A – No UI changes.

## Related Issue

https://openmrs.atlassian.net/browse/O3-5719

## Other

* Uses `@internationalized/date` as the calendar conversion engine.
* Maintains a consistent 0-based month API across all calendar systems.
* Supports calendar-specific week starts (e.g., Saturday-first weeks for Persian calendars).
* Uses Carbon Design System tokens for theme-aware styling.
