### PR TITLE
(fix) Correct singular minute translation

### DIFF
--- a/packages/esm-ward-app/translations/en.json
+++ b/packages/esm-ward-app/translations/en.json
@@ -72,7 +72,7 @@
   "lastEditedBy": "Last edited by: {{name}}, {{date}}",
   "male": "Male",
   "manage": "Manage",
-  "minutes_one": "{{count}} minutes",
+  "minutes_one": "{{count}} minute",
   "minutes_other": "{{count}} minutes",
   "motherChildBedShare": "Mother / Child",
   "mothers": "Mothers",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The ward app's English catalog uses `{{count}} minutes` for both plural forms, so a one-minute stay renders as “1 minutes.”

This corrects `minutes_one` to `{{count}} minute`. The source default already uses the singular form, so the catalog and source now agree.

## Screenshots

## Related Issue

## Other
