### PR TITLE
(fix) O3-5737: Center align download button in the appointments table toolbar

### DIFF
--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.component.tsx
@@ -199,7 +199,7 @@ const AppointmentsTable: React.FC<AppointmentsTableProps> = ({ appointments, isL
                     {t('changeStatus', 'Change status')}
                   </TableBatchAction>
                 </TableBatchActions>
-                <TableToolbarContent>
+                <TableToolbarContent className={styles.toolbarContent}>
                   <TableToolbarSearch
                     className={styles.searchbar}
                     labelText={t('filterAppointments', 'Filter appointments')}

--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.scss
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.scss
@@ -27,6 +27,15 @@
     position: relative;
     overflow: visible;
   }
+
+  :global(.cds--toolbar-content) {
+    align-items: center;
+
+    :global(.cds--btn) {
+      max-height: 2rem;
+      align-self: center;
+    }
+  }
 }
 
 .headerContainer {
@@ -135,6 +144,7 @@ html[dir='rtl'] {
       margin-left: 0;
       margin-right: layout.$spacing-03;
     }
+
     h2 {
       text-align: right;
     }

--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.scss
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.scss
@@ -27,15 +27,10 @@
     position: relative;
     overflow: visible;
   }
+}
 
-  :global(.cds--toolbar-content) {
-    align-items: center;
-
-    :global(.cds--btn) {
-      max-height: 2rem;
-      align-self: center;
-    }
-  }
+.toolbarContent {
+  align-items: center;
 }
 
 .headerContainer {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

The Download button button is oversized with more padding (screenshot attached) 

i couldn't reproduce the issue locally eventhough it appears in dev3 , so i pushed few hope that it fixes the issue
align-items: center — prevents the button from stretching to fill the toolbar
max-height: 2rem — caps the button at Carbon's sm height (32px), so even if extra padding is being injected by another CSS rule in production, it can't grow beyond spec
align-self: center — belt-and-suspenders: ensures the button specifically stays centered even if something else overrides the container's align-items

## Screenshots
<img width="406" height="78" alt="image" src="https://github.com/user-attachments/assets/365f629f-799d-4435-b46c-02915933b351" />

## Related Issue
https://issues.openmrs.org/browse/O3-5737

## Other
n/a
