### PR TITLE
(feat) O3-5764: Gate service queues on privileges and add the queue-user default view

### DIFF
--- a/packages/esm-service-queues-app/src/constants.ts
+++ b/packages/esm-service-queues-app/src/constants.ts
@@ -16,3 +16,8 @@ export const queueEntryCustomRepresentation =
 // Error codes
 export const DUPLICATE_QUEUE_ENTRY_ERROR_CODE = '[queue.entry.duplicate.patient]';
 export const QUEUE_ENTRY_ALREADY_ENDED_ERROR = 'queue entry that has already ended';
+
+// Service queues app privileges
+export const CLINIC_ADMIN_PRIVILEGE = 'App: Service Queues Clinic Administrator';
+export const CLERK_PRIVILEGE = 'App: Service Queues Clerk';
+export const CLINICIAN_PRIVILEGE = 'App: Service Queues Clinician';

--- a/packages/esm-service-queues-app/src/home.component.tsx
+++ b/packages/esm-service-queues-app/src/home.component.tsx
@@ -1,9 +1,23 @@
 import React from 'react';
+import { useSession, userHasAccess } from '@openmrs/esm-framework';
 import PatientQueueHeader from './patient-queue-header/patient-queue-header.component';
 import ClinicMetrics from './metrics/metrics-container.component';
 import DefaultQueueTable from './queue-table/default-queue-table.component';
+import FocusedQueueView from './views/focused-queue-view.component';
+import { CLERK_PRIVILEGE, CLINIC_ADMIN_PRIVILEGE, CLINICIAN_PRIVILEGE } from './constants';
 
 const Home: React.FC = () => {
+  const session = useSession();
+  const user = session?.user;
+  const isClinicAdmin = !!user && userHasAccess(CLINIC_ADMIN_PRIVILEGE, user);
+  // userHasAccess treats an array as "all required", so OR the two privileges separately.
+  const isQueueUser = !!user && (userHasAccess(CLERK_PRIVILEGE, user) || userHasAccess(CLINICIAN_PRIVILEGE, user));
+
+  if (isQueueUser && !isClinicAdmin) {
+    return <FocusedQueueView />;
+  }
+
+  // Admins fall through to the existing view; O3-5770 adds their monitoring screen here.
   return (
     <>
       <PatientQueueHeader showFilters />

--- a/packages/esm-service-queues-app/src/home.test.tsx
+++ b/packages/esm-service-queues-app/src/home.test.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, useConfig, useSession, userHasAccess } from '@openmrs/esm-framework';
 import { type ConfigObject, configSchema } from './config-schema';
+import { CLERK_PRIVILEGE, CLINIC_ADMIN_PRIVILEGE, CLINICIAN_PRIVILEGE } from './constants';
 import { useQueueEntries } from './hooks/useQueueEntries';
+import { useQueueLocations } from './create-queue-entry/hooks/useQueueLocations';
 import { updateSelectedQueueLocationName } from './store/store';
 import Home from './home.component';
 
 const mockUseConfig = vi.mocked(useConfig<ConfigObject>);
+const mockUseSession = vi.mocked(useSession);
+const mockUserHasAccess = vi.mocked(userHasAccess);
+const mockUseQueueLocations = vi.mocked(useQueueLocations);
 
 vi.mock('./hooks/useQueues', () => ({
   useQueues: vi.fn(() => ({ queues: [] })),
@@ -36,12 +41,31 @@ mockUseConfig.mockReturnValue({
   visitQueueNumberAttributeUuid: 'c61ce16f-272a-41e7-9924-4c555d0932c5',
 });
 
+const mockSessionWithUser = {
+  authenticated: true,
+  sessionId: 'session-id',
+  user: { uuid: 'user-uuid', privileges: [], roles: [] },
+  sessionLocation: { uuid: 'location-uuid', display: 'Test Location' },
+};
+
 describe('Home Component', () => {
   beforeEach(() => {
     updateSelectedQueueLocationName('Test Location');
+    // Default: a user with none of the service-queues privileges.
+    mockUserHasAccess.mockReturnValue(false);
+    mockUseSession.mockReturnValue(mockSessionWithUser as ReturnType<typeof useSession>);
+    // Two queue locations so the (filtered) location dropdown is distinguishable between views.
+    mockUseQueueLocations.mockReturnValue({
+      queueLocations: [
+        { id: 'location-uuid', name: 'Test Location' },
+        { id: 'other-location-uuid', name: 'Other Location' },
+      ],
+      isLoading: false,
+      error: undefined,
+    });
   });
 
-  it('renders the service queues dashboard', () => {
+  it('renders the standard service queues dashboard for users without service-queues privileges', () => {
     render(<Home />);
 
     expect(screen.getByRole('heading', { name: /patients currently in queue/i })).toBeInTheDocument();
@@ -49,11 +73,45 @@ describe('Home Component', () => {
     expect(screen.getByRole('search', { name: /search this list/i })).toBeInTheDocument();
     expect(screen.getByRole('table', { name: /queue table/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /clear queue entries/i })).not.toBeInTheDocument();
+    // The standard view exposes the location filter.
+    expect(screen.getByRole('combobox', { name: /select a queue location/i })).toBeInTheDocument();
 
     const expectedColumnHeaders = [/name/, /priority/, /coming from/, /status/, /queue/, /wait time/, /actions/];
 
     expectedColumnHeaders.forEach((header) => {
       expect(screen.getByRole('columnheader', { name: new RegExp(header, 'i') })).toBeInTheDocument();
     });
+  });
+
+  it('renders the standard dashboard (with location filter) for a clinic administrator', () => {
+    mockUserHasAccess.mockImplementation((privilege) => privilege === CLINIC_ADMIN_PRIVILEGE);
+
+    render(<Home />);
+
+    expect(screen.getByRole('table', { name: /queue table/i })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /select a queue location/i })).toBeInTheDocument();
+  });
+
+  it.each([
+    ['clerk', CLERK_PRIVILEGE],
+    ['clinician', CLINICIAN_PRIVILEGE],
+  ])('renders the focused single-location view for a %s (no location filter)', (_label, privilege) => {
+    mockUserHasAccess.mockImplementation((required) => required === privilege);
+
+    render(<Home />);
+
+    // Still a queue table, but the location filter is hidden (locked to the session location).
+    expect(screen.getByRole('table', { name: /queue table/i })).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /select a queue location/i })).not.toBeInTheDocument();
+  });
+
+  it('prefers the standard dashboard when a user is both a clinic administrator and a queue user', () => {
+    mockUserHasAccess.mockImplementation(
+      (privilege) => privilege === CLINIC_ADMIN_PRIVILEGE || privilege === CLERK_PRIVILEGE,
+    );
+
+    render(<Home />);
+
+    expect(screen.getByRole('combobox', { name: /select a queue location/i })).toBeInTheDocument();
   });
 });

--- a/packages/esm-service-queues-app/src/views/focused-queue-view.component.tsx
+++ b/packages/esm-service-queues-app/src/views/focused-queue-view.component.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react';
+import { useSession } from '@openmrs/esm-framework';
+import PatientQueueHeader from '../patient-queue-header/patient-queue-header.component';
+import ClinicMetrics from '../metrics/metrics-container.component';
+import DefaultQueueTable from '../queue-table/default-queue-table.component';
+import { updateSelectedQueueLocationName, updateSelectedQueueLocationUuid } from '../store/store';
+
+/**
+ * The default view for a normal queue user (Clerk / Clinician): a focused, single-location
+ * "patients waiting" view. Reuses the standard header, metrics, and table, but hides the
+ * filters and locks the selected location to the user's session location.
+ */
+const FocusedQueueView: React.FC = () => {
+  const session = useSession();
+  const sessionLocation = session?.sessionLocation;
+
+  useEffect(() => {
+    if (sessionLocation?.uuid) {
+      updateSelectedQueueLocationUuid(sessionLocation.uuid);
+      updateSelectedQueueLocationName(sessionLocation.display);
+    }
+  }, [sessionLocation?.uuid, sessionLocation?.display]);
+
+  return (
+    <>
+      <PatientQueueHeader showFilters={false} />
+      <ClinicMetrics />
+      <DefaultQueueTable />
+    </>
+  );
+};
+
+export default FocusedQueueView;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Introduces the privilege model for the Service Queues app and makes the default landing view privilege-aware:

- Adds the three privilege-name constants (`constants.ts`).
- `home.component.tsx` now checks the current user's privileges via `useSession()` + `userHasAccess`. A **Clerk** or **Clinician** (who is not a Clinic Administrator) lands on a new focused view; everyone else — including admins — keeps the existing dashboard unchanged.
- New `FocusedQueueView`: reuses the existing header/metrics/table but hides the filters and locks the location to the user's session location.

The privileges themselves are defined as distribution content in the reference application content package ([see related PR](https://github.com/openmrs/openmrs-content-referenceapplication-demo)), which must be present and attached to roles for the behavior to take effect; until then the app degrades gracefully to the existing view.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-5764

## Other
<!-- Anything not covered above -->
Depends on: [openmrs-content-referenceapplication-demo PR](https://github.com/openmrs/openmrs-content-referenceapplication-demo) — defines the three `App: Service Queues …` privileges and attaches them to demo roles.

Follow-up: [O3-5770] (Clinic Administrator screen) plugs into the same admin check.

[O3-5770]: https://openmrs.atlassian.net/browse/O3-5770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
