### PR TITLE
(fix) Resolve TypeError crash in getWardMetrics when spreading undefined patient arrays

### DIFF
--- a/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
+++ b/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
@@ -50,9 +50,9 @@ export function filterBeds(admissionLocation: AdmissionLocationFetchResponse): B
 export function getWardMetrics(wardPatientGroup: WardPatientGroupDetails): WardMetrics {
   // pull all the patients out of the three constructs they are stored in: unadmitted but in a bed, admitted and in a bed, and admitted but not in a bed
   const allPatients = [
-    ...wardPatientGroup.wardUnadmittedPatientsWithBed?.values(),
-    ...[...wardPatientGroup.wardAdmittedPatientsWithBed?.values()].map((admission) => admission.patient),
-    ...wardPatientGroup.wardUnassignedPatientsList?.map((admission) => admission.patient),
+    ...(wardPatientGroup.wardUnadmittedPatientsWithBed?.values() ?? []),
+    ...[...(wardPatientGroup.wardAdmittedPatientsWithBed?.values() ?? [])].map((admission) => admission.patient),
+    ...(wardPatientGroup.wardUnassignedPatientsList?.map((admission) => admission.patient) ?? []),
   ];
 
   const patientCount = allPatients?.length ?? 0;

--- a/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
+++ b/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
@@ -49,17 +49,26 @@ export function filterBeds(admissionLocation: AdmissionLocationFetchResponse): B
 
 export function getWardMetrics(wardPatientGroup: WardPatientGroupDetails): WardMetrics {
   // pull all the patients out of the three constructs they are stored in: unadmitted but in a bed, admitted and in a bed, and admitted but not in a bed
-  const allPatients = [
-    ...(wardPatientGroup.wardUnadmittedPatientsWithBed?.values() ?? []),
-    ...[...(wardPatientGroup.wardAdmittedPatientsWithBed?.values() ?? [])].map((admission) => admission.patient),
-    ...(wardPatientGroup.wardUnassignedPatientsList?.map((admission) => admission.patient) ?? []),
-  ];
+  const unadmittedPatients = wardPatientGroup?.wardUnadmittedPatientsWithBed
+    ? Array.from(wardPatientGroup.wardUnadmittedPatientsWithBed.values())
+    : [];
 
-  const patientCount = allPatients?.length ?? 0;
+  const admittedPatients = wardPatientGroup?.wardAdmittedPatientsWithBed
+    ? Array.from(wardPatientGroup.wardAdmittedPatientsWithBed.values()).map((admission) => admission.patient)
+    : [];
+
+  const unassignedPatients = wardPatientGroup?.wardUnassignedPatientsList
+    ? wardPatientGroup.wardUnassignedPatientsList.map((admission) => admission.patient)
+    : [];
+
+  const allPatients = [...unadmittedPatients, ...admittedPatients, ...unassignedPatients].filter(Boolean);
+
+  const patientCount = allPatients.length;
   const newborns = filterNewborns(allPatients)?.length ?? 0;
   const femalesOfReproductiveAge = filterReproductiveAge(filterFemale(allPatients))?.length ?? 0;
-  const totalBeds = wardPatientGroup.bedLayouts?.length ?? 0;
-  const occupiedBeds = wardPatientGroup.bedLayouts?.filter((bed) => bed.patients?.length > 0).length ?? 0;
+  const totalBeds = wardPatientGroup?.bedLayouts?.length ?? 0;
+  const occupiedBeds = wardPatientGroup?.bedLayouts?.filter((bed) => bed.patients?.length > 0).length ?? 0;
+
   return {
     patients: patientCount.toString(),
     freeBeds: (totalBeds - occupiedBeds).toString(),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR resolves a `TypeError` crash that occurs in `getWardMetrics` when attempting to spread iterables (like `wardUnadmittedPatientsWithBed.values()`) or mapped patient arrays that may evaluate to `undefined`. 

The function was refactored to extract iterables safely using `Array.from()` with proper optional chaining to prevent undefined property access. Additionally, falsy/undefined values are explicitly filtered out using `.filter(Boolean)` when constructing the `allPatients` array, ensuring that downstream demographic metrics do not crash by accessing `.person` on `undefined` patient records.

## Screenshots

N/A

## Related Issue

N/A

## Other

N/A
