### PR TITLE
(fix) O3-5821: Fix ward patient card pill spacing and workspace banner typography

### DIFF
--- a/packages/esm-ward-app/src/ward-patient-card/ward-patient-card.scss
+++ b/packages/esm-ward-app/src/ward-patient-card/ward-patient-card.scss
@@ -192,6 +192,7 @@
 .dotSeparatedChildren {
   display: flex;
   flex-wrap: wrap;
+  row-gap: layout.$spacing-02;
 
   > *:not(*:first-of-type):not(:empty) {
     display: flex;

--- a/packages/esm-ward-app/src/ward-workspace/patient-banner/patient-banner.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-banner/patient-banner.component.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import classNames from 'classnames';
 import { useAppContext } from '@openmrs/esm-framework';
 import type { WardPatientCardType, WardViewContext } from '../../types';
+import wardPatientCardStyles from '../../ward-patient-card/ward-patient-card.scss';
 import styles from './style.scss';
 
 const WardPatientWorkspaceBanner: WardPatientCardType = ({ wardPatient }) => {
@@ -13,7 +15,7 @@ const WardPatientWorkspaceBanner: WardPatientCardType = ({ wardPatient }) => {
   }
 
   return WardPatientHeader ? (
-    <div className={styles.wardWorkspacePatientBanner}>
+    <div className={classNames(styles.wardWorkspacePatientBanner, wardPatientCardStyles.wardPatientCard)}>
       <WardPatientHeader wardPatient={wardPatient} />
     </div>
   ) : (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Fixes the two cosmetic bugs reported in [openmrs.atlassian.net/browse/O3-5821](https://openmrs.atlassian.net/browse/O3-5821):

1. When a ward patient card header wraps onto multiple lines, the bed number pill and the patient identifier pill sit flush against each other. The header is a wrapping flex container with no vertical gap between rows, so this adds a `row-gap` of `$spacing-02` (4px) to the dot separated header rows.

2. The patient banner rendered inside ward workspaces (Transfers, Discharge, Patient note, and so on) reuses the same card header component as the ward view, but without the `wardPatientCard` wrapper class that supplies the `body-compact-01` type style. The banner text therefore rendered at 16px instead of the 14px used everywhere else. This composes the `wardPatientCard` class onto the banner wrapper so both contexts share the same typography.

## Screenshots

### Before

<img width="1252" height="432" alt="CleanShot 2026-07-17 at 20 43 11@2x" src="https://github.com/user-attachments/assets/a5039669-e544-432a-84fc-ee6262857c70" />

<img width="2004" height="444" alt="CleanShot 2026-07-17 at 20 44 34@2x" src="https://github.com/user-attachments/assets/e99c2245-645e-4f82-97bf-148eaa49c1d0" />

### After

Blue and gray tags no longer touching

<img width="1248" height="406" alt="CleanShot 2026-07-17 at 20 51 57@2x" src="https://github.com/user-attachments/assets/5a8c7773-93cb-4574-b384-538a306598d4" />

Typography in patient banner matches typography in ward cards

<img width="1876" height="486" alt="CleanShot 2026-07-17 at 20 44 10@2x" src="https://github.com/user-attachments/assets/99234630-7576-43a4-8f9d-57354cc734d2" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-5821

## Other
