### PR TITLE
(fix) Support recording allergies from the ward order basket

### DIFF
--- a/packages/esm-ward-app/src/action-menu-buttons/order-basket-action-button.component.tsx
+++ b/packages/esm-ward-app/src/action-menu-buttons/order-basket-action-button.component.tsx
@@ -23,6 +23,7 @@ function WardPatientOrderBasketActionButton({ groupProps: { wardPatient } }: War
           drugOrderWorkspaceName: 'ward-patient-order-basket-add-drug-order-workspace',
           labOrderWorkspaceName: 'ward-patient-order-basket-add-lab-order-workspace',
           generalOrderWorkspaceName: 'ward-patient-order-basket-add-general-order-workspace',
+          allergyFormWorkspaceName: 'ward-patient-order-basket-add-allergy-workspace',
         },
       }}
     />

--- a/packages/esm-ward-app/src/routes.json
+++ b/packages/esm-ward-app/src/routes.json
@@ -166,6 +166,11 @@
       "name": "ward-patient-order-basket-add-general-order-workspace",
       "component": "@openmrs/esm-patient-orders-app#exportedOrderBasketWorkspace",
       "window": "ward-patient-order-basket"
+    },
+    {
+      "name": "ward-patient-order-basket-add-allergy-workspace",
+      "component": "@openmrs/esm-patient-allergies-app#exportedAllergyFormWorkspace",
+      "window": "ward-patient-order-basket"
     }
   ],
   "workspaceWindows2": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Clicking "Add allergy" in the ward order basket's drug search crashed with `Cannot read properties of null (reading 'patientUuid')`. The allergy form is a patient-chart workspace; launching it from the ward opened the `patient-chart` workspace group with no props, which crashed the action buttons registered to that group (orders, notes, forms, vitals).

This registers `exportedAllergyFormWorkspace` (from `@openmrs/esm-patient-allergies-app`) into the order basket window and passes its name via `allergyFormWorkspaceName`, so the order basket launches the allergy form as a child of the ward's own window rather than the chart's. This mirrors how the ward already hosts the order basket and its drug, lab, and general order workspaces.

## Screenshots

### Behavior (in the ward order basket, which renders the order basket outside the chart):

#### **Before:** clicking the allergy **+** raised a stack of `Cannot read properties of null (reading 'patientUuid')` errors and the form never opened.

https://github.com/user-attachments/assets/33e5371b-6b7e-431c-b65d-7d35a475d81e

#### **After:** the allergy form opens cleanly within the ward, with no console errors, and closing it returns to the order basket.

https://github.com/user-attachments/assets/a610dae8-ebdf-4592-9fd6-89a8d5967dc9

## Related Issue

Companion to openmrs/openmrs-esm-patient-chart#3353.

## Other

Depends on openmrs/openmrs-esm-patient-chart#3353 