### PR TITLE
(fix) Request a minimal custom representation in useConceptAnswers

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.resource.test.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.resource.test.ts
@@ -1,0 +1,34 @@
+import useSWRImmutable from 'swr/immutable';
+import { vi, describe, it, expect, type Mock } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { restBaseUrl } from '@openmrs/esm-framework';
+import { useConceptAnswers } from './field.resource';
+
+vi.mock('swr/immutable', () => ({
+  default: vi.fn().mockReturnValue({
+    data: undefined,
+    error: null,
+    isLoading: false,
+    isValidating: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+const useSWRImmutableMock = useSWRImmutable as Mock;
+
+describe('useConceptAnswers', () => {
+  it('requests a minimal custom representation instead of the default representation', () => {
+    renderHook(() => useConceptAnswers('concept-uuid'));
+
+    expect(useSWRImmutableMock).toHaveBeenCalledWith(
+      `${restBaseUrl}/concept/concept-uuid?v=custom:(uuid,display,answers:(uuid,display))`,
+      expect.any(Function),
+    );
+  });
+
+  it('does not fetch when conceptUuid is empty', () => {
+    renderHook(() => useConceptAnswers(''));
+
+    expect(useSWRImmutableMock).toHaveBeenCalledWith(null, expect.any(Function));
+  });
+});

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.resource.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.resource.ts
@@ -27,7 +27,7 @@ export function useConceptAnswers(conceptUuid: string): {
 } {
   const shouldFetch = typeof conceptUuid === 'string' && conceptUuid !== '';
   const { data, error, isLoading } = useSWRImmutable<FetchResponse<ConceptResponse>, Error>(
-    shouldFetch ? `${restBaseUrl}/concept/${conceptUuid}` : null,
+    shouldFetch ? `${restBaseUrl}/concept/${conceptUuid}?v=custom:(uuid,display,answers:(uuid,display))` : null,
     openmrsFetch,
   );
   if (error) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
`useConceptAnswers` (used by coded person-attribute fields, obs fields, and the cause-of-death field) fetched `/concept/{uuid}` with no `v=` representation, falling back to OpenMRS's default concept representation - names, descriptions, mappings, conceptClass, datatype, version, attributes, links, etc. Every consumer of this hook only reads `answer.uuid` and `answer.display` per answer to populate a dropdown.

This adds a minimal custom representation, `v=custom:(uuid,display,answers:(uuid,display))`, requesting only the fields actually used.

Measured against a live OpenMRS instance (a concept with 4 answers, 3 names each): default representation returned 3,396 bytes; the custom representation returns 493 bytes - an 85% payload reduction. 

## Screenshots
  N/A — no UI change. Dropdown behavior and rendered options are unchanged, only the wire payload shrinks.

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

Verified:
- `ConceptAnswers`/`ConceptResponse` types already only require `uuid`/`display` on each answer, so no type changes were needed.
- Checked all consumers of `useConceptAnswers` (`cause-of-death.component.tsx`, `obs-field.component.tsx`, `coded-person-attribute-field.component.tsx`) none rely on fields beyond `uuid`/`display`.
- Added `field.resource.test.ts` asserting the fetch key includes the `v=` param (didn't previously exist).
- Full `field/` test suite, `tsc --noEmit`, and `eslint` all pass clean.
