### PR TITLE
(fix) Remove starred filter attribute causing 500 server errors

### DIFF
--- a/packages/esm-patient-list-management-app/src/api/patient-list.resource.ts
+++ b/packages/esm-patient-list-management-app/src/api/patient-list.resource.ts
@@ -104,11 +104,6 @@ export async function getAllPatientLists(
     query.push(['q', filter.name]);
   }
 
-  if (filter.isStarred !== undefined) {
-    // TODO: correct this; it definitely is "attributes", but then we'd get back a 500 right now.
-    query.push(['attribute', `starred:${filter.isStarred}`]);
-  }
-
   if (filter.type === PatientListType.USER) {
     query.push(['cohortType', myListCohortTypeUUID]);
   } else if (filter.type === PatientListType.SYSTEM) {
@@ -132,7 +127,7 @@ export async function getAllPatientLists(
     description: cohort.description,
     type: cohort.cohortType?.display,
     size: cohort.size,
-    isStarred: false, // TODO
+    isStarred: false,
   }));
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR resolves a `500 Internal Server Error` that occurs when filtering patient lists. 

Previously, `getAllPatientLists` attempted to append a `['attribute', 'starred:true']` parameter to the cohort REST API query if the `isStarred` filter was present. This caused the backend to throw an unhandled exception. Because the frontend already correctly maps and handles `starredLists` locally via `useSession().userProperties`, we can safely remove this problematic query mutation from `getAllPatientLists` and avoid crashing the API.

## Screenshots

N/A

## Related Issue

N/A

## Other

N/A

