### PR TITLE
(fix) Apply the configured age bounds to the refine search age field

### DIFF
--- a/packages/esm-patient-search-app/src/config-schema.ts
+++ b/packages/esm-patient-search-app/src/config-schema.ts
@@ -51,7 +51,7 @@ export const configSchema = {
         max: {
           _type: Type.Number,
           _default: 0,
-          _description: 'The maximum value for the age field',
+          _description: 'The maximum value for the age field. 0 means no maximum.',
         },
       },
       postcode: {

--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search-tablet.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search-tablet.component.tsx
@@ -41,9 +41,13 @@ export const RefineSearchTablet: React.FC<RefineSearchTabletProps> = ({
 
     Object.entries(config.search.searchFilterFields).forEach(([fieldName, fieldConfig]) => {
       if (fieldName !== 'personAttributes' && (fieldConfig as BuiltInFieldConfig).enabled) {
+        const { min, max } = fieldConfig as BuiltInFieldConfig;
         fields.push({
           name: fieldName,
           type: fieldName as SearchFieldType,
+          ...(min !== undefined ? { min } : {}),
+          // A configured maximum of 0 means no maximum: Carbon marks any value above `max` invalid.
+          ...(max ? { max } : {}),
         });
       }
     });

--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.component.tsx
@@ -70,9 +70,13 @@ const RefineSearch: React.FC<RefineSearchProps> = ({ setFilters, inTabletOrOverl
 
     Object.entries(config.search.searchFilterFields).forEach(([fieldName, fieldConfig]) => {
       if (fieldName !== 'personAttributes' && (fieldConfig as BuiltInFieldConfig).enabled) {
+        const { min, max } = fieldConfig as BuiltInFieldConfig;
         fields.push({
           name: fieldName,
           type: fieldName as SearchFieldType,
+          ...(min !== undefined ? { min } : {}),
+          // A configured maximum of 0 means no maximum: Carbon marks any value above `max` invalid.
+          ...(max ? { max } : {}),
         });
       }
     });

--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.test.tsx
@@ -134,13 +134,16 @@ describe('RefineSearch', () => {
         },
       } as PatientSearchConfig);
 
-    it('applies the configured minimum and maximum to the age field', () => {
+    it('applies the configured minimum and maximum to the age field', async () => {
       withAgeConfig({ enabled: true, min: 18, max: 65 });
       renderComponent();
 
       const ageInput = screen.getByRole('spinbutton', { name: /age/i });
       expect(ageInput).toHaveAttribute('min', '18');
       expect(ageInput).toHaveAttribute('max', '65');
+
+      await user.type(ageInput, '70');
+      expect(screen.getByText('Enter an age between 18 and 65')).toBeInTheDocument();
     });
 
     it('leaves the age field unbounded above when the maximum is 0', () => {

--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search/refine-search.test.tsx
@@ -124,6 +124,47 @@ describe('RefineSearch', () => {
     );
   });
 
+  describe('Age field bounds', () => {
+    const withAgeConfig = (age: { enabled: boolean; min?: number; max?: number }) =>
+      mockUseConfig.mockReturnValue({
+        ...mockConfig,
+        search: {
+          ...mockConfig.search,
+          searchFilterFields: { ...mockConfig.search.searchFilterFields, age },
+        },
+      } as PatientSearchConfig);
+
+    it('applies the configured minimum and maximum to the age field', () => {
+      withAgeConfig({ enabled: true, min: 18, max: 65 });
+      renderComponent();
+
+      const ageInput = screen.getByRole('spinbutton', { name: /age/i });
+      expect(ageInput).toHaveAttribute('min', '18');
+      expect(ageInput).toHaveAttribute('max', '65');
+    });
+
+    it('leaves the age field unbounded above when the maximum is 0', () => {
+      withAgeConfig({ enabled: true, min: 0, max: 0 });
+      renderComponent();
+
+      const ageInput = screen.getByRole('spinbutton', { name: /age/i });
+      expect(ageInput).toHaveAttribute('min', '0');
+      expect(ageInput).not.toHaveAttribute('max');
+    });
+
+    it('applies the configured bounds in the tablet dialog too', async () => {
+      withAgeConfig({ enabled: true, min: 18, max: 65 });
+      mockUseLayoutType.mockReturnValue('tablet');
+      renderComponent({ inTabletOrOverlay: true });
+
+      await user.click(screen.getByRole('button', { name: /refine search/i }));
+
+      const ageInput = screen.getByRole('spinbutton', { name: /age/i });
+      expect(ageInput).toHaveAttribute('min', '18');
+      expect(ageInput).toHaveAttribute('max', '65');
+    });
+  });
+
   describe('Layout rendering', () => {
     it('renders desktop layout by default', () => {
       renderComponent();

--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search/search-field.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search/search-field.component.tsx
@@ -135,6 +135,14 @@ export const SearchField: React.FC<SearchFieldProps> = ({ field, control, inTabl
                 label={t('age', 'Age')}
                 min={field.min}
                 max={field.max}
+                invalidText={
+                  field.max
+                    ? t('ageOutOfRange', 'Enter an age between {{min}} and {{max}}', {
+                        min: field.min ?? 0,
+                        max: field.max,
+                      })
+                    : t('ageBelowMinimum', 'Enter an age of at least {{min}}', { min: field.min ?? 0 })
+                }
                 allowEmpty
                 hideSteppers
                 size={isTablet ? 'lg' : 'md'}

--- a/packages/esm-patient-search-app/translations/en.json
+++ b/packages/esm-patient-search-app/translations/en.json
@@ -1,5 +1,7 @@
 {
   "age": "Age",
+  "ageBelowMinimum": "Enter an age of at least {{min}}",
+  "ageOutOfRange": "Enter an age between {{min}} and {{max}}",
   "any": "Any",
   "apply": "Apply",
   "clear": "Clear",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The config schema has offered `searchFilterFields.age.min` and `max` since the person attribute filters landed in #1362, and the age field reads them, but neither field builder ever passed them through. The built-in fields were created with only a name and a type, so setting the values did nothing. Both the desktop panel and the tablet dialog now hand the configured bounds to the field.

A maximum of 0, the schema default, means no maximum. Carbon marks any value above `max` invalid, so passing 0 through would have flagged every age. The schema description says so now.

Carbon only draws the invalid border and icon for a value outside the bounds, so the field now also says which range is allowed: "Enter an age between 18 and 65", or "Enter an age of at least 0" when no maximum is set. Two new strings for Transifex: `ageOutOfRange` and `ageBelowMinimum`.

Tests cover configured bounds on desktop and in the tablet dialog, the unbounded default, and the message for an out-of-range value.

For context, the implementer configs I could find on GitHub (MSF's LIME-EMR base and site configs, CRUDEM's Ozone HSC) all set `age.min: 0` and none set `max`, so today's practical effect is that a negative age gets flagged for them.

## Screenshots

### Age 70 typed with `searchFilterFields.age` configured as `min: 18, max: 65`.

#### Before
<img width="1280" height="720" alt="age70withmax65before" src="https://github.com/user-attachments/assets/c6ad6cdd-5ecf-46ba-a7b5-c49e858ee0d5" />

#### After
<img width="1280" height="720" alt="age70withmax65after" src="https://github.com/user-attachments/assets/42e47cba-8875-4767-9046-ec1dc68dd587" />

## Related Issue

## Other
