### PR TITLE
(test) O3-5851: Drive the visit summary Timeline tab in the queue entry spec

### DIFF
--- a/e2e/specs/queue-entry-visit-summary.spec.ts
+++ b/e2e/specs/queue-entry-visit-summary.spec.ts
@@ -56,24 +56,27 @@ test('Edit an encounter from the Previous visit tab of a queue entry', async ({ 
     await patientRow.getByRole('button', { name: /expand current row/i }).click();
   });
 
-  await test.step('And I open the Encounters tab of the Previous visit', async () => {
+  await test.step('And I open the Timeline tab of the Previous visit', async () => {
     await page.getByRole('tab', { name: /previous visit/i }).click();
-    await page.getByRole('tab', { name: /encounters/i }).click();
+    await page.getByRole('tab', { name: /timeline/i }).click();
   });
 
-  const encounters = page.getByLabel(/queue table/i).getByRole('table');
+  // Carbon names each tab panel after its tab, so this is the Timeline panel of the visible Previous visit
+  // tab; the Current visit tab's Timeline panel is hidden and stays out of the accessibility tree.
+  const timeline = page.getByRole('tabpanel', { name: /timeline/i });
 
   await test.step('Then I should see the encounter recorded on that visit', async () => {
-    await expect(encounters).toContainText(/visit note/i);
+    await expect(timeline).toContainText(/visit note/i);
   });
 
   await test.step('And then I expand that encounter', async () => {
-    await encounters.getByRole('button', { name: /expand current row/i }).click();
-    await expect(encounters).toContainText(/text of encounter note/i);
+    await timeline.getByRole('button', { name: /expand encounter/i }).click();
+    await expect(timeline).toContainText(/text of encounter note/i);
   });
 
   await test.step('When I choose "Edit this encounter"', async () => {
-    await encounters.getByRole('button', { name: /edit this encounter/i }).click();
+    await timeline.getByRole('button', { name: /options/i }).click();
+    await page.getByRole('menuitem', { name: /edit this encounter/i }).click();
   });
 
   await test.step('Then the visit note form opens on that encounter, with no extension erroring', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The queue entry visit summary spec has failed on every CI run since openmrs/openmrs-esm-patient-chart#3585 retired the visit summary Encounters tab: the spec's Encounters tab click times out. The encounters now live on the Timeline tab, which is selected by default and renders each encounter as a row with an expand button and an overflow menu.

This updates the spec to drive the Timeline tab instead. The assertions are scoped to the Timeline tab panel (Carbon names each tab panel after its tab, so the hidden Current visit panel stays out of the way), the encounter is expanded via its "Expand encounter" button, and "Edit this encounter" is reached through the row's overflow menu, whose trigger Carbon names "Options". The guarded behavior is unchanged: expanding the queue entry on the waiting list, opening the Previous visit tab, editing the visit note encounter through the Service Queues workspace, and asserting the form opens prefilled with the note text and no extension error boundary appears.

Verified against the e2e docker setup with the patient chart `next` build that includes the Timeline tab. Three repeated runs pass.

One caveat from local runs on a slow machine: if a queue entries refetch (the dashboard polls and revalidates on focus) lands mid test, `useOpenmrsFetchAll` briefly reports `isLoading` again, the waiting list swaps to its skeleton, and the expanded row collapses, which fails the spec. That window predates this change (the old spec had the same shape) and CI has not been hitting it. It is a real UX papercut though: a clinician's expanded row collapses whenever the dashboard refreshes.

## Screenshots

## Related Issue

https://openmrs.atlassian.net/browse/O3-5851

## Other

Failing run this fixes: https://github.com/openmrs/openmrs-esm-patient-management/actions/runs/33477029563
