### PR TITLE
(fix) O3-5856: Declare react-dom as a peer dependency in esm-home-app

### DIFF
--- a/packages/esm-home-app/package.json
+++ b/packages/esm-home-app/package.json
@@ -38,6 +38,7 @@
   "peerDependencies": {
     "@openmrs/esm-framework": "10.x",
     "react": "18.x",
+    "react-dom": "18.x",
     "react-i18next": "16.x",
     "react-router-dom": "6.x",
     "swr": "2.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2684,6 +2684,7 @@ __metadata:
   peerDependencies:
     "@openmrs/esm-framework": 10.x
     react: 18.x
+    react-dom: 18.x
     react-i18next: 16.x
     react-router-dom: 6.x
     swr: 2.x


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
`esm-home-app` was missing `react-dom` from its `peerDependencies`, causing the build to bundle its own copy (~125 kB) instead of using the app shell's shared singleton via Module Federation. This adds `react-dom: 18.x` to `peerDependencies` to match the pattern used by other apps like `esm-login-app`.

## Screenshots

## Related Issue
https://issues.openmrs.org/browse/O3-5856

## Other