### PR TITLE
(fix) O3-5846: Make 'Admit elsewhere' create an admission request instead of a transfer request

### DIFF
--- a/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-admit-or-transfer-request-form.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-admit-or-transfer-request-form.component.tsx
@@ -301,7 +301,7 @@ export default function PatientAdmitOrTransferForm({
             )}
           />
         </div>
-        {!formDefaultValues.transferType && (
+        {!formDefaultValues.transferType && dispositionsOfRequestedType?.length > 1 && (
           <div className={styles.field}>
             <h2 className={styles.productiveHeading02}>
               {isTransfer ? t('transferType', 'Transfer type') : t('admitType', 'Admit type')}
@@ -317,7 +317,7 @@ export default function PatientAdmitOrTransferForm({
                     invalid={!!error?.message}
                     invalidText={error?.message}>
                     {dispositionsOfRequestedType.map((disposition) => (
-                      <RadioButton id={disposition.uuid} labelText={disposition.name} value={disposition.uuid} />
+                      <RadioButton id={disposition.uuid} labelText={disposition.name} value={disposition.conceptCode} />
                     ))}
                   </RadioButtonGroup>
                 </ResponsiveWrapper>

--- a/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-admit-or-transfer-request-form.component.tsx
+++ b/packages/esm-ward-app/src/ward-workspace/patient-transfer-bed-swap/patient-admit-or-transfer-request-form.component.tsx
@@ -57,9 +57,13 @@ export default function PatientAdmitOrTransferForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { createEncounter, emrConfiguration, isLoadingEmrConfiguration, errorFetchingEmrConfiguration } =
     useCreateEncounter();
-  const dispositionsWithTypeTransfer = useMemo(
-    () => emrConfiguration?.dispositions.filter(({ type }) => type === 'TRANSFER'),
-    [emrConfiguration],
+
+  const dispositionType = wardPatient.inpatientRequest?.dispositionType ?? 'TRANSFER';
+  const isTransfer = dispositionType === 'TRANSFER';
+  // dispositions of either type TRANSFER or ADMIT, depending on the disposition type of the wardPatient
+  const dispositionsOfRequestedType = useMemo(
+    () => emrConfiguration?.dispositions.filter(({ type }) => type === dispositionType),
+    [emrConfiguration, dispositionType],
   );
   const { wardPatientGroupDetails } = useAppContext<WardViewContext>('ward-view-context') ?? {};
   const currentAdmission = wardPatientGroupDetails?.inpatientAdmissionsByPatientUuid?.get(patient?.uuid);
@@ -71,28 +75,34 @@ export default function PatientAdmitOrTransferForm({
     () =>
       z.object({
         location: z.string({
-          required_error: t('pleaseSelectTransferLocation', 'Please select transfer location'),
+          required_error: isTransfer
+            ? t('pleaseSelectTransferLocation', 'Please select transfer location')
+            : t('pleaseSelectAdmitLocation', 'Please select admit location'),
         }),
         note: z.string().optional(),
         transferType:
-          dispositionsWithTypeTransfer?.length > 1
+          dispositionsOfRequestedType?.length > 1
             ? z.string({
-                required_error: t('pleaseSelectTransferType', 'Please select transfer type'),
+                required_error: isTransfer
+                  ? t('pleaseSelectTransferType', 'Please select transfer type')
+                  : t('pleaseSelectAdmitType', 'Please select admit type'),
               })
             : z.string().optional(),
       }),
-    [t, dispositionsWithTypeTransfer],
+    [t, dispositionsOfRequestedType, isTransfer],
   );
 
   type FormValues = z.infer<typeof zodSchema>;
 
   const formDefaultValues: Partial<FormValues> = useMemo(() => {
     const defaultValues: FormValues = {};
-    if (dispositionsWithTypeTransfer?.length === 1) {
-      defaultValues.transferType = dispositionsWithTypeTransfer[0].uuid;
+    if (wardPatient.inpatientRequest?.dispositionType) {
+      defaultValues.transferType = wardPatient.inpatientRequest.disposition.uuid;
+    } else if (dispositionsOfRequestedType?.length === 1) {
+      defaultValues.transferType = dispositionsOfRequestedType[0].conceptCode;
     }
     return defaultValues;
-  }, [dispositionsWithTypeTransfer]);
+  }, [dispositionsOfRequestedType, wardPatient.inpatientRequest]);
 
   const {
     formState: { errors, isDirty },
@@ -102,10 +112,10 @@ export default function PatientAdmitOrTransferForm({
   } = useForm<FormValues>({ resolver: zodResolver(zodSchema), defaultValues: formDefaultValues });
 
   useEffect(() => {
-    if (dispositionsWithTypeTransfer?.length === 1) {
-      setValue('transferType', dispositionsWithTypeTransfer[0].uuid);
+    if (dispositionsOfRequestedType?.length === 1) {
+      setValue('transferType', dispositionsOfRequestedType[0].conceptCode);
     }
-  }, [dispositionsWithTypeTransfer, setValue]);
+  }, [dispositionsOfRequestedType, setValue]);
 
   const onSubmit = useCallback(
     async (values: FormValues) => {
@@ -118,7 +128,7 @@ export default function PatientAdmitOrTransferForm({
         },
         {
           concept: emrConfiguration.dispositionDescriptor.dispositionConcept.uuid,
-          value: dispositionsWithTypeTransfer.find(({ uuid }) => uuid === values.transferType)?.conceptCode,
+          value: values.transferType,
         },
       ];
 
@@ -129,15 +139,15 @@ export default function PatientAdmitOrTransferForm({
         });
       }
 
-      const wardPatientsToTransfer = [
+      const wardPatientsToAdmitOrTransfer = [
         wardPatient,
         ...relatedTransferPatients.filter((rp) => selectedRelatedPatient.includes(rp.patient.uuid)),
       ];
 
       try {
         const results = await Promise.allSettled(
-          wardPatientsToTransfer.map(async (wardPatientToTransfer) => {
-            const { patient: patientToTransfer, visit: patientToTransferVisit } = wardPatientToTransfer;
+          wardPatientsToAdmitOrTransfer.map(async (wardPatientToAdmitOrTransfer) => {
+            const { patient: patientToTransfer, visit: patientToTransferVisit } = wardPatientToAdmitOrTransfer;
 
             return createEncounter(
               patientToTransfer,
@@ -154,19 +164,27 @@ export default function PatientAdmitOrTransferForm({
         );
 
         results.forEach((result, i) => {
-          const patientName = wardPatientsToTransfer[i].patient.person.preferredName.display;
+          const patientName = wardPatientsToAdmitOrTransfer[i].patient.person.preferredName.display;
           if (result.status === 'fulfilled') {
             showSnackbar({
-              title: t('patientTransferRequestCreatedForPatient', 'Transfer request created for {{patientName}}', {
-                patientName,
-              }),
+              title: isTransfer
+                ? t('patientTransferRequestCreatedForPatient', 'Transfer request created for {{patientName}}', {
+                    patientName,
+                  })
+                : t('patientAdmitRequestCreatedForPatient', 'Admit request created for {{patientName}}', {
+                    patientName,
+                  }),
               kind: 'success',
             });
           } else {
             showSnackbar({
-              title: t('errorCreatingTransferRequest', 'Error creating transfer request for {{patientName}}', {
-                patientName,
-              }),
+              title: isTransfer
+                ? t('errorCreatingTransferRequest', 'Error creating transfer request for {{patientName}}', {
+                    patientName,
+                  })
+                : t('errorCreatingAdmitRequest', 'Error creating admit request for {{patientName}}', {
+                    patientName,
+                  }),
               subtitle: (result.reason as Error)?.message,
               kind: 'error',
             });
@@ -184,13 +202,13 @@ export default function PatientAdmitOrTransferForm({
     [
       onSuccess,
       createEncounter,
-      dispositionsWithTypeTransfer,
       emrConfiguration,
       t,
       wardPatientGroupDetails,
       selectedRelatedPatient,
       relatedTransferPatients,
       wardPatient,
+      isTransfer,
     ],
   );
 
@@ -283,9 +301,11 @@ export default function PatientAdmitOrTransferForm({
             )}
           />
         </div>
-        {dispositionsWithTypeTransfer?.length > 1 && (
+        {!formDefaultValues.transferType && (
           <div className={styles.field}>
-            <h2 className={styles.productiveHeading02}>{t('transferType', 'Transfer type')}</h2>
+            <h2 className={styles.productiveHeading02}>
+              {isTransfer ? t('transferType', 'Transfer type') : t('admitType', 'Admit type')}
+            </h2>
             <Controller
               name="transferType"
               control={control}
@@ -296,7 +316,7 @@ export default function PatientAdmitOrTransferForm({
                     {...field}
                     invalid={!!error?.message}
                     invalidText={error?.message}>
-                    {dispositionsWithTypeTransfer.map((disposition) => (
+                    {dispositionsOfRequestedType.map((disposition) => (
                       <RadioButton id={disposition.uuid} labelText={disposition.name} value={disposition.uuid} />
                     ))}
                   </RadioButtonGroup>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
See: https://openmrs.atlassian.net/browse/O3-5846

The user has 3 options to handle a pending transfer request: accept the transfer, cancel the transfer, or transfer elsewhere (by making another transfer request). The user can similarly do one of those 3 things for a pending admit request. Currently "Admit elsewhere" results in a new transfer request, which is incorrect. This PR changes it so that "Admit elsewhere" creates another admit request.

Secondary change:
Clicking on "Admit elsewhere" / "Transfer elsewhere" opens the admit / transfer request workspace. That workspace has a field that asks for the admission / transfer type (configured as dispositions in EMRAPI), but it's only shown if there is more than one disposition of that type. (In the case where there is only one disposition, that one is automatically selected, and the field is hidden). This PR changes it so that an "Admit elsewhere" / "Transfer elsewhere" request automatically inherit the original request's disposition, and thus also making the field hidden. 

## Screenshots

### Before secondary change
<img width="3121" height="1731" alt="image" src="https://github.com/user-attachments/assets/4bdc8313-615c-4bdf-9da9-da5aa8467ec3" />

### After secondary change (same as current behavior)
<img width="2113" height="1208" alt="image" src="https://github.com/user-attachments/assets/589dbb45-8ea2-4d88-9a17-060a14487ed8" />

Testing done:
Ran internal PIH E2E tests for the following scenarios:
- Create admission request for patient in HTML form, then in ward app, have them admit elsewhere to location X, then login to location X and accept admit request
- Create admission request for patient in HTML form, then in ward app, cancel the admission request
- Create admission request for patient in HTML form, then in ward app,have them admitted. Then create a transfer request for patient to location X, then login to location X and accept transfer request

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-5846

## Other
<!-- Anything not covered above -->
