### PR TITLE
(fix) O3-5910: Preserve local-language names when editing a patient

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.test.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.test.ts
@@ -89,4 +89,49 @@ describe('FormManager', () => {
       expect(mockGenerateIdentifier.mock.calls).toHaveLength(0);
     });
   });
+
+  describe('getDeletedNames', () => {
+    const patientUuid = 'patient-uuid';
+    const patientUuidMap = { additionalNameUuid: 'additional-name-uuid' };
+
+    it('does not delete the local-language name when the option is still enabled', () => {
+      const values: FormValues = { ...formValues, patientUuid, addNameInLocalLanguage: true };
+
+      expect(FormManager.getDeletedNames(values, patientUuidMap)).toEqual([]);
+    });
+
+    it('deletes the local-language name when the option has been disabled', () => {
+      const values: FormValues = { ...formValues, patientUuid, addNameInLocalLanguage: false };
+
+      expect(FormManager.getDeletedNames(values, patientUuidMap)).toEqual([
+        { nameUuid: 'additional-name-uuid', personUuid: patientUuid },
+      ]);
+    });
+
+    it('updates the local-language name rather than deleting it when it is edited', () => {
+      const values: FormValues = {
+        ...formValues,
+        patientUuid,
+        addNameInLocalLanguage: true,
+        additionalGivenName: 'Wanjiru',
+        additionalMiddleName: '',
+        additionalFamilyName: 'Kamau',
+      };
+
+      expect(FormManager.getDeletedNames(values, patientUuidMap)).toEqual([]);
+      expect(FormManager.getNames(values, patientUuidMap)).toContainEqual({
+        uuid: 'additional-name-uuid',
+        preferred: false,
+        givenName: 'Wanjiru',
+        middleName: '',
+        familyName: 'Kamau',
+      });
+    });
+
+    it('returns no deletions when the patient has no local-language name', () => {
+      const values: FormValues = { ...formValues, patientUuid, addNameInLocalLanguage: false };
+
+      expect(FormManager.getDeletedNames(values, {})).toEqual([]);
+    });
+  });
 });

--- a/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/form-manager.ts
@@ -123,7 +123,7 @@ export class FormManager {
       config,
     );
 
-    FormManager.getDeletedNames(values.patientUuid, patientUuidMap).forEach(async (name) => {
+    FormManager.getDeletedNames(values, patientUuidMap).forEach(async (name) => {
       await deletePersonName(name.nameUuid, name.personUuid);
     });
 
@@ -290,12 +290,12 @@ export class FormManager {
     return Promise.all(identifierTypeRequests);
   }
 
-  static getDeletedNames(patientUuid: string, patientUuidMap: PatientUuidMapType) {
-    if (patientUuidMap?.additionalNameUuid) {
+  static getDeletedNames(values: FormValues, patientUuidMap: PatientUuidMapType) {
+    if (patientUuidMap?.additionalNameUuid && !values.addNameInLocalLanguage) {
       return [
         {
           nameUuid: patientUuidMap.additionalNameUuid,
-          personUuid: patientUuid,
+          personUuid: values.patientUuid,
         },
       ];
     }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

This is patient data loss on every edit. Opening an existing patient who has a local-language name, changing any unrelated field and saving silently destroys that name — the user never touches the local-language option, and nothing in the UI indicates anything was removed.

`getDeletedNames()` returned the existing additional-name UUID whenever one was present, without consulting `values.addNameInLocalLanguage`. Since that flag is still set for any patient who has such a name, the name was scheduled for deletion on every save.

The mechanism is worse than an unwanted delete. `getNames()` already rebuilds the additional name using the same UUID, so each edit updated the name and then deleted it — the two statics disagreed about what to do with one UUID. This changes `getDeletedNames()` to take `values`, mirroring the neighbouring `getNames(values, patientUuidMap)`, and to return the deletion only when `addNameInLocalLanguage` is no longer set, so both functions read the flag from the same place. Checking for a falsy value also covers the `undefined` that `getFormValuesFromFhirPatient` produces when a patient has no additional name.

**Scope note.** The deletions are dispatched through `forEach` with an async callback, so the save reports success before they finish. That is O3-5913, which is assigned, and it is deliberately untouched here — only the predicate and the arguments at its single call site change, so the two fixes compose cleanly. Because the deletion is not awaited today, the tests assert on what `getDeletedNames()` returns rather than on the async side effect; it is a pure function, which is what makes it the right seam.

Tests cover the acceptance criteria: an unrelated edit preserves the name, editing the name updates it (asserted against `getNames()`, showing the same UUID is reused), disabling the option removes it, and a patient with no local-language name produces no deletion. The first and third of these fail without the fix and pass with it.

## Screenshots

N/A — no UI changes.

## Related Issue

https://openmrs.atlassian.net/browse/O3-5910

## Other

Verified with `yarn verify` (27/27 tasks), the full registration suite (37 files, 274 passing), `tsc`, `eslint` and a production build. Two files changed: the `getDeletedNames` predicate and its tests.
