### PR TITLE
(fix) Match the birthdate filters against the stored date and trim the postcode filter

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.component.tsx
@@ -23,6 +23,20 @@ const resultsPerPage = 50;
  */
 const pagesPerWave = 4;
 
+/**
+ * Reads the calendar date off a REST birthdate. The backend serialises birthdates as midnight in
+ * its own timezone (for example `1940-01-01T00:00:00.000+0000`), so parsing them with `Date` would
+ * shift the day, month and year for a browser in a different timezone, and would turn a missing
+ * birthdate into 1 January 1970.
+ */
+function parseBirthdate(birthdate: string | null | undefined) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(birthdate ?? '');
+  if (!match) {
+    return null;
+  }
+  return { year: Number(match[1]), month: Number(match[2]), day: Number(match[3]) };
+}
+
 interface AdvancedPatientSearchProps {
   query: string;
   inTabletOrOverlay?: boolean;
@@ -95,24 +109,19 @@ const AdvancedPatientSearchComponent: React.FC<AdvancedPatientSearchProps> = ({
           }
         }
 
-        // Date of birth filters
-        if (filters.dateOfBirth) {
-          const dayOfBirth = new Date(patient.person.birthdate).getDate();
-          if (dayOfBirth !== filters.dateOfBirth) {
+        // Date of birth filters. A patient with no recorded birthdate cannot match any of them.
+        if (filters.dateOfBirth || filters.monthOfBirth || filters.yearOfBirth) {
+          const birthdate = parseBirthdate(patient.person.birthdate);
+          if (!birthdate) {
             return false;
           }
-        }
-
-        if (filters.monthOfBirth) {
-          const monthOfBirth = new Date(patient.person.birthdate).getMonth() + 1;
-          if (monthOfBirth !== filters.monthOfBirth) {
+          if (filters.dateOfBirth && birthdate.day !== filters.dateOfBirth) {
             return false;
           }
-        }
-
-        if (filters.yearOfBirth) {
-          const yearOfBirth = new Date(patient.person.birthdate).getFullYear();
-          if (yearOfBirth !== filters.yearOfBirth) {
+          if (filters.monthOfBirth && birthdate.month !== filters.monthOfBirth) {
+            return false;
+          }
+          if (filters.yearOfBirth && birthdate.year !== filters.yearOfBirth) {
             return false;
           }
         }

--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.test.tsx
@@ -164,6 +164,52 @@ describe('AdvancedPatientSearchComponent', () => {
       // expect(within(patientBanners[0]).getByText(/Joseph Davis/i)).toBeInTheDocument();
     });
 
+    it('does not match a patient without a birthdate to a date of birth filter', async () => {
+      const [patient] = mockAdvancedSearchResults;
+      mockUseInfinitePatientSearch.mockReturnValue({
+        ...mockSearchResults,
+        data: [
+          { ...patient, person: { ...patient.person, birthdate: null, age: null } },
+        ] as unknown as PatientSearchResponse['data'],
+      });
+      renderComponent();
+
+      await user.type(screen.getByRole('spinbutton', { name: /day of birth/i }), '1');
+      await user.type(screen.getByRole('spinbutton', { name: /month of birth/i }), '1');
+      await user.type(screen.getByRole('spinbutton', { name: /year of birth/i }), '1970');
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(screen.getByText(/0 search result/)).toBeInTheDocument();
+    });
+
+    it('matches the date of birth as stored, whatever timezone the backend serialised it in', async () => {
+      // Tests run in UTC, where `new Date` would read this birthdate as 31 December 1939.
+      const [patient] = mockAdvancedSearchResults;
+      mockUseInfinitePatientSearch.mockReturnValue({
+        ...mockSearchResults,
+        data: [
+          { ...patient, person: { ...patient.person, birthdate: '1940-01-01T00:00:00.000+0300' } },
+        ] as unknown as PatientSearchResponse['data'],
+      });
+      renderComponent();
+
+      await user.type(screen.getByRole('spinbutton', { name: /day of birth/i }), '1');
+      await user.type(screen.getByRole('spinbutton', { name: /month of birth/i }), '1');
+      await user.type(screen.getByRole('spinbutton', { name: /year of birth/i }), '1940');
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(screen.getByText(/1 search result/)).toBeInTheDocument();
+    });
+
+    it('ignores surrounding whitespace in the postcode filter', async () => {
+      renderComponent();
+
+      await user.type(screen.getByRole('textbox', { name: /postcode/i }), ' 20839 ');
+      await user.click(screen.getByRole('button', { name: /apply/i }));
+
+      expect(screen.getByText(/1 search result/)).toBeInTheDocument();
+    });
+
     it('filters by person attribute correctly', async () => {
       renderComponent();
 

--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.component.tsx
@@ -50,7 +50,7 @@ const RefineSearch: React.FC<RefineSearchProps> = ({ setFilters, inTabletOrOverl
 
   const onSubmit = useCallback(
     (data: AdvancedPatientSearchState) => {
-      setFilters(data);
+      setFilters({ ...data, postcode: data.postcode.trim() });
       setShowRefineSearchDialog(false);
     },
     [setFilters],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR applies two fixes to how the refine search filters match patients.

The date of birth filters parsed each patient's birthdate with `new Date` and read the local day, month and year. The backend serialises birthdates as midnight in its own timezone (`1940-01-01T00:00:00.000+0000`), so in a browser west of that timezone every patient shifts to the previous day and misses the filters, and a patient with no recorded birthdate parses as 1 January 1970 and matches filters for that date. The filters now read the calendar date off the string, and a patient without a birthdate matches no date of birth filter.

The postcode filter compared the typed value exactly, so a stray leading or trailing space matched nothing. It's trimmed when the filters are applied, which also keeps the applied-filter count honest for a whitespace-only value.

Tests cover a null birthdate against a 1 January 1970 filter, a birthdate serialised with a non-UTC offset (the suite runs in UTC, where `new Date` reads it as the previous day), and a padded postcode.

## Screenshots

### Filtering on day 1, month 1, year 1970 with a patient who has no recorded birthdate.

#### Before

<img width="1280" height="720" alt="dob1970filterbefore" src="https://github.com/user-attachments/assets/8580ee3b-71a6-4c98-9264-0e1b53f78859" />

#### After
<img width="1280" height="720" alt="dob1970filterafter" src="https://github.com/user-attachments/assets/2e334d1c-c617-4d09-89f2-93fa62d5a79e" />

### Postcode filter with a trailing space.

#### Before
<img width="1280" height="720" alt="postcodetrailingspacebefore" src="https://github.com/user-attachments/assets/7558402c-6400-4024-a697-90ce1891e25e" />

#### After
<img width="1280" height="720" alt="postcodetrailingspaceafter" src="https://github.com/user-attachments/assets/ca18217f-9525-4b9a-920a-ebb9d0648592" />

## Related Issue

## Other
