### PR TITLE
(test) O3-5943: Update the visit summary timeline locator for the renamed overflow menu trigger

### DIFF
--- a/e2e/specs/queue-entry-visit-summary.spec.ts
+++ b/e2e/specs/queue-entry-visit-summary.spec.ts
@@ -75,7 +75,7 @@ test('Edit an encounter from the Previous visit tab of a queue entry', async ({ 
   });
 
   await test.step('When I choose "Edit this encounter"', async () => {
-    await timeline.getByRole('button', { name: /options/i }).click();
+    await timeline.getByRole('button', { name: /encounter table actions menu/i }).click();
     await page.getByRole('menuitem', { name: /edit this encounter/i }).click();
   });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

openmrs/openmrs-esm-patient-chart#3612 renamed the visit timeline overflow menu trigger's accessible name from "Options" (Carbon's `iconDescription` default) to "Encounter table actions menu". The queue entry visit summary spec still locates the trigger by the old name, so the click times out and every e2e run in this repo currently fails (see the run on #2712). This updates the locator to the new name.

## Screenshots

## Related Issue

https://openmrs.atlassian.net/browse/O3-5943

## Other
