### PR TITLE
(test) Assert the search paging tests through what the user sees

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search-paging.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search-paging.test.tsx
@@ -1,19 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The refine-search form submit does not fire its callback under happy-dom (see
+ * advanced-patient-search.test.tsx). Run this file under jsdom.
+ */
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { SWRConfig } from 'swr';
 import { type FetchResponse, getDefaultsFromConfigSchema, openmrsFetch, useConfig } from '@openmrs/esm-framework';
+import { type SearchedPatient } from '../types';
 import { configSchema } from '../config-schema';
 import { usePersonAttributeType } from './refine-search/person-attributes.resource';
 import AdvancedPatientSearchComponent from './advanced-patient-search.component';
 
 vi.mock('./refine-search/person-attributes.resource', () => ({ usePersonAttributeType: vi.fn() }));
-vi.mock('./patient-search-views.component', () => ({
-  EmptyState: () => <div data-testid="results" data-count="0" />,
-  ErrorState: () => <div data-testid="error" />,
-  LoadingState: () => <div />,
-  PatientSearchResults: ({ searchResults }: { searchResults: Array<unknown> }) => (
-    <div data-testid="results" data-count={searchResults.length} />
+
+// The framework mock hides the banner's contents, so render each result as its name. The other views are real.
+vi.mock('./patient-search-views.component', async () => ({
+  ...((await vi.importActual('./patient-search-views.component')) as object),
+  PatientSearchResults: ({ searchResults }: { searchResults: Array<SearchedPatient> }) => (
+    <>
+      {searchResults.map((patient) => (
+        <div key={patient.uuid}>{patient.person.personName.display}</div>
+      ))}
+    </>
   ),
 }));
 
@@ -30,19 +42,50 @@ const noRetryWrapper = ({ children }: { children: React.ReactNode }) => (
   </SWRConfig>
 );
 
-const startIndexesOf = (urls: Array<string>) =>
-  urls.map((url) => Number(new URL(url, 'http://localhost').searchParams.get('startIndex') ?? 0));
-
 // A big clinic's result set: far more pages than one wave, and not a whole number of pages.
 const TOTAL = 1700;
 const PAGE_SIZE = 50;
-// Mirrors `pagesPerWave` in the component: how many requests may be in flight together.
-const PAGES_PER_WAVE = 4;
+const TOTAL_PAGES = Math.ceil(TOTAL / PAGE_SIZE);
+
+// Every patient gets a unique postcode, so the refine filter can single out any one of them.
+const postcodeOf = (index: number) => `${10000 + index}`;
+
+const makePatient = (index: number) => ({
+  uuid: `p-${index}`,
+  person: {
+    personName: { display: `Patient ${index}` },
+    addresses: [{ postalCode: postcodeOf(index) }],
+  },
+});
 
 describe('advanced search paging for a large result set', () => {
   let requestedUrls: Array<string>;
   let inFlight: number;
   let maxInFlight: number;
+
+  /** Serves the result set a page at a time, resolving after a tick so overlap is observable. */
+  const respondWith = (failAtStartIndex?: number) =>
+    mockOpenmrsFetch.mockImplementation(async (url: string) => {
+      requestedUrls.push(url);
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+
+      const startIndex = Number(new URL(url, 'http://localhost').searchParams.get('startIndex') ?? 0);
+      if (startIndex === failAtStartIndex) {
+        throw new Error('page request failed');
+      }
+
+      const count = Math.max(0, Math.min(PAGE_SIZE, TOTAL - startIndex));
+      return {
+        data: {
+          results: Array.from({ length: count }, (_, i) => makePatient(startIndex + i)),
+          links: TOTAL > startIndex + PAGE_SIZE ? [{ rel: 'next' }] : [],
+          totalCount: TOTAL,
+        },
+      } as unknown as FetchResponse;
+    });
 
   beforeEach(() => {
     vi.useRealTimers();
@@ -53,36 +96,26 @@ describe('advanced search paging for a large result set', () => {
     vi.mocked(useConfig).mockReturnValue(getDefaultsFromConfigSchema(configSchema));
 
     mockOpenmrsFetch.mockReset();
-    mockOpenmrsFetch.mockImplementation(async (url: string) => {
-      requestedUrls.push(url);
-      inFlight++;
-      maxInFlight = Math.max(maxInFlight, inFlight);
-      await new Promise((r) => setTimeout(r, 5));
-      inFlight--;
-
-      const startIndex = Number(new URL(url, 'http://localhost').searchParams.get('startIndex') ?? 0);
-      const count = Math.max(0, Math.min(PAGE_SIZE, TOTAL - startIndex));
-
-      return {
-        data: {
-          results: Array.from({ length: count }, (_, i) => ({ uuid: `p-${startIndex + i}`, person: {} })),
-          links: TOTAL > startIndex + PAGE_SIZE ? [{ rel: 'next' }] : [],
-          totalCount: TOTAL,
-        },
-      } as unknown as FetchResponse;
-    });
+    respondWith();
   });
 
-  it('loads every page of a 1700-result query without leaving patients unreachable', async () => {
+  it('loads every page of a 1700-result query so a patient on the last page can be found', async () => {
+    const user = userEvent.setup();
     render(<AdvancedPatientSearchComponent query="jos" />, { wrapper });
 
-    // The header counts every row held on the client, so it is the loaded total — the rendered list
-    // only ever holds one page of it.
+    // The header counts every loaded row, not just the rendered page.
     await screen.findByRole('heading', { name: /1700 search result/i }, { timeout: 10000 });
 
     // Nothing truncated, and no page fetched twice.
-    expect(requestedUrls).toHaveLength(Math.ceil(TOTAL / PAGE_SIZE));
+    expect(requestedUrls).toHaveLength(TOTAL_PAGES);
     expect(new Set(requestedUrls).size).toBe(requestedUrls.length);
+
+    // The refine filter runs over the loaded rows, so this only finds the patient if the last page landed.
+    await user.type(screen.getByRole('textbox', { name: /postcode/i }), postcodeOf(TOTAL - 1));
+    await user.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(screen.getByRole('heading', { name: '1 search result' })).toBeInTheDocument();
+    expect(screen.getByText(`Patient ${TOTAL - 1}`)).toBeInTheDocument();
   });
 
   it('spreads the pages over bounded waves rather than one burst of requests', async () => {
@@ -90,43 +123,23 @@ describe('advanced search paging for a large result set', () => {
 
     await screen.findByRole('heading', { name: /1700 search result/i }, { timeout: 10000 });
 
-    expect(maxInFlight).toBeLessThanOrEqual(PAGES_PER_WAVE);
     expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThan(TOTAL_PAGES - 1);
   });
 
   it('stops opening waves once a page request fails', async () => {
     // Page 1 lands, so the loop knows there are 34 pages; a page in the first wave then fails.
-    mockOpenmrsFetch.mockImplementation(async (url: string) => {
-      requestedUrls.push(url);
-      inFlight++;
-      maxInFlight = Math.max(maxInFlight, inFlight);
-      await new Promise((r) => setTimeout(r, 5));
-      inFlight--;
-
-      const startIndex = Number(new URL(url, 'http://localhost').searchParams.get('startIndex') ?? 0);
-      if (startIndex === PAGE_SIZE) {
-        throw new Error('page request failed');
-      }
-
-      const count = Math.max(0, Math.min(PAGE_SIZE, TOTAL - startIndex));
-      return {
-        data: {
-          results: Array.from({ length: count }, (_, i) => ({ uuid: `p-${startIndex + i}`, person: {} })),
-          links: TOTAL > startIndex + PAGE_SIZE ? [{ rel: 'next' }] : [],
-          totalCount: TOTAL,
-        },
-      } as unknown as FetchResponse;
-    });
+    respondWith(PAGE_SIZE);
 
     render(<AdvancedPatientSearchComponent query="jos" />, { wrapper: noRetryWrapper });
 
-    await screen.findByTestId('error', undefined, { timeout: 10000 });
+    await screen.findByText(/sorry, there was an error/i, undefined, { timeout: 10000 });
+    const requestedByTheError = requestedUrls.length;
 
     // Give any further wave time to be opened, so this fails loudly if the loop keeps going.
     await new Promise((r) => setTimeout(r, 200));
 
-    // The first wave ends at this startIndex; a second wave would start one page past it.
-    expect(Math.max(...startIndexesOf(requestedUrls))).toBeLessThanOrEqual(PAGES_PER_WAVE * PAGE_SIZE);
-    expect(maxInFlight).toBeLessThanOrEqual(PAGES_PER_WAVE);
+    expect(requestedUrls).toHaveLength(requestedByTheError);
+    expect(requestedUrls.length).toBeLessThan(TOTAL_PAGES);
   });
 });

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.test.tsx
@@ -5,74 +5,73 @@ import userEvent from '@testing-library/user-event';
 import { type SearchedPatient } from '../types';
 import PatientSearchComponent from './patient-search-lg.component';
 
-vi.mock('./patient-search-views.component', () => ({
-  EmptyState: () => <div data-testid="empty" />,
-  ErrorState: () => <div data-testid="error" />,
-  LoadingState: () => <div data-testid="loading" />,
+// The framework mock hides the banner's contents, so render each result as its name. The other views are real.
+vi.mock('./patient-search-views.component', async () => ({
+  ...((await vi.importActual('./patient-search-views.component')) as object),
   PatientSearchResults: ({ searchResults }: { searchResults: Array<SearchedPatient> }) => (
-    <div data-testid="results">{searchResults.map((p) => p.uuid).join(',')}</div>
+    <>
+      {searchResults.map((patient) => (
+        <div key={patient.uuid}>{patient.person.personName.display}</div>
+      ))}
+    </>
   ),
 }));
 
-const makeResults = (count: number, offset = 0) =>
-  Array.from({ length: count }, (_, i) => ({ uuid: `p-${i + offset}`, person: {} })) as Array<SearchedPatient>;
+const makeResults = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    uuid: `p-${i}`,
+    person: { personName: { display: `Patient ${i}` } },
+  })) as Array<SearchedPatient>;
 
-const firstShown = () => screen.getByTestId('results').textContent.split(',')[0];
+const search = (searchResults: Array<SearchedPatient>, query = 'jos') => (
+  <PatientSearchComponent query={query} searchResults={searchResults} isLoading={false} fetchError={null} />
+);
 
 describe('PatientSearchComponent pagination', () => {
   it('stays on the selected page when more server results are appended', async () => {
     const user = userEvent.setup();
     // 50 results at 20 per page (desktop) => 3 client pages
-    const { rerender } = render(
-      <PatientSearchComponent query="jos" searchResults={makeResults(50)} isLoading={false} fetchError={null} />,
-    );
+    const { rerender } = render(search(makeResults(50)));
 
-    expect(firstShown()).toBe('p-0');
+    expect(screen.getByText('Patient 0')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: '2' }));
-    expect(firstShown()).toBe('p-20');
+    expect(screen.getByText('Patient 20')).toBeInTheDocument();
+    expect(screen.queryByText('Patient 0')).not.toBeInTheDocument();
 
     // The eager prefetch in advanced-patient-search appends the next 50 server results.
-    rerender(
-      <PatientSearchComponent query="jos" searchResults={makeResults(100)} isLoading={false} fetchError={null} />,
-    );
+    rerender(search(makeResults(100)));
 
-    expect(firstShown()).toBe('p-20');
+    expect(screen.getByRole('heading', { name: /100 search result/ })).toBeInTheDocument();
+    expect(screen.getByText('Patient 20')).toBeInTheDocument();
+    expect(screen.queryByText('Patient 0')).not.toBeInTheDocument();
   });
 
   it('resets to page 1 when the query changes', async () => {
     const user = userEvent.setup();
-    const { rerender } = render(
-      <PatientSearchComponent query="jos" searchResults={makeResults(50)} isLoading={false} fetchError={null} />,
-    );
+    const { rerender } = render(search(makeResults(50)));
 
     await user.click(screen.getByRole('button', { name: '2' }));
-    expect(firstShown()).toBe('p-20');
+    expect(screen.getByText('Patient 20')).toBeInTheDocument();
 
-    rerender(
-      <PatientSearchComponent query="mary" searchResults={makeResults(50)} isLoading={false} fetchError={null} />,
-    );
+    rerender(search(makeResults(50), 'mary'));
 
-    expect(firstShown()).toBe('p-0');
+    expect(screen.getByText('Patient 0')).toBeInTheDocument();
+    expect(screen.queryByText('Patient 20')).not.toBeInTheDocument();
   });
 
   it('resets to page 1 when a refine filter leaves the selected page out of range', async () => {
     const user = userEvent.setup();
-    // 50 results at 20 per page => 3 client pages.
-    const { rerender } = render(
-      <PatientSearchComponent query="jos" searchResults={makeResults(50)} isLoading={false} fetchError={null} />,
-    );
+    const { rerender } = render(search(makeResults(50)));
 
     await user.click(screen.getByRole('button', { name: '3' }));
-    expect(firstShown()).toBe('p-40');
+    expect(screen.getByText('Patient 40')).toBeInTheDocument();
 
-    // Refine-search filters run on the client under the same query, so only the row count changes.
-    // Page 3 no longer exists in a 10-row result set.
-    rerender(
-      <PatientSearchComponent query="jos" searchResults={makeResults(10)} isLoading={false} fetchError={null} />,
-    );
+    // A refine filter narrows the rows under the same query. Page 3 no longer exists in 10 rows.
+    rerender(search(makeResults(10)));
 
-    expect(screen.queryByTestId('empty')).not.toBeInTheDocument();
-    expect(firstShown()).toBe('p-0');
+    expect(screen.getByRole('heading', { name: /10 search result/ })).toBeInTheDocument();
+    expect(screen.queryByText(/no patient charts were found/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Patient 0')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Follow up to #2708. The paging tests it added stub the result views and then assert through the stubs: which uuid slice got passed to `PatientSearchResults`, and test ids for the empty and error states. This reworks them so the assertions read what a user would see.

- The stub for `PatientSearchResults` now renders each patient's name, and the empty, error and loading states are the real components. Assertions are `getByText('Patient 20')` and the real "Sorry, no patient charts were found" and error copy. The stub stays because the framework mock hides the banner's contents, so a real banner can't show a name in tests.
- The 1700-result test now proves the last page is reachable the way a user would: filter by a postcode only the last patient has and expect that patient. Before, it only counted requests.
- The wave and error tests no longer copy `pagesPerWave` from the component, so tuning it doesn't break them. The wave test bounds concurrency between one page and the whole set, and the error test asserts no request follows the error state.
- The paging file runs under jsdom, same as `advanced-patient-search.test.tsx` and for the same reason: the refine-search form submit doesn't fire under happy-dom.

No behaviour changes. The paging file takes roughly 200ms longer, mostly the filter step and jsdom.

## Screenshots

## Related Issue

## Other
