### PR TITLE
(fix) O3-5736: Aligned clear queue entries button and filter status dropdown

### DIFF
--- a/packages/esm-service-queues-app/src/queue-table/queue-table.scss
+++ b/packages/esm-service-queues-app/src/queue-table/queue-table.scss
@@ -57,6 +57,7 @@
 .search {
   max-width: 16rem;
   display: inline;
+
   input {
     background-color: $ui-02 !important;
   }
@@ -99,6 +100,7 @@
 
   .toolbarContent {
     display: flex;
+    align-items: center;
     z-index: 1; // prevent dropdown from getting covered by table elements
     column-gap: layout.$spacing-03;
   }
@@ -161,20 +163,25 @@ html[dir='rtl'] {
       margin-left: 0;
       margin-right: layout.$spacing-03;
     }
+
     h2 {
       text-align: right;
     }
   }
+
   .tableContainer {
     th > div {
       text-align: right;
     }
+
     td {
       text-align: right;
+
       .serviceColor {
         margin-right: 0;
         margin-left: layout.$spacing-03;
       }
+
       button {
         padding: layout.$spacing-03 0 layout.$spacing-03 layout.$spacing-05;
         text-align: right;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
In dev3 Clear queue entries button and filter dropdown is misaligned (screenshot attached)

i pulled the latest chnages but couldn’t reproduce the issue locally , in queue-table.scss
eventhough i noticed
.toolbarContent was declared flex but didn’t had align-items: center , so i added it and raised a pr hope that it fixes the issue

## Screenshots
<img width="1619" height="207" alt="image" src="https://github.com/user-attachments/assets/f9c0e6d4-ba9a-4996-9281-320b827a708a" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-5736

## Other
n/a
