### PR TITLE
(fix) Keep patient chart siderail visible when editing an appointment

### DIFF
--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-action-menu.component.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-action-menu.component.tsx
@@ -8,14 +8,29 @@ import styles from './patient-appointments-action-menu.scss';
 interface appointmentsActionMenuProps {
   appointment: Appointment;
   patientUuid: string;
+
+  /**
+   * Optional callback to launch the appropriate appointments form workspace, depending
+   * on which app is using this component. If not provided, defaults to launching the
+   * standalone appointments form workspace.
+   */
+  launchAppointmentForm?(patientUuid: string, appointment?: Appointment): void;
 }
 
-export const PatientAppointmentsActionMenu = ({ appointment, patientUuid }: appointmentsActionMenuProps) => {
+export const PatientAppointmentsActionMenu = ({
+  appointment,
+  patientUuid,
+  launchAppointmentForm,
+}: appointmentsActionMenuProps) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
 
   const handleLaunchEditAppointmentForm = () => {
-    launchWorkspace2('appointments-form-workspace', { appointment, patientUuid });
+    if (launchAppointmentForm) {
+      launchAppointmentForm(patientUuid, appointment);
+    } else {
+      launchWorkspace2('appointments-form-workspace', { appointment, patientUuid });
+    }
   };
 
   const handleLaunchCancelAppointmentModal = () => {

--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-action-menu.test.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-action-menu.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { type Mock, vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { launchWorkspace2 } from '@openmrs/esm-framework';
+import { type Appointment } from '../types';
+import { PatientAppointmentsActionMenu } from './patient-appointments-action-menu.component';
+
+const mockLaunchWorkspace2 = launchWorkspace2 as Mock;
+
+const appointment = { uuid: 'appointment-uuid' } as Appointment;
+const patientUuid = 'patient-uuid';
+
+describe('PatientAppointmentsActionMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the provided launchAppointmentForm callback when editing an appointment', async () => {
+    const user = userEvent.setup();
+    const launchAppointmentForm = vi.fn();
+
+    render(
+      <PatientAppointmentsActionMenu
+        appointment={appointment}
+        patientUuid={patientUuid}
+        launchAppointmentForm={launchAppointmentForm}
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByText(/edit/i));
+
+    expect(launchAppointmentForm).toHaveBeenCalledWith(patientUuid, appointment);
+    expect(mockLaunchWorkspace2).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the standalone appointments form workspace when no callback is provided', async () => {
+    const user = userEvent.setup();
+
+    render(<PatientAppointmentsActionMenu appointment={appointment} patientUuid={patientUuid} />);
+
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByText(/edit/i));
+
+    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('appointments-form-workspace', { appointment, patientUuid });
+  });
+});

--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-detailed-summary.extension.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-detailed-summary.extension.tsx
@@ -115,6 +115,7 @@ const PatientAppointmentsDetailedSummary: React.FC<PatientAppointmentsDetailProp
                   switchedView={switchedView}
                   setSwitchedView={setSwitchedView}
                   patientUuid={patientUuid}
+                  launchAppointmentForm={handleLaunchAppointmentForm}
                 />
               );
             }
@@ -141,6 +142,7 @@ const PatientAppointmentsDetailedSummary: React.FC<PatientAppointmentsDetailProp
                   switchedView={switchedView}
                   setSwitchedView={setSwitchedView}
                   patientUuid={patientUuid}
+                  launchAppointmentForm={handleLaunchAppointmentForm}
                 />
               );
             }
@@ -167,6 +169,7 @@ const PatientAppointmentsDetailedSummary: React.FC<PatientAppointmentsDetailProp
                   switchedView={switchedView}
                   setSwitchedView={setSwitchedView}
                   patientUuid={patientUuid}
+                  launchAppointmentForm={handleLaunchAppointmentForm}
                 />
               );
             }

--- a/packages/esm-appointments-app/src/patient-appointments/patient-appointments-table.component.tsx
+++ b/packages/esm-appointments-app/src/patient-appointments/patient-appointments-table.component.tsx
@@ -27,6 +27,7 @@ interface AppointmentTableProps {
   switchedView: boolean;
   setSwitchedView: (value: boolean) => void;
   patientUuid: string;
+  launchAppointmentForm?(patientUuid: string, appointment?: Appointment): void;
 }
 
 const PatientAppointmentsTable: React.FC<AppointmentTableProps> = ({
@@ -34,6 +35,7 @@ const PatientAppointmentsTable: React.FC<AppointmentTableProps> = ({
   patientUuid,
   switchedView,
   setSwitchedView,
+  launchAppointmentForm,
 }) => {
   const { t } = useTranslation();
   const { results: paginatedAppointments, currentPage, goTo } = usePagination(patientAppointments, pageSize);
@@ -102,7 +104,11 @@ const PatientAppointmentsTable: React.FC<AppointmentTableProps> = ({
                       <TableCell key={cell.id}>{cell.value?.content ?? cell.value}</TableCell>
                     ))}
                     <TableCell className="cds--table-column-menu">
-                      <PatientAppointmentsActionMenu appointment={paginatedAppointments[i]} patientUuid={patientUuid} />
+                      <PatientAppointmentsActionMenu
+                        appointment={paginatedAppointments[i]}
+                        patientUuid={patientUuid}
+                        launchAppointmentForm={launchAppointmentForm}
+                      />
                     </TableCell>
                   </TableRow>
                 ))}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Editing an appointment from the **Appointments** dashboard in the patient chart made the chart's right-hand siderail (Clinical forms, Orders, Notes, Tasks, Patient lists) disappear.

The row **Edit** action launched `appointments-form-workspace`, which belongs to `appointments-group` rather than the `patient-chart` group. The workspaces2 system renders only one group's action menu at a time, so this switched the active group away from `patient-chart` and dropped its siderail. Because `appointments-group` defines no window icons of its own, nothing rendered in its place.

`PatientAppointmentsDetailedSummary` already receives a `launchAppointmentForm` callback that the patient chart sets to launch the chart-scoped `patient-chart-appointments-form-workspace`, but it was only wired to the **Add** button. This threads the callback through `PatientAppointmentsTable` to `PatientAppointmentsActionMenu` so the **Edit** action uses it too. When no callback is provided (standalone appointments app), it falls back to the existing `appointments-form-workspace` behavior.

Same class of bug as openmrs/openmrs-esm-billing-app#779.

## Screenshots

### Before

https://github.com/user-attachments/assets/3eba60ba-16f5-4ee1-9f6b-836aae7127f8

### After

https://github.com/user-attachments/assets/6934d2e6-3dcf-4f74-8edc-c31523b873fd

## Related Issue

## Other
