### PR TITLE
(fix) Clean build outputs before bundle size comparison

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -38,3 +38,4 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           minimum-change-threshold: 10000 # 10 KB
           build-script: "turbo run build --concurrency=5"
+          clean-script: "clean:dist"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "start": "openmrs develop",
+    "clean:dist": "turbo run clean --color --concurrency=5",
     "ci:publish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-patient-management npm publish --access public --tag latest",
     "ci:prepublish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-patient-management npm publish --access public --tag next",
     "release": "yarn workspaces foreach --all --topological version",

--- a/packages/esm-active-visits-app/package.json
+++ b/packages/esm-active-visits-app/package.json
@@ -12,6 +12,7 @@
     "serve": "rspack serve --mode=development",
     "debug": "npm run serve",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env.analyze=true",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/packages/esm-appointments-app/package.json
+++ b/packages/esm-appointments-app/package.json
@@ -12,6 +12,7 @@
     "serve": "rspack serve --mode=development",
     "debug": "npm run serve",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env analyze=true",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/packages/esm-bed-management-app/package.json
+++ b/packages/esm-bed-management-app/package.json
@@ -12,6 +12,7 @@
     "serve": "rspack serve --mode=development",
     "debug": "npm run serve",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env.analyze=true",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/packages/esm-home-app/package.json
+++ b/packages/esm-home-app/package.json
@@ -11,6 +11,7 @@
     "serve": "rspack serve --mode=development",
     "debug": "npm run serve",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env.analyze=true",
     "lint": "eslint src --fix --max-warnings=0 --color",
     "typescript": "tsc",

--- a/packages/esm-patient-list-management-app/package.json
+++ b/packages/esm-patient-list-management-app/package.json
@@ -12,6 +12,7 @@
     "serve": "rspack serve --mode=development",
     "debug": "npm run serve",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env.analyze=true",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/packages/esm-patient-registration-app/package.json
+++ b/packages/esm-patient-registration-app/package.json
@@ -12,6 +12,7 @@
     "serve": "rspack serve --mode=development",
     "debug": "npm run serve",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env.analyze=true",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/packages/esm-patient-search-app/package.json
+++ b/packages/esm-patient-search-app/package.json
@@ -12,6 +12,7 @@
     "serve": "rspack serve --mode=development",
     "debug": "npm run serve",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env.analyze=true",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/packages/esm-service-queues-app/package.json
+++ b/packages/esm-service-queues-app/package.json
@@ -12,6 +12,7 @@
     "serve": "rspack serve --mode=development",
     "debug": "npm run serve",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env.analyze=true",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/packages/esm-ward-app/package.json
+++ b/packages/esm-ward-app/package.json
@@ -12,6 +12,7 @@
     "serve": "rspack serve --mode=development",
     "debug": "npm run serve",
     "build": "rspack --mode production",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env.analyze=true",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "tasks": {
+    "clean": {
+      "cache": false
+    },
     "build": {
       "outputs": [
         "dist/**"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

The compressed-size action builds the pull request and base revisions sequentially in the same workspace. When the base build is restored from the Turborepo cache, its build command is skipped and stale pull-request chunks can remain in `dist`. Those files are then incorrectly reported as removed, inflating the bundle-size change.

This adds the action-supported cleanup hook. Each of the 9 buildable packages owns a `clean` script scoped to its ignored `dist` directory, and the root script orchestrates those package tasks through a non-cacheable Turborepo task.

This follows the workflow fix validated in openmrs/openmrs-esm-patient-chart#3607.

## Screenshots

## Related Issue

Follow-up to openmrs/openmrs-esm-patient-chart#3607.

## Other
