### PR TITLE
(fix) Pin discharge workspace action buttons to the bottom

### DIFF
--- a/packages/esm-ward-app/src/ward-workspace/patient-discharge/patient-discharge.scss
+++ b/packages/esm-ward-app/src/ward-workspace/patient-discharge/patient-discharge.scss
@@ -14,6 +14,8 @@
 }
 
 .workspaceForm {
+  display: flex;
+  flex-direction: column;
   margin-top: layout.$spacing-05;
   flex: 1;
 }
@@ -21,7 +23,8 @@
 .buttonSet {
   display: flex;
   align-items: center;
-  margin: (layout.$spacing-05) (-(layout.$spacing-05)) (-(layout.$spacing-05)) (-(layout.$spacing-05));
+  margin: auto (-(layout.$spacing-05)) (-(layout.$spacing-05)) (-(layout.$spacing-05));
+  padding-top: layout.$spacing-05;
 
   button {
     max-width: unset !important;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

The Cancel and Confirm discharge buttons in the ward app's discharge workspace rendered directly below the discharge note field, floating in the middle of the workspace, instead of sitting at the bottom edge like the action buttons in every other workspace form.

The form element stretched to fill the workspace height with `flex: 1`, but it was still a block container internally, so its children stacked from the top. This change makes the form a flex column and pushes the button set down with `margin-top: auto`. That matches the layout used by the admit patient and patient transfer workspaces in this repo, and the workspace forms in patient chart. A `padding-top` on the button set preserves the previous gap above the buttons once the form content grows tall enough to reach them.

## Screenshots

### Before

#### Desktop

<img width="3396" height="1966" alt="CleanShot 2026-07-20 at 22 44 36@2x" src="https://github.com/user-attachments/assets/6887f9d4-f215-4e82-981d-233fd2532cd3" />

#### Tablet

<img width="1974" height="1966" alt="CleanShot 2026-07-20 at 22 58 10@2x" src="https://github.com/user-attachments/assets/068bd363-1f6f-478d-a0a9-0dcbed6f8b6a" />

### After

#### Desktop
<img width="3396" height="1968" alt="CleanShot 2026-07-20 at 22 49 36@2x" src="https://github.com/user-attachments/assets/cbce1e0a-b286-4caa-9bdf-ec04402fdec3" />

#### Tablet
<img width="1980" height="1962" alt="CleanShot 2026-07-20 at 22 57 38@2x" src="https://github.com/user-attachments/assets/bc89cb7f-6068-4a41-9241-88260829c926" />

## Related Issue

## Other
