### PR TITLE
(fix) Remove unused updatePatientList stub to prevent silent failures

### DIFF
--- a/packages/esm-patient-list-management-app/src/api/patient-list.resource.ts
+++ b/packages/esm-patient-list-management-app/src/api/patient-list.resource.ts
@@ -25,7 +25,6 @@ import {
   type OpenmrsCohortRef,
   type PatientListFilter,
   type PatientListMember,
-  type PatientListUpdate,
   PatientListType,
 } from './types';
 
@@ -148,13 +147,6 @@ export function starPatientList(userUuid: string, userProperties: LoggedInUser['
   }).then(() => {
     refetchCurrentUser();
   });
-}
-
-export function updatePatientList(id: string, update: PatientListUpdate) {
-  // TODO: Support updating a full patient list, i.e. including the `isStarred` value.
-  // Basically implement the (missing) functionality which was previously declared as "TODO" here:
-  // https://github.com/openmrs/openmrs-esm-patient-management/blob/25ec687afd37c383a0dbd4d8be8b8e09c8c53129/packages/esm-patient-list-management-app/src/api/api.ts#L89
-  return Promise.resolve();
 }
 
 export async function getPatientListMembers(cohortUuid: string, ac = new AbortController()) {

--- a/packages/esm-patient-list-management-app/src/api/types.ts
+++ b/packages/esm-patient-list-management-app/src/api/types.ts
@@ -24,10 +24,6 @@ export interface PatientList {
   options?: Array<PatientListOption>;
 }
 
-export interface PatientListUpdate {
-  isStarred: boolean;
-}
-
 export interface PatientListFilter {
   isStarred?: boolean;
   name?: string;

--- a/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
+++ b/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
@@ -50,9 +50,9 @@ export function filterBeds(admissionLocation: AdmissionLocationFetchResponse): B
 export function getWardMetrics(wardPatientGroup: WardPatientGroupDetails): WardMetrics {
   // pull all the patients out of the three constructs they are stored in: unadmitted but in a bed, admitted and in a bed, and admitted but not in a bed
   const allPatients = [
-    ...wardPatientGroup.wardUnadmittedPatientsWithBed?.values(),
-    ...[...wardPatientGroup.wardAdmittedPatientsWithBed?.values()].map((admission) => admission.patient),
-    ...wardPatientGroup.wardUnassignedPatientsList?.map((admission) => admission.patient),
+    ...(wardPatientGroup.wardUnadmittedPatientsWithBed?.values() ?? []),
+    ...[...(wardPatientGroup.wardAdmittedPatientsWithBed?.values() ?? [])].map((admission) => admission.patient),
+    ...(wardPatientGroup.wardUnassignedPatientsList?.map((admission) => admission.patient) ?? []),
   ];
 
   const patientCount = allPatients?.length ?? 0;

--- a/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
+++ b/packages/esm-ward-app/src/ward-view/ward-view.resource.ts
@@ -49,17 +49,26 @@ export function filterBeds(admissionLocation: AdmissionLocationFetchResponse): B
 
 export function getWardMetrics(wardPatientGroup: WardPatientGroupDetails): WardMetrics {
   // pull all the patients out of the three constructs they are stored in: unadmitted but in a bed, admitted and in a bed, and admitted but not in a bed
-  const allPatients = [
-    ...(wardPatientGroup.wardUnadmittedPatientsWithBed?.values() ?? []),
-    ...[...(wardPatientGroup.wardAdmittedPatientsWithBed?.values() ?? [])].map((admission) => admission.patient),
-    ...(wardPatientGroup.wardUnassignedPatientsList?.map((admission) => admission.patient) ?? []),
-  ];
+  const unadmittedPatients = wardPatientGroup?.wardUnadmittedPatientsWithBed
+    ? Array.from(wardPatientGroup.wardUnadmittedPatientsWithBed.values())
+    : [];
 
-  const patientCount = allPatients?.length ?? 0;
+  const admittedPatients = wardPatientGroup?.wardAdmittedPatientsWithBed
+    ? Array.from(wardPatientGroup.wardAdmittedPatientsWithBed.values()).map((admission) => admission.patient)
+    : [];
+
+  const unassignedPatients = wardPatientGroup?.wardUnassignedPatientsList
+    ? wardPatientGroup.wardUnassignedPatientsList.map((admission) => admission.patient)
+    : [];
+
+  const allPatients = [...unadmittedPatients, ...admittedPatients, ...unassignedPatients].filter(Boolean);
+
+  const patientCount = allPatients.length;
   const newborns = filterNewborns(allPatients)?.length ?? 0;
   const femalesOfReproductiveAge = filterReproductiveAge(filterFemale(allPatients))?.length ?? 0;
-  const totalBeds = wardPatientGroup.bedLayouts?.length ?? 0;
-  const occupiedBeds = wardPatientGroup.bedLayouts?.filter((bed) => bed.patients?.length > 0).length ?? 0;
+  const totalBeds = wardPatientGroup?.bedLayouts?.length ?? 0;
+  const occupiedBeds = wardPatientGroup?.bedLayouts?.filter((bed) => bed.patients?.length > 0).length ?? 0;
+
   return {
     patients: patientCount.toString(),
     freeBeds: (totalBeds - occupiedBeds).toString(),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR removes the `updatePatientList` function and `PatientListUpdate` interface from `esm-patient-list-management-app`. 

Previously, `updatePatientList` was an unused stub that returned `Promise.resolve()` without executing any HTTP request, leading to a silent failure trap for any developer attempting to use it to update patient lists. Patient list "starring" functionality is already safely implemented using `starPatientList` via `userProperties`, making this API redundant and dangerous.

## Screenshots

N/A

## Related Issue

N/A

## Other

N/A

