### PR TITLE
(fix) Keep patient search on the selected page and load result pages in parallel

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search-paging.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search-paging.test.tsx
@@ -36,6 +36,8 @@ const startIndexesOf = (urls: Array<string>) =>
 // A big clinic's result set: far more pages than one wave, and not a whole number of pages.
 const TOTAL = 1700;
 const PAGE_SIZE = 50;
+// Mirrors `pagesPerWave` in the component: how many requests may be in flight together.
+const PAGES_PER_WAVE = 4;
 
 describe('advanced search paging for a large result set', () => {
   let requestedUrls: Array<string>;
@@ -88,7 +90,7 @@ describe('advanced search paging for a large result set', () => {
 
     await screen.findByRole('heading', { name: /1700 search result/i }, { timeout: 10000 });
 
-    expect(maxInFlight).toBeLessThanOrEqual(8);
+    expect(maxInFlight).toBeLessThanOrEqual(PAGES_PER_WAVE);
     expect(maxInFlight).toBeGreaterThan(1);
   });
 
@@ -123,8 +125,8 @@ describe('advanced search paging for a large result set', () => {
     // Give any further wave time to be opened, so this fails loudly if the loop keeps going.
     await new Promise((r) => setTimeout(r, 200));
 
-    // The first wave reaches startIndex=400. A second wave would start at 450.
-    expect(Math.max(...startIndexesOf(requestedUrls))).toBeLessThanOrEqual(400);
-    expect(maxInFlight).toBeLessThanOrEqual(8);
+    // The first wave ends at this startIndex; a second wave would start one page past it.
+    expect(Math.max(...startIndexesOf(requestedUrls))).toBeLessThanOrEqual(PAGES_PER_WAVE * PAGE_SIZE);
+    expect(maxInFlight).toBeLessThanOrEqual(PAGES_PER_WAVE);
   });
 });

--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search-paging.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search-paging.test.tsx
@@ -10,7 +10,7 @@ import AdvancedPatientSearchComponent from './advanced-patient-search.component'
 vi.mock('./refine-search/person-attributes.resource', () => ({ usePersonAttributeType: vi.fn() }));
 vi.mock('./patient-search-views.component', () => ({
   EmptyState: () => <div data-testid="results" data-count="0" />,
-  ErrorState: () => <div />,
+  ErrorState: () => <div data-testid="error" />,
   LoadingState: () => <div />,
   PatientSearchResults: ({ searchResults }: { searchResults: Array<unknown> }) => (
     <div data-testid="results" data-count={searchResults.length} />
@@ -22,6 +22,16 @@ const mockOpenmrsFetch = vi.mocked(openmrsFetch);
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
 );
+
+// Retries would mask which pages the wave loop asked for on its own.
+const noRetryWrapper = ({ children }: { children: React.ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, shouldRetryOnError: false, errorRetryCount: 0 }}>
+    {children}
+  </SWRConfig>
+);
+
+const startIndexesOf = (urls: Array<string>) =>
+  urls.map((url) => Number(new URL(url, 'http://localhost').searchParams.get('startIndex') ?? 0));
 
 // A big clinic's result set: far more pages than one wave, and not a whole number of pages.
 const TOTAL = 1700;
@@ -80,5 +90,41 @@ describe('advanced search paging for a large result set', () => {
 
     expect(maxInFlight).toBeLessThanOrEqual(8);
     expect(maxInFlight).toBeGreaterThan(1);
+  });
+
+  it('stops opening waves once a page request fails', async () => {
+    // Page 1 lands, so the loop knows there are 34 pages; a page in the first wave then fails.
+    mockOpenmrsFetch.mockImplementation(async (url: string) => {
+      requestedUrls.push(url);
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+
+      const startIndex = Number(new URL(url, 'http://localhost').searchParams.get('startIndex') ?? 0);
+      if (startIndex === PAGE_SIZE) {
+        throw new Error('page request failed');
+      }
+
+      const count = Math.max(0, Math.min(PAGE_SIZE, TOTAL - startIndex));
+      return {
+        data: {
+          results: Array.from({ length: count }, (_, i) => ({ uuid: `p-${startIndex + i}`, person: {} })),
+          links: TOTAL > startIndex + PAGE_SIZE ? [{ rel: 'next' }] : [],
+          totalCount: TOTAL,
+        },
+      } as unknown as FetchResponse;
+    });
+
+    render(<AdvancedPatientSearchComponent query="jos" />, { wrapper: noRetryWrapper });
+
+    await screen.findByTestId('error', undefined, { timeout: 10000 });
+
+    // Give any further wave time to be opened, so this fails loudly if the loop keeps going.
+    await new Promise((r) => setTimeout(r, 200));
+
+    // The first wave reaches startIndex=400. A second wave would start at 450.
+    expect(Math.max(...startIndexesOf(requestedUrls))).toBeLessThanOrEqual(400);
+    expect(maxInFlight).toBeLessThanOrEqual(8);
   });
 });

--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search-paging.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search-paging.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { type FetchResponse, getDefaultsFromConfigSchema, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { configSchema } from '../config-schema';
+import { usePersonAttributeType } from './refine-search/person-attributes.resource';
+import AdvancedPatientSearchComponent from './advanced-patient-search.component';
+
+vi.mock('./refine-search/person-attributes.resource', () => ({ usePersonAttributeType: vi.fn() }));
+vi.mock('./patient-search-views.component', () => ({
+  EmptyState: () => <div data-testid="results" data-count="0" />,
+  ErrorState: () => <div />,
+  LoadingState: () => <div />,
+  PatientSearchResults: ({ searchResults }: { searchResults: Array<unknown> }) => (
+    <div data-testid="results" data-count={searchResults.length} />
+  ),
+}));
+
+const mockOpenmrsFetch = vi.mocked(openmrsFetch);
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+
+// A big clinic's result set: far more pages than one wave, and not a whole number of pages.
+const TOTAL = 1700;
+const PAGE_SIZE = 50;
+
+describe('advanced search paging for a large result set', () => {
+  let requestedUrls: Array<string>;
+  let inFlight: number;
+  let maxInFlight: number;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    requestedUrls = [];
+    inFlight = 0;
+    maxInFlight = 0;
+    vi.mocked(usePersonAttributeType).mockReturnValue({ data: null, isLoading: false, error: null } as never);
+    vi.mocked(useConfig).mockReturnValue(getDefaultsFromConfigSchema(configSchema));
+
+    mockOpenmrsFetch.mockReset();
+    mockOpenmrsFetch.mockImplementation(async (url: string) => {
+      requestedUrls.push(url);
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+
+      const startIndex = Number(new URL(url, 'http://localhost').searchParams.get('startIndex') ?? 0);
+      const count = Math.max(0, Math.min(PAGE_SIZE, TOTAL - startIndex));
+
+      return {
+        data: {
+          results: Array.from({ length: count }, (_, i) => ({ uuid: `p-${startIndex + i}`, person: {} })),
+          links: TOTAL > startIndex + PAGE_SIZE ? [{ rel: 'next' }] : [],
+          totalCount: TOTAL,
+        },
+      } as unknown as FetchResponse;
+    });
+  });
+
+  it('loads every page of a 1700-result query without leaving patients unreachable', async () => {
+    render(<AdvancedPatientSearchComponent query="jos" />, { wrapper });
+
+    // The header counts every row held on the client, so it is the loaded total — the rendered list
+    // only ever holds one page of it.
+    await screen.findByRole('heading', { name: /1700 search result/i }, { timeout: 10000 });
+
+    // Nothing truncated, and no page fetched twice.
+    expect(requestedUrls).toHaveLength(Math.ceil(TOTAL / PAGE_SIZE));
+    expect(new Set(requestedUrls).size).toBe(requestedUrls.length);
+  });
+
+  it('spreads the pages over bounded waves rather than one burst of requests', async () => {
+    render(<AdvancedPatientSearchComponent query="jos" />, { wrapper });
+
+    await screen.findByRole('heading', { name: /1700 search result/i }, { timeout: 10000 });
+
+    expect(maxInFlight).toBeLessThanOrEqual(8);
+    expect(maxInFlight).toBeGreaterThan(1);
+  });
+});

--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.component.tsx
@@ -12,10 +12,16 @@ const resultsPerPage = 50;
 
 /**
  * How many pages to request at once. Every page of a result set still gets loaded — this only
- * bounds how many are in flight together, so a query matching thousands of patients arrives in a
- * handful of waves instead of one burst of requests at the backend.
+ * bounds how many are in flight together, so a broad query arrives in a handful of waves instead of
+ * one burst of requests at the backend.
+ *
+ * Deliberately small. The REST patient search re-runs the whole search and hydration on every page
+ * request and applies `startIndex` in memory at the end, so each page in a wave costs a full search
+ * at the backend, not a slice of one. Paging serially held that to one at a time; this trades a
+ * bounded amount of concurrency for far fewer round trips, and four is low enough for a modest
+ * install to absorb when several people are searching at once.
  */
-const pagesPerWave = 8;
+const pagesPerWave = 4;
 
 interface AdvancedPatientSearchProps {
   query: string;
@@ -56,11 +62,12 @@ const AdvancedPatientSearchComponent: React.FC<AdvancedPatientSearchProps> = ({
 
   // The refine-search filters and the result count below both run over the rows held on the client,
   // so the whole result set has to be loaded. `useInfinitePatientSearch` fetches pages in parallel,
-  // so request them a wave at a time: a 1700-result query then costs five round trips rather than
-  // the thirty-four it took to walk the set one page at a time, without leaving any patient
-  // unreachable. Waiting on `isValidating` is what keeps a wave from being requested on top of the
-  // one still in flight — `currentPage` advances as soon as the pages are asked for, not when they
-  // land, so without it every wave would collapse back into a single burst.
+  // so request them a wave at a time: `person.searchMaxResults` caps the search at 1000 patients by
+  // default, so even a broad query is around twenty pages, and those arrive in five waves rather
+  // than twenty sequential round trips — without leaving any patient unreachable. Waiting on
+  // `isValidating` is what keeps a wave from being requested on top of the one still in flight —
+  // `currentPage` advances as soon as the pages are asked for, not when they land, so without it
+  // every wave would collapse back into a single burst.
   const pagesNeeded = Math.ceil(totalResultsForQuery / resultsPerPage);
 
   // A failed request also ends the wave, so stop on `fetchError`: the count that `pagesNeeded` is

--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.component.tsx
@@ -8,6 +8,15 @@ import PatientSearchComponent from './patient-search-lg.component';
 import RefineSearch, { initialFilters } from './refine-search/refine-search.component';
 import styles from './advanced-patient-search.scss';
 
+const resultsPerPage = 50;
+
+/**
+ * How many pages to request at once. Every page of a result set still gets loaded — this only
+ * bounds how many are in flight together, so a query matching thousands of patients arrives in a
+ * handful of waves instead of one burst of requests at the backend.
+ */
+const pagesPerWave = 8;
+
 interface AdvancedPatientSearchProps {
   query: string;
   inTabletOrOverlay?: boolean;
@@ -39,16 +48,26 @@ const AdvancedPatientSearchComponent: React.FC<AdvancedPatientSearchProps> = ({
     data: searchResults,
     currentPage,
     setPage,
-    hasMore,
     isLoading,
+    isValidating,
     fetchError,
-  } = useInfinitePatientSearch(query, includeDead, !!query, 50);
+    totalResults,
+  } = useInfinitePatientSearch(query, includeDead, !!query, resultsPerPage);
+
+  // The refine-search filters and the result count below both run over the rows held on the client,
+  // so the whole result set has to be loaded. `useInfinitePatientSearch` fetches pages in parallel,
+  // so request them a wave at a time: a 1700-result query then costs five round trips rather than
+  // the thirty-four it took to walk the set one page at a time, without leaving any patient
+  // unreachable. Waiting on `isValidating` is what keeps a wave from being requested on top of the
+  // one still in flight — `currentPage` advances as soon as the pages are asked for, not when they
+  // land, so without it every wave would collapse back into a single burst.
+  const pagesNeeded = Math.ceil(totalResults / resultsPerPage);
 
   useEffect(() => {
-    if (searchResults?.length === currentPage * 50 && hasMore) {
-      setPage((page) => page + 1);
+    if (!isValidating && pagesNeeded > currentPage) {
+      setPage(Math.min(currentPage + pagesPerWave, pagesNeeded));
     }
-  }, [searchResults, currentPage, hasMore, setPage]);
+  }, [isValidating, pagesNeeded, currentPage, setPage]);
 
   const filteredResults = useMemo(() => {
     if (searchResults && filtersApplied) {

--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.component.tsx
@@ -51,7 +51,7 @@ const AdvancedPatientSearchComponent: React.FC<AdvancedPatientSearchProps> = ({
     isLoading,
     isValidating,
     fetchError,
-    totalResults,
+    totalResultsForQuery,
   } = useInfinitePatientSearch(query, includeDead, !!query, resultsPerPage);
 
   // The refine-search filters and the result count below both run over the rows held on the client,
@@ -61,13 +61,16 @@ const AdvancedPatientSearchComponent: React.FC<AdvancedPatientSearchProps> = ({
   // unreachable. Waiting on `isValidating` is what keeps a wave from being requested on top of the
   // one still in flight — `currentPage` advances as soon as the pages are asked for, not when they
   // land, so without it every wave would collapse back into a single burst.
-  const pagesNeeded = Math.ceil(totalResults / resultsPerPage);
+  const pagesNeeded = Math.ceil(totalResultsForQuery / resultsPerPage);
 
+  // A failed request also ends the wave, so stop on `fetchError`: the count that `pagesNeeded` is
+  // derived from survives the failure, and the loop would otherwise keep opening waves for a result
+  // set the user is no longer being shown.
   useEffect(() => {
-    if (!isValidating && pagesNeeded > currentPage) {
+    if (!fetchError && !isValidating && pagesNeeded > currentPage) {
       setPage(Math.min(currentPage + pagesPerWave, pagesNeeded));
     }
-  }, [isValidating, pagesNeeded, currentPage, setPage]);
+  }, [fetchError, isValidating, pagesNeeded, currentPage, setPage]);
 
   const filteredResults = useMemo(() => {
     if (searchResults && filtersApplied) {

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
@@ -35,14 +35,21 @@ const PatientSearchComponent: React.FC<PatientSearchComponentProps> = ({
 
   // `goTo` from `usePagination` is rebuilt whenever `totalPages` changes, and `totalPages` grows
   // as the infinite search appends server pages. Depending on `goTo` alone would therefore snap the
-  // user back to page 1 every time another page of results lands. Reset only on an actual new query.
+  // user back to page 1 every time another page of results lands.
+  //
+  // Reset on a new query, and whenever the selected page falls outside the result set: `usePagination`
+  // holds its page in state and only clamps inside `goTo`, so a refine filter — which narrows the rows
+  // on the client under an unchanged query — can leave the page pointing past the end, rendering the
+  // empty state under a non-zero result count.
   const previousQueryRef = useRef(query);
   useEffect(() => {
-    if (previousQueryRef.current !== query) {
-      previousQueryRef.current = query;
+    const queryChanged = previousQueryRef.current !== query;
+    previousQueryRef.current = query;
+
+    if (queryChanged || currentPage > totalPages) {
       goTo(1);
     }
-  }, [query, goTo]);
+  }, [query, currentPage, totalPages, goTo]);
 
   const searchResultsView = useMemo(() => {
     // Only show the full skeleton when there is nothing to show

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { usePagination } from '@openmrs/esm-framework';
@@ -33,8 +33,15 @@ const PatientSearchComponent: React.FC<PatientSearchComponentProps> = ({
     resultsToShow,
   );
 
+  // `goTo` from `usePagination` is rebuilt whenever `totalPages` changes, and `totalPages` grows
+  // as the infinite search appends server pages. Depending on `goTo` alone would therefore snap the
+  // user back to page 1 every time another page of results lands. Reset only on an actual new query.
+  const previousQueryRef = useRef(query);
   useEffect(() => {
-    goTo(1);
+    if (previousQueryRef.current !== query) {
+      previousQueryRef.current = query;
+      goTo(1);
+    }
   }, [query, goTo]);
 
   const searchResultsView = useMemo(() => {

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.test.tsx
@@ -55,4 +55,24 @@ describe('PatientSearchComponent pagination', () => {
 
     expect(firstShown()).toBe('p-0');
   });
+
+  it('resets to page 1 when a refine filter leaves the selected page out of range', async () => {
+    const user = userEvent.setup();
+    // 50 results at 20 per page => 3 client pages.
+    const { rerender } = render(
+      <PatientSearchComponent query="jos" searchResults={makeResults(50)} isLoading={false} fetchError={null} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '3' }));
+    expect(firstShown()).toBe('p-40');
+
+    // Refine-search filters run on the client under the same query, so only the row count changes.
+    // Page 3 no longer exists in a 10-row result set.
+    rerender(
+      <PatientSearchComponent query="jos" searchResults={makeResults(10)} isLoading={false} fetchError={null} />,
+    );
+
+    expect(screen.queryByTestId('empty')).not.toBeInTheDocument();
+    expect(firstShown()).toBe('p-0');
+  });
 });

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { vi, describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type SearchedPatient } from '../types';
+import PatientSearchComponent from './patient-search-lg.component';
+
+vi.mock('./patient-search-views.component', () => ({
+  EmptyState: () => <div data-testid="empty" />,
+  ErrorState: () => <div data-testid="error" />,
+  LoadingState: () => <div data-testid="loading" />,
+  PatientSearchResults: ({ searchResults }: { searchResults: Array<SearchedPatient> }) => (
+    <div data-testid="results">{searchResults.map((p) => p.uuid).join(',')}</div>
+  ),
+}));
+
+const makeResults = (count: number, offset = 0) =>
+  Array.from({ length: count }, (_, i) => ({ uuid: `p-${i + offset}`, person: {} })) as Array<SearchedPatient>;
+
+const firstShown = () => screen.getByTestId('results').textContent.split(',')[0];
+
+describe('PatientSearchComponent pagination', () => {
+  it('stays on the selected page when more server results are appended', async () => {
+    const user = userEvent.setup();
+    // 50 results at 20 per page (desktop) => 3 client pages
+    const { rerender } = render(
+      <PatientSearchComponent query="jos" searchResults={makeResults(50)} isLoading={false} fetchError={null} />,
+    );
+
+    expect(firstShown()).toBe('p-0');
+
+    await user.click(screen.getByRole('button', { name: '2' }));
+    expect(firstShown()).toBe('p-20');
+
+    // The eager prefetch in advanced-patient-search appends the next 50 server results.
+    rerender(
+      <PatientSearchComponent query="jos" searchResults={makeResults(100)} isLoading={false} fetchError={null} />,
+    );
+
+    expect(firstShown()).toBe('p-20');
+  });
+
+  it('resets to page 1 when the query changes', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <PatientSearchComponent query="jos" searchResults={makeResults(50)} isLoading={false} fetchError={null} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '2' }));
+    expect(firstShown()).toBe('p-20');
+
+    rerender(
+      <PatientSearchComponent query="mary" searchResults={makeResults(50)} isLoading={false} fetchError={null} />,
+    );
+
+    expect(firstShown()).toBe('p-0');
+  });
+});

--- a/packages/esm-patient-search-app/src/patient-search.resource.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.test.tsx
@@ -435,13 +435,31 @@ describe('useInfinitePatientSearch parallel paging', () => {
       wrapper: sharedCacheWrapper,
       initialProps: { q: 'Mary' },
     });
-    await waitFor(() => expect(result.current.totalResults).toBe(100));
+    await waitFor(() => expect(result.current.totalResultsForQuery).toBe(100));
 
     mockOpenmrsFetch.mockImplementation(() => new Promise(() => {}) as never);
     rerender({ q: 'Zebediah' });
     await settle();
 
     expect(result.current.data).toHaveLength(10); // the previous query's page 1, still on screen
-    expect(result.current.totalResults).toBe(0);
+    expect(result.current.totalResultsForQuery).toBe(0);
+  });
+
+  // The counterpart to the above: the rows held by `keepPreviousData` are still on screen, and
+  // `totalResults` is what a view prints above them. Reporting the incoming query's total here —
+  // zero until its first page lands — renders those patients under "0 search results".
+  it('keeps reporting the loaded result count while a new query is being fetched', async () => {
+    const { result, rerender } = renderHook(({ q }: { q: string }) => useInfinitePatientSearch(q, false), {
+      wrapper: sharedCacheWrapper,
+      initialProps: { q: 'Mary' },
+    });
+    await waitFor(() => expect(result.current.totalResults).toBe(100));
+
+    mockOpenmrsFetch.mockImplementation(() => new Promise(() => {}) as never);
+    rerender({ q: 'Zebediah' });
+    await settle();
+
+    expect(result.current.data).toHaveLength(10);
+    expect(result.current.totalResults).toBe(100);
   });
 });

--- a/packages/esm-patient-search-app/src/patient-search.resource.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.test.tsx
@@ -343,3 +343,105 @@ describe('useRestPatients', () => {
     expect(result.current.isLoading).toBe(false);
   });
 });
+
+// The advanced search needs the whole result set on the client for its filters and result count.
+// Walking it a page at a time cost a serialised round trip per page, so pages are fetched in
+// parallel instead. `parallel: true` stops SWR passing the previous page to `getKey`, so the end of
+// the result set is recognised from the total page 1 reports rather than from its `next` link.
+describe('useInfinitePatientSearch parallel paging', () => {
+  let cache: Map<string, unknown>;
+  let requestedUrls: Array<string>;
+  let inFlight: number;
+  let maxInFlight: number;
+
+  const sharedCacheWrapper = ({ children }: { children: React.ReactNode }) => (
+    <SWRConfig value={{ provider: () => cache as never, dedupingInterval: 0 }}>{children}</SWRConfig>
+  );
+
+  /** Serves `total` patients in pages of 10, resolving after a tick so overlap is observable. */
+  const respondWith = (total: number) =>
+    mockOpenmrsFetch.mockImplementation(async (url: string) => {
+      requestedUrls.push(url);
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+
+      const params = new URL(url, 'http://localhost').searchParams;
+      const startIndex = Number(params.get('startIndex') ?? 0);
+      const count = Math.max(0, Math.min(10, total - startIndex));
+
+      return {
+        data: {
+          results: Array.from({ length: count }, (_, i) => ({ uuid: `p-${startIndex + i}`, person: {} })),
+          links: total > startIndex + 10 ? [{ rel: 'next' }] : [],
+          totalCount: total,
+        },
+      } as unknown as FetchResponse;
+    });
+
+  const settle = () =>
+    act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    cache = new Map();
+    requestedUrls = [];
+    inFlight = 0;
+    maxInFlight = 0;
+    mockOpenmrsFetch.mockReset();
+    respondWith(100);
+  });
+
+  it('fetches the requested pages concurrently rather than one round trip at a time', async () => {
+    const { result } = renderHook(() => useInfinitePatientSearch('Mary', false), { wrapper: sharedCacheWrapper });
+    await waitFor(() => expect(result.current.totalResults).toBe(100));
+
+    requestedUrls = [];
+    maxInFlight = 0;
+    await act(async () => {
+      await result.current.setPage(10);
+    });
+    await settle();
+
+    expect(result.current.data).toHaveLength(100);
+    expect(requestedUrls).toHaveLength(9); // pages 2..10; page 1 is already cached
+    expect(maxInFlight).toBe(9);
+  });
+
+  it('does not request pages past the end of the result set', async () => {
+    respondWith(25);
+    const { result } = renderHook(() => useInfinitePatientSearch('Mary', false), { wrapper: sharedCacheWrapper });
+    await waitFor(() => expect(result.current.totalResults).toBe(25));
+
+    // Far more pages than exist: the guard, not the caller, has to stop the fetching.
+    await act(async () => {
+      await result.current.setPage(20);
+    });
+    await settle();
+
+    expect(requestedUrls).toHaveLength(3);
+    expect(result.current.data).toHaveLength(25);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  // `keepPreviousData` leaves the outgoing query's pages in `data`, so reading the total off
+  // `data[0]` reported the previous query's count. Callers size their page requests from it, which
+  // would make a narrow query fetch pages the new result set does not have.
+  it('reports no total for a query whose first page has not arrived yet', async () => {
+    const { result, rerender } = renderHook(({ q }: { q: string }) => useInfinitePatientSearch(q, false), {
+      wrapper: sharedCacheWrapper,
+      initialProps: { q: 'Mary' },
+    });
+    await waitFor(() => expect(result.current.totalResults).toBe(100));
+
+    mockOpenmrsFetch.mockImplementation(() => new Promise(() => {}) as never);
+    rerender({ q: 'Zebediah' });
+    await settle();
+
+    expect(result.current.data).toHaveLength(10); // the previous query's page 1, still on screen
+    expect(result.current.totalResults).toBe(0);
+  });
+});

--- a/packages/esm-patient-search-app/src/patient-search.resource.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.tsx
@@ -111,7 +111,8 @@ function useRevalidateFirstPageOnce<T>(firstPageUrl: string | null, mutate: SWRI
  *   - isValidating: Boolean indicating if new data is being loaded
  *   - setPage: Function to load the next page of results
  *   - currentPage: The current page number
- *   - totalResults: The total number of results for the search query
+ *   - totalResults: The number of results for the query the returned `data` belongs to
+ *   - totalResultsForQuery: The number of results for the query currently being searched for
  */
 export function useInfinitePatientSearch(
   searchQuery: string,
@@ -130,9 +131,10 @@ export function useInfinitePatientSearch(
         v: customRepresentation,
         includeDead: includeDead.toString(),
         limit: resultsToFetch.toString(),
-        // Only page 1's count is ever read (see `totalResults` below). `totalCount=true` makes the
-        // REST module run a separate count query, so asking for it on every appended page buys
-        // nothing and adds a second query to each round trip.
+        // Only page 1's count is ever read (see below), so only page 1 asks for it. This is about
+        // asking for what we use rather than about backend cost: the patient search handler hands
+        // back a `NeedsPaging`, whose count is the size of the list it has already built in memory,
+        // so `totalCount=true` does not make the REST module run a separate count query here.
         ...(page ? { startIndex: (page * resultsToFetch).toString() } : { totalCount: 'true' }),
       });
 
@@ -144,9 +146,9 @@ export function useInfinitePatientSearch(
   const shouldFetch = isSearching && Boolean(searchQuery);
   const firstPageUrl = shouldFetch ? buildUrl(0) : null;
 
-  // Read the total through the cache rather than off `data`: `keepPreviousData` leaves the outgoing
-  // query's pages in `data` while a new query loads, so `data[0]` would report the wrong query's
-  // total — and callers size their page requests from it.
+  // The count for the query being fetched, read through the cache rather than off `data`:
+  // `keepPreviousData` leaves the outgoing query's pages in `data` while a new query loads, so
+  // `data[0]` would report the wrong query's total — and callers size their page requests from it.
   const totalCount = firstPageUrl ? cache.get(firstPageUrl)?.data?.data?.totalCount : undefined;
 
   // Pages are fetched in parallel, so appending one costs a round trip rather than a round trip per
@@ -200,7 +202,11 @@ export function useInfinitePatientSearch(
       isValidating,
       setPage: setSize,
       currentPage: size,
-      totalResults: totalCount ?? 0,
+      // Describes the rows in `data`, which under `keepPreviousData` are the outgoing query's until
+      // the new first page lands — so a view can print this above the rows it is rendering without
+      // the count and the list disagreeing mid-query.
+      totalResults: shouldFetch ? (data?.[0]?.data?.totalCount ?? 0) : 0,
+      totalResultsForQuery: totalCount ?? 0,
     }),
     [shouldFetch, mappedData, isLoading, error, data, isValidating, setSize, size, totalCount],
   );
@@ -346,6 +352,9 @@ export function useRestPatients(
       setPage: setSize,
       currentPage: size,
       totalResults: patientUuids?.length ?? 0,
+      // This hook pages a list it already holds, so there is no in-flight query for the count to
+      // lag behind.
+      totalResultsForQuery: patientUuids?.length ?? 0,
     }),
     [mappedData, isLoading, error, patientUuids, size, isValidating, setSize],
   );

--- a/packages/esm-patient-search-app/src/patient-search.resource.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.tsx
@@ -120,23 +120,20 @@ export function useInfinitePatientSearch(
   resultsToFetch: number = 10,
   customRepresentation: string = patientSearchCustomRepresentation,
 ): PatientSearchResponse {
-  const getUrl = useCallback(
-    (
-      page: number,
-      prevPageData: FetchResponse<{ results: Array<SearchedPatient>; links: Array<{ rel: 'prev' | 'next' }> }>,
-    ) => {
-      if (prevPageData && !prevPageData?.data?.links.some((link) => link.rel === 'next')) {
-        return null;
-      }
+  const { cache } = useSWRConfig();
 
+  const buildUrl = useCallback(
+    (page: number) => {
       const baseUrl = `${restBaseUrl}/patient`;
       const params = new URLSearchParams({
         q: searchQuery,
         v: customRepresentation,
         includeDead: includeDead.toString(),
         limit: resultsToFetch.toString(),
-        totalCount: 'true',
-        ...(page ? { startIndex: (page * resultsToFetch).toString() } : {}),
+        // Only page 1's count is ever read (see `totalResults` below). `totalCount=true` makes the
+        // REST module run a separate count query, so asking for it on every appended page buys
+        // nothing and adds a second query to each round trip.
+        ...(page ? { startIndex: (page * resultsToFetch).toString() } : { totalCount: 'true' }),
       });
 
       return `${baseUrl}?${params.toString()}`;
@@ -145,6 +142,30 @@ export function useInfinitePatientSearch(
   );
 
   const shouldFetch = isSearching && Boolean(searchQuery);
+  const firstPageUrl = shouldFetch ? buildUrl(0) : null;
+
+  // Read the total through the cache rather than off `data`: `keepPreviousData` leaves the outgoing
+  // query's pages in `data` while a new query loads, so `data[0]` would report the wrong query's
+  // total — and callers size their page requests from it.
+  const totalCount = firstPageUrl ? cache.get(firstPageUrl)?.data?.data?.totalCount : undefined;
+
+  // Pages are fetched in parallel, so appending one costs a round trip rather than a round trip per
+  // page walked. The trade-off is that SWR no longer passes the previous page to `getKey`, so the
+  // end of the result set is recognised from the total page 1 reports instead of its `next` link.
+  // Until that total is known there is nothing to page through, so only page 1 is requested.
+  const getUrl = useCallback(
+    (page: number) => {
+      if (page > 0) {
+        const total = cache.get(buildUrl(0))?.data?.data?.totalCount;
+        if (total === undefined || page * resultsToFetch >= total) {
+          return null;
+        }
+      }
+
+      return buildUrl(page);
+    },
+    [buildUrl, cache, resultsToFetch],
+  );
 
   // Re-fetching page 1 on every page load would cost a round trip and replace the rendered rows'
   // objects, breaking the identity they memoize on. See `useRevalidateFirstPageOnce` for how the
@@ -152,9 +173,9 @@ export function useInfinitePatientSearch(
   const { data, isLoading, isValidating, setSize, error, size, mutate } = useSWRInfinite<
     InfinitePatientSearchResponse,
     Error
-  >(shouldFetch ? getUrl : null, fetcher, { keepPreviousData: true, revalidateFirstPage: false });
+  >(shouldFetch ? getUrl : null, fetcher, { keepPreviousData: true, revalidateFirstPage: false, parallel: true });
 
-  useRevalidateFirstPageOnce(shouldFetch ? getUrl(0, null) : null, mutate);
+  useRevalidateFirstPageOnce(firstPageUrl, mutate);
 
   // Filter out null patients and patients with null person property to prevent errors
   // when components access patient.person properties. This filtering happens at the source
@@ -179,9 +200,9 @@ export function useInfinitePatientSearch(
       isValidating,
       setPage: setSize,
       currentPage: size,
-      totalResults: shouldFetch ? (data?.[0]?.data?.totalCount ?? 0) : 0,
+      totalResults: totalCount ?? 0,
     }),
-    [shouldFetch, mappedData, isLoading, error, data, isValidating, setSize, size],
+    [shouldFetch, mappedData, isLoading, error, data, isValidating, setSize, size, totalCount],
   );
 }
 

--- a/packages/esm-patient-search-app/src/types/index.ts
+++ b/packages/esm-patient-search-app/src/types/index.ts
@@ -75,7 +75,10 @@ export interface PatientSearchResponse {
   isLoading: boolean;
   isValidating: boolean;
   setPage: (page: number | ((_page: number) => number)) => Promise<unknown[] | undefined>;
+  /** The number of results for the query that `data` belongs to. Use this to describe `data`. */
   totalResults: number;
+  /** The number of results for the query being searched for. Use this to size page requests. */
+  totalResultsForQuery: number;
 }
 
 export interface AdvancedPatientSearchState {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Fixes two problems in the advanced patient search. Follow up to #2702 

### Pagination reverted to page 1

Selecting page 2 would snap back to page 1 a moment later.

`usePagination` rebuilds `goTo` whenever `totalPages` changes, and the search page reset the page with `useEffect(() => goTo(1), [query, goTo])`. Because the search appends result pages in the background, `totalPages` kept growing, `goTo` kept getting a new identity and the effect kept firing. The reset now runs only when the query itself changes.

### Search was slow

The search loaded the entire result set 50 rows at a time, each request waiting on the previous one, before the first 20 rows settled. Measured with a probe against the old code: a 500-result query took **10 serialised round trips**; a 1700-result query took 34.

`useInfinitePatientSearch` now fetches pages with SWR's `parallel: true`, and the advanced search requests them in waves of 4 rather than walking the set one page at a time. A 1700-result query now costs **10 round trips instead of 34**, with at most 4 requests in flight.

Two smaller fixes:

- `totalCount=true` was sent on *every* page request, but only page 1's count is ever read, so now only page 1 asks for it. On this path the count is the size of the list the search handler already built in memory, so this doesn't save a backend query; it just asks for what we use.
- `totalResults` read the count from `data[0]`, which under `keepPreviousData` is the *outgoing* query's page so it reported the previous query's count during a query change. It now reads the count for the current query.

## Screenshots

Before

https://github.com/user-attachments/assets/2acbd5f4-db0c-4f49-9136-1fd9125e28c3

After

https://github.com/user-attachments/assets/654b49bc-8d40-4d11-8ba0-97614a127d82


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

