### PR TITLE
(fix) Remove nonexistent over-fetched properties from Appointment interface

### DIFF
--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-actions.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-actions.test.tsx
@@ -48,9 +48,7 @@ const appointment: Appointment = {
   additionalInfo: null,
   providers: [{ uuid: '24252571-dd5a-11e6-9d9c-0242ac150002', display: 'Dr James Cook' }],
   recurring: false,
-  voided: false,
-  teleconsultationLink: null,
-  extensions: [],
+
   endDateTime: null,
   dateAppointmentScheduled: null,
 };

--- a/packages/esm-appointments-app/src/appointments/common-components/appointments-table.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/appointments-table.test.tsx
@@ -56,9 +56,6 @@ const mockAppointments = [
     additionalInfo: null,
     providers: [{ uuid: '24252571-dd5a-11e6-9d9c-0242ac150002', display: 'Dr James Cook' }],
     recurring: false,
-    voided: false,
-    teleconsultationLink: null,
-    extensions: [],
   },
 ] as unknown as Array<Appointment>;
 

--- a/packages/esm-appointments-app/src/appointments/common-components/batch-change-appointment-statuses.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/batch-change-appointment-statuses.test.tsx
@@ -65,9 +65,7 @@ const mockAppointment1: Appointment = {
   additionalInfo: null,
   providers: [{ uuid: 'person-1', display: 'Dr James Cook' }],
   recurring: false,
-  voided: false,
-  teleconsultationLink: null,
-  extensions: {},
+
   endDateTime: null,
   dateAppointmentScheduled: null,
 };

--- a/packages/esm-appointments-app/src/appointments/common-components/checkin-button.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/common-components/checkin-button.test.tsx
@@ -57,9 +57,7 @@ const appointment: Appointment = {
   additionalInfo: null,
   providers: [{ uuid: '24252571-dd5a-11e6-9d9c-0242ac150002', display: 'Dr James Cook' }],
   recurring: false,
-  voided: false,
-  teleconsultationLink: null,
-  extensions: [],
+
   endDateTime: null,
   dateAppointmentScheduled: null,
 };

--- a/packages/esm-appointments-app/src/appointments/details/appointment-details.test.tsx
+++ b/packages/esm-appointments-app/src/appointments/details/appointment-details.test.tsx
@@ -45,10 +45,7 @@ const appointment: Appointment = {
   additionalInfo: null,
   providers: [{ uuid: '24252571-dd5a-11e6-9d9c-0242ac150002', display: 'Dr James Cook' }],
   recurring: false,
-  voided: false,
   dateAppointmentScheduled: '',
-  teleconsultationLink: null,
-  extensions: [],
 };
 
 const mockUsePatient = vi.mocked(usePatient);

--- a/packages/esm-appointments-app/src/form/appointments-form.test.tsx
+++ b/packages/esm-appointments-app/src/form/appointments-form.test.tsx
@@ -49,9 +49,7 @@ const existingAppointment = {
   provider: { uuid: 'f9badd80-ab76-11e2-9e96-0800200c9a66', display: 'Dr. Cook' },
   providers: [{ uuid: 'f9badd80-ab76-11e2-9e96-0800200c9a66', response: 'ACCEPTED' }],
   recurring: false,
-  voided: false,
-  extensions: {},
-  teleconsultationLink: null,
+
   dateAppointmentScheduled: '2024-01-04T00:00:00.000Z',
 };
 

--- a/packages/esm-appointments-app/src/types/index.ts
+++ b/packages/esm-appointments-app/src/types/index.ts
@@ -53,9 +53,6 @@ export interface Appointment {
   uuid: string;
   additionalInfo?: string | null;
   serviceTypes?: Array<ServiceTypes> | null;
-  voided: boolean;
-  extensions: {};
-  teleconsultationLink: string | null;
 }
 
 export interface AppointmentsFetchResponse {


### PR DESCRIPTION
…erface

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR resolves a TypeScript over-fetching issue where the `Appointment` interface included `voided`, `extensions`, and `teleconsultationLink` properties. 

These fields are not actually returned by the Bahmni Appointments API runtime responses. Having them present in the definition created misleading assumptions for developers consuming this type. Along with deleting them from `packages/esm-appointments-app/src/types/index.ts`, I updated all associated unit test mocks (like `appointments-form.test.tsx` and `appointment-details.test.tsx`) to remove these properties and prevent TS compiler errors.

## Screenshots

N/A

## Related Issue

N/A

## Other

N/A
