### PR TITLE
(fix) Improve Service Queues attending empty state contrast

### DIFF
--- a/packages/esm-service-queues-app/src/attending-patients/attending-patients.component.tsx
+++ b/packages/esm-service-queues-app/src/attending-patients/attending-patients.component.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, SkeletonPlaceholder, Tag, Tile } from '@carbon/react';
+import { Button, Layer, SkeletonPlaceholder, Tag, Tile } from '@carbon/react';
 import {
   age,
   ConfigurableLink,
@@ -60,10 +60,14 @@ const AttendingPatients: React.FC = () => {
       ) : error ? (
         <ErrorState error={error} headerTitle={t('attending', 'Attending')} />
       ) : queueEntries.length === 0 ? (
-        <Tile className={styles.emptyState}>
-          <EmptyCardIllustration />
-          <p className={styles.emptyStateContent}>{t('noOneBeingAttended', 'No one is being attended')}</p>
-        </Tile>
+        <Layer role="status">
+          <Tile className={styles.emptyState}>
+            <EmptyCardIllustration />
+            <p className={styles.emptyStateContent}>
+              {t('noOneBeingAttended', 'No patients are currently being attended to')}
+            </p>
+          </Tile>
+        </Layer>
       ) : (
         <div className={styles.cards}>
           {visibleEntries.map((queueEntry) => (

--- a/packages/esm-service-queues-app/src/attending-patients/attending-patients.test.tsx
+++ b/packages/esm-service-queues-app/src/attending-patients/attending-patients.test.tsx
@@ -69,12 +69,13 @@ describe('AttendingPatients', () => {
     expect(screen.queryByText(/1990/)).not.toBeInTheDocument();
   });
 
-  it('says explicitly that no one is being attended rather than hiding the section', () => {
+  it('says explicitly that no patients are being attended to rather than hiding the section', () => {
     mockEntries([]);
     render(<AttendingPatients />);
 
     expect(screen.getByText('Attending')).toBeInTheDocument();
-    expect(screen.getByText('No one is being attended')).toBeInTheDocument();
+    expect(screen.getByText('No patients are currently being attended to')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveClass('cds--layer-two');
   });
 
   it('distinguishes a failed request from an empty list', () => {
@@ -82,7 +83,7 @@ describe('AttendingPatients', () => {
     render(<AttendingPatients />);
 
     expect(screen.getByText('Error State')).toBeInTheDocument();
-    expect(screen.queryByText('No one is being attended')).not.toBeInTheDocument();
+    expect(screen.queryByText('No patients are currently being attended to')).not.toBeInTheDocument();
   });
 
   it('caps the cards and reveals the rest behind "View all"', async () => {

--- a/packages/esm-service-queues-app/translations/en.json
+++ b/packages/esm-service-queues-app/translations/en.json
@@ -76,7 +76,7 @@
   "noActiveVisit": "No active visit",
   "noCheckedInPatients": "No checked-in patients waiting to be added to a queue at this location",
   "noColumnsDefined": "No table columns defined. Check Configuration",
-  "noOneBeingAttended": "No one is being attended",
+  "noOneBeingAttended": "No patients are currently being attended to",
   "noPatientsToDisplay": "No patients to display",
   "noPreviousVisitFound": "No previous visit found",
   "noPrioritiesConfigured": "No priorities configured",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The Attending empty state currently puts the illustration on the same Gray 10 background used by its lightest tones, so parts of the illustration disappear.

This wraps the tile in a Carbon `Layer`, which gives it a white contextual background and matches the illustrated empty states used elsewhere in O3. It also changes the copy from “No one is being attended” to “No patients are currently being attended to.”

## Screenshots

### Before

<img width="2664" height="1516" alt="CleanShot 2026-08-30 at 23 46 36@2x" src="https://github.com/user-attachments/assets/745cb16d-94bd-4efc-a460-e8cf56ec12e2" />

### After

<img width="2664" height="1510" alt="CleanShot 2026-08-30 at 23 46 07@2x" src="https://github.com/user-attachments/assets/644b74ba-5d2e-47f5-afee-31dd0fcfc440" />

### Updated translation

<img width="1928" height="500" alt="CleanShot 2026-08-31 at 12 22 15@2x" src="https://github.com/user-attachments/assets/017c6764-b5cf-4373-9b7c-3b9238459991" />

## Related Issue

## Other

