### PR TITLE
(fix) O3-5911: Require a non-empty registration encounter type

### DIFF
--- a/packages/esm-patient-registration-app/src/config-schema.test.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { getDefaultsFromConfigSchema } from '@openmrs/esm-framework';
+import { esmPatientRegistrationSchema, type FieldDefinition, type RegistrationConfig } from './config-schema';
+
+const obsFieldDefinition: FieldDefinition = {
+  id: 'chief-complaint',
+  type: 'obs',
+  label: 'Chief complaint',
+  placeholder: '',
+  showHeading: false,
+  uuid: 'chief-complaint-uuid',
+  validation: {
+    required: false,
+    matches: null,
+  },
+  answerConceptSetUuid: null,
+  customConceptAnswers: [],
+};
+
+const personAttributeFieldDefinition: FieldDefinition = {
+  ...obsFieldDefinition,
+  id: 'referred-by',
+  type: 'person attribute',
+  label: 'Referred by',
+  uuid: 'referred-by-uuid',
+};
+
+function buildConfig(overrides: Partial<RegistrationConfig> = {}): RegistrationConfig {
+  return {
+    ...getDefaultsFromConfigSchema(esmPatientRegistrationSchema),
+    ...overrides,
+  } as RegistrationConfig;
+}
+
+/**
+ * Runs every top-level schema validator and returns the messages that failed.
+ * Indexing into `_validators` directly would break if validators are reordered.
+ */
+function validationErrors(config: RegistrationConfig): Array<string> {
+  return esmPatientRegistrationSchema._validators
+    .map((validate) => validate(config))
+    .filter((message): message is string => typeof message === 'string');
+}
+
+function encounterTypeErrors(config: RegistrationConfig): Array<string> {
+  return validationErrors(config).filter((message) => message.includes('registrationObs.encounterTypeUuid'));
+}
+
+describe('esmPatientRegistrationSchema registrationObs.encounterTypeUuid validator', () => {
+  describe('when obs fields are configured', () => {
+    it.each([
+      ['an empty string', ''],
+      ['a whitespace-only string', '   '],
+      ['null', null],
+      ['undefined', undefined],
+    ])('reports an error when the encounter type is %s', (_label, encounterTypeUuid) => {
+      const config = buildConfig({
+        fieldDefinitions: [obsFieldDefinition],
+        registrationObs: {
+          encounterTypeUuid,
+          encounterProviderRoleUuid: 'provider-role-uuid',
+          registrationFormUuid: null,
+        },
+      } as Partial<RegistrationConfig>);
+
+      expect(encounterTypeErrors(config)).toHaveLength(1);
+      expect(encounterTypeErrors(config)[0]).toMatch(/non-empty/i);
+    });
+
+    it('accepts a valid encounter type', () => {
+      const config = buildConfig({
+        fieldDefinitions: [obsFieldDefinition],
+        registrationObs: {
+          encounterTypeUuid: 'registration-encounter-type-uuid',
+          encounterProviderRoleUuid: 'provider-role-uuid',
+          registrationFormUuid: null,
+        },
+      });
+
+      expect(encounterTypeErrors(config)).toEqual([]);
+    });
+  });
+
+  describe('when no obs fields are configured', () => {
+    it.each([
+      ['an empty string', ''],
+      ['null', null],
+    ])('allows the encounter type to be %s', (_label, encounterTypeUuid) => {
+      const config = buildConfig({
+        fieldDefinitions: [personAttributeFieldDefinition],
+        registrationObs: {
+          encounterTypeUuid,
+          encounterProviderRoleUuid: 'provider-role-uuid',
+          registrationFormUuid: null,
+        },
+      } as Partial<RegistrationConfig>);
+
+      expect(encounterTypeErrors(config)).toEqual([]);
+    });
+
+    it('allows the encounter type to be omitted when there are no field definitions at all', () => {
+      const config = buildConfig({ fieldDefinitions: [] });
+
+      expect(encounterTypeErrors(config)).toEqual([]);
+    });
+  });
+});

--- a/packages/esm-patient-registration-app/src/config-schema.ts
+++ b/packages/esm-patient-registration-app/src/config-schema.ts
@@ -419,8 +419,9 @@ export const esmPatientRegistrationSchema = {
   _validators: [
     validator(
       (config: RegistrationConfig) =>
-        !config.fieldDefinitions.some((d) => d.type === 'obs') || config.registrationObs.encounterTypeUuid !== null,
-      "If fieldDefinitions contains any fields of type 'obs', `registrationObs.encounterTypeUuid` must be specified.",
+        !config.fieldDefinitions.some((d) => d.type === 'obs') ||
+        Boolean(config.registrationObs.encounterTypeUuid?.trim()),
+      "If fieldDefinitions contains any fields of type 'obs', `registrationObs.encounterTypeUuid` must be set to a non-empty encounter type UUID.",
     ),
     validator(
       (config: RegistrationConfig) =>

--- a/packages/esm-patient-registration-app/src/patient-registration/field/obs/obs-field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/obs/obs-field.test.tsx
@@ -223,6 +223,18 @@ describe('ObsField', () => {
     consoleSpy.mockRestore();
   });
 
+  it('does not render if the registration encounter type is an empty string', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(esmPatientRegistrationSchema),
+      registrationObs: { encounterTypeUuid: '' },
+    } as RegistrationConfig);
+
+    const { container } = render(<ObsField fieldDefinition={textFieldDef} />);
+    expect(container).toBeEmptyDOMElement();
+    consoleSpy.mockRestore();
+  });
+
   it('does not render while concept is loading', () => {
     mockUseConcept.mockReturnValue({
       data: null,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Registration observation fields could be configured without an encounter type. The configuration was accepted, but the fields were silently hidden at runtime and no observation data could be entered.

The validator for `registrationObs.encounterTypeUuid` only rejected `null`, while the setting defaults to an empty string. A config declaring `obs` field definitions without an encounter type therefore passed validation, but the two places that consume the value test it for truthiness and treat `''` as missing: `ObsField` renders nothing, and `FormManager` skips saving the obs. So the fields disappeared and their values were never persisted, with no configuration error to explain why.

This tightens the validator to reject missing, empty and whitespace-only values, so all three checks agree on what counts as unset and the misconfiguration surfaces up front. The error message now says the value must be set to a non-empty encounter type UUID, since "must be specified" reads oddly to someone who did write `encounterTypeUuid: ""`.

Tests cover the three acceptance criteria: a missing or empty encounter type fails validation (`''`, whitespace, `null` and `undefined`), a valid one is accepted and allows obs fields to render, and a configuration with no obs fields may still omit it. A new test in `obs-field.test.tsx` pins the runtime half — an empty encounter type renders nothing.

## Screenshots

N/A — configuration validation only, no UI changes.

## Related Issue

https://openmrs.atlassian.net/browse/O3-5911

## Other

Verified against `c64fb3366119833e9e09a0eb31d580c9e1558d8b`. The full registration suite passes (38 files, 279 tests), along with `tsc`, `eslint` and a production build.
