### PR TITLE
(feat) O3-5742: Build DailyCalendarView with compact appointment card list

### DIFF
--- a/packages/esm-appointments-app/src/calendar/daily/daily-calendar-view.component.tsx
+++ b/packages/esm-appointments-app/src/calendar/daily/daily-calendar-view.component.tsx
@@ -1,0 +1,113 @@
+import React, { useMemo } from 'react';
+import { Tag, InlineLoading } from '@carbon/react';
+import { type Dayjs } from 'dayjs';
+import { useTranslation } from 'react-i18next';
+import { formatAMPM } from '../../helpers/functions';
+import { type Appointment } from '../../types';
+import { useAppointmentsByDate } from '../../hooks/useAppointmentsByDate';
+import {
+  getServiceColor,
+  STATUS_TAG_TYPES,
+  DEFAULT_STATUS_TAG_TYPE,
+  CALENDAR_HOURS,
+  formatHourLabel,
+} from '../utils/calendar-colors';
+import styles from './daily-calendar-view.scss';
+
+const LOCALE_MAP: Record<string, string> = {
+  gregory: 'en-US',
+  ethiopic: 'am-ET',
+  islamic: 'ar-SA',
+  persian: 'fa-IR',
+};
+
+interface DailyCalendarViewProps {
+  calKey: string;
+  calendarSelectedDate: Dayjs;
+}
+
+const DailyCalendarView: React.FC<DailyCalendarViewProps> = ({ calKey, calendarSelectedDate }) => {
+  const { t } = useTranslation();
+  const isoDate = calendarSelectedDate.format('YYYY-MM-DD');
+  const locale = LOCALE_MAP[calKey] ?? 'en-US';
+  const { appointments, isLoading } = useAppointmentsByDate(isoDate);
+
+  const displayDate = useMemo(() => {
+    const d = calendarSelectedDate.toDate();
+    return new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      calendar: calKey,
+    }).format(d);
+  }, [calendarSelectedDate, locale, calKey]);
+
+  const hourSlots = useMemo(
+    () =>
+      CALENDAR_HOURS.map((hr) => ({
+        hr,
+        appts: appointments.filter((a) => {
+          if (a.startDateTime == null) return false;
+          return new Date(a.startDateTime).getHours() === hr;
+        }),
+      })).filter((s) => s.appts.length > 0),
+    [appointments],
+  );
+
+  if (isLoading) {
+    return (
+      <div className={styles.container}>
+        <InlineLoading description={t('loadingAppointments', 'Loading appointments…')} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.heading}>
+        <h2 className={styles.title}>{displayDate}</h2>
+        <p className={styles.subtitle}>
+          {appointments.length === 0
+            ? t('noAppointments', 'No appointments scheduled')
+            : t('appointmentCount', '{{count}} appointment(s)', { count: appointments.length })}
+        </p>
+      </div>
+      {hourSlots.map(({ hr, appts }) => (
+        <div key={hr} className={styles.hourRow}>
+          <div className={styles.hourLabel}>{formatHourLabel(hr)}</div>
+          <div className={styles.hourSlot}>
+            {appts.map((a) => (
+              <DailyCard key={a.uuid} appointment={a} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const DailyCard: React.FC<{ appointment: Appointment }> = ({ appointment }) => {
+  const color = getServiceColor(appointment.service?.name ?? '');
+  const tagType = STATUS_TAG_TYPES[appointment.status] ?? DEFAULT_STATUS_TAG_TYPE;
+  const time = useMemo(() => {
+    if (appointment.startDateTime == null) return '—';
+    return formatAMPM(new Date(appointment.startDateTime));
+  }, [appointment.startDateTime]);
+
+  return (
+    <div className={styles.card} style={{ borderLeftColor: color }}>
+      <span className={styles.cardTime}>{time}</span>
+      <div className={styles.cardDetails}>
+        <div className={styles.cardName}>{appointment.patient?.name ?? '—'}</div>
+        <div className={styles.cardService} style={{ color }}>
+          {appointment.service?.name ?? '—'}
+        </div>
+      </div>
+      <Tag type={tagType} size="sm">
+        {appointment.status}
+      </Tag>
+    </div>
+  );
+};
+
+export default DailyCalendarView;

--- a/packages/esm-appointments-app/src/calendar/daily/daily-calendar-view.scss
+++ b/packages/esm-appointments-app/src/calendar/daily/daily-calendar-view.scss
@@ -1,0 +1,74 @@
+@use '@carbon/colors';
+@use '@carbon/layout';
+@use '@carbon/type';
+
+.container {
+  padding: layout.$spacing-05;
+}
+
+.heading {
+  margin-bottom: layout.$spacing-06;
+}
+
+.title {
+  @include type.type-style('heading-04');
+  color: colors.$gray-100;
+  margin: 0 0 layout.$spacing-02;
+}
+
+.subtitle {
+  @include type.type-style('body-compact-01');
+  color: colors.$gray-60;
+  margin: 0;
+}
+
+.hourRow {
+  display: flex;
+  gap: layout.$spacing-04;
+  margin-bottom: layout.$spacing-02;
+}
+
+.hourLabel {
+  @include type.type-style('heading-compact-01');
+  color: colors.$gray-50;
+  min-width: 3.5rem;
+  padding-top: layout.$spacing-03;
+  text-align: right;
+}
+
+.hourSlot {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: layout.$spacing-02;
+}
+
+.card {
+  display: flex;
+  align-items: center;
+  gap: layout.$spacing-04;
+  padding: layout.$spacing-03 layout.$spacing-04;
+  border-left: 3px solid;
+  border-radius: 0 4px 4px 0;
+  background: colors.$gray-10;
+}
+
+.cardTime {
+  @include type.type-style('heading-compact-01');
+  color: colors.$gray-70;
+  min-width: 3.5rem;
+}
+
+.cardDetails {
+  flex: 1;
+  min-width: 0;
+}
+
+.cardName {
+  @include type.type-style('body-compact-02');
+  color: colors.$gray-100;
+}
+
+.cardService {
+  @include type.type-style('label-01');
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

Creates `DailyCalendarView` — a compact daily schedule showing only non-empty hour slots with appointment cards. Unlike the weekly view's full 24-hour grid, this view optimizes for clinical workflows where most hours are empty.

## Screenshots
EXPECTED VIEW : 
<img width="806" height="280" alt="image" src="https://github.com/user-attachments/assets/13c9f363-44a3-49f6-b461-1126a48bc047" />

## Related Issue
https://openmrs.atlassian.net/browse/O3-5742
## Other

Depends on [PR](https://github.com/openmrs/openmrs-esm-patient-management/pull/2571)