### PR TITLE
(fix) Keep the header search input in step with the query in the URL

### DIFF
--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.component.tsx
@@ -33,6 +33,12 @@ const CompactPatientSearchComponent: React.FC<CompactPatientSearchProps> = ({
 
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const debouncedSearchTerm = useDebounce(searchTerm);
+
+  // On the search page the term comes from the URL, so follow it when the route changes (a browser
+  // back or forward, or a link to another query) rather than reading it once on mount.
+  useEffect(() => {
+    setSearchTerm(initialSearchTerm ?? '');
+  }, [initialSearchTerm]);
   const hasSearchTerm = Boolean(debouncedSearchTerm?.trim());
 
   const config = useConfig<PatientSearchConfig>();

--- a/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/compact-patient-search/compact-patient-search.test.tsx
@@ -7,7 +7,8 @@
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { getDefaultsFromConfigSchema, navigate, useConfig, useSession } from '@openmrs/esm-framework';
 import { renderWithRouter } from 'tools';
 import { mockSession } from '__mocks__';
@@ -71,6 +72,17 @@ describe('CompactPatientSearchComponent', () => {
     renderWithRouter(<CompactPatientSearchComponent isSearchPage={false} initialSearchTerm="" />);
 
     expect(screen.getByPlaceholderText(/Search for a patient by name or identifier number/i)).toBeInTheDocument();
+  });
+
+  it('follows the search term from the URL when it changes on the search page', () => {
+    const { rerender } = render(<CompactPatientSearchComponent isSearchPage initialSearchTerm="John" />, {
+      wrapper: MemoryRouter,
+    });
+    expect(screen.getByRole('searchbox')).toHaveValue('John');
+
+    // A browser back or forward changes the query in the URL without remounting the header.
+    rerender(<CompactPatientSearchComponent isSearchPage initialSearchTerm="Mary" />);
+    expect(screen.getByRole('searchbox')).toHaveValue('Mary');
   });
 
   it('renders search results when search term is not empty', async () => {

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Search } from '@carbon/react';
 import styles from './patient-search-bar.scss';
@@ -17,6 +17,11 @@ const PatientSearchBar = React.forwardRef<HTMLInputElement, React.PropsWithChild
     const { t } = useTranslation();
     const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
     const responsiveSize = isCompact ? 'sm' : 'lg';
+
+    // Keep the field in step with a term supplied from outside, such as the query in the URL.
+    useEffect(() => {
+      setSearchTerm(initialSearchTerm);
+    }, [initialSearchTerm]);
 
     const handleChange = useCallback(
       (value: string) => {

--- a/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-bar/patient-search-bar.test.tsx
@@ -30,6 +30,14 @@ describe('PatientSearchBar', () => {
     expect(searchInput.value).toBe(initialSearchTerm);
   });
 
+  it('updates the field when the initial search term changes', () => {
+    const { rerender } = render(<PatientSearchBar initialSearchTerm="John" onClear={vi.fn()} onSubmit={vi.fn()} />);
+    expect(screen.getByRole('searchbox')).toHaveValue('John');
+
+    rerender(<PatientSearchBar initialSearchTerm="Mary" onClear={vi.fn()} onSubmit={vi.fn()} />);
+    expect(screen.getByRole('searchbox')).toHaveValue('Mary');
+  });
+
   it('calls the onChange callback on input change', async () => {
     const user = userEvent.setup();
     const onChangeMock = vi.fn();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

On the search page the header search input is seeded from the query in the URL, but only once, when it mounts. A browser back or forward, or a link to another query, changes the results and the heading while the input keeps showing the previous term. The compact search and the search bar now follow the term they're given whenever it changes.

Repro on main: search for one term, then another, then press the browser back button. The results go back to the first term while the input still shows the second.

## Screenshots

### After searching `mi`, then `10`, then pressing browser back. The results are for `mi`.

#### Before
<img width="1280" height="720" alt="headerinputafterbackbefore" src="https://github.com/user-attachments/assets/9e08eac6-2402-4edc-b71e-cb013f720663" />

#### After
<img width="1280" height="720" alt="headerinputafterbackafter" src="https://github.com/user-attachments/assets/2d57d711-8cab-4725-8216-315732275254" />

## Related Issue

## Other
