### PR TITLE
(fix) O3-5917: Keep newly added relationship rows correctly associated

### DIFF
--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.types.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.types.ts
@@ -153,6 +153,11 @@ export interface RelationshipValue {
    */
   initialrelationshipTypeValue?: string;
   uuid?: string;
+  /**
+   * Client-side identifier for a relationship that has not been saved yet.
+   * Used as a stable React key until the server assigns a uuid. Never sent to the server.
+   */
+  clientId?: string;
 }
 
 export interface FormValues {

--- a/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships-section.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships-section.component.tsx
@@ -3,6 +3,7 @@ import { ActionableNotification, Button, Layer, Select, SelectItem, SkeletonText
 import { TrashCan } from '@carbon/react/icons';
 import { FieldArray } from 'formik';
 import { useTranslation } from 'react-i18next';
+import { v4 } from 'uuid';
 import { Autosuggest } from '../../input/custom-input/autosuggest/autosuggest.component';
 import { usePatientRegistrationContext } from '../../patient-registration-context';
 import { fetchPerson } from '../../patient-registration.resource';
@@ -120,7 +121,7 @@ const RelationshipView: React.FC<RelationshipViewProps> = ({
             labelText={t('relationship', 'Relationship')}
             onChange={handleRelationshipTypeChange}
             name={`relationships[${index}].relationshipType`}
-            defaultValue={relationship?.relationshipType ?? 'placeholder-item'}>
+            value={relationship.relationshipType || 'placeholder-item'}>
             <SelectItem
               disabled
               hidden
@@ -203,7 +204,7 @@ export const RelationshipsSection = () => {
             {relationships && relationships.length > 0
               ? relationships.map((relationship: RelationshipValue, index) => {
                   return (
-                    <div key={relationship.uuid} className={sectionStyles.formSection}>
+                    <div key={relationship.uuid ?? relationship.clientId} className={sectionStyles.formSection}>
                       <RelationshipView
                         relationship={relationship}
                         index={index}
@@ -219,6 +220,7 @@ export const RelationshipsSection = () => {
                 kind="ghost"
                 onClick={() =>
                   push({
+                    clientId: v4(),
                     relatedPersonUuid: '',
                     action: 'ADD',
                   })

--- a/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships-section.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships-section.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { vi, describe, it, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
 import { Form, Formik } from 'formik';
@@ -12,14 +12,10 @@ import { renderWithContext } from 'tools';
 import { initialFormValues } from '../../patient-registration.component';
 
 vi.mock('../../patient-registration.resource', () => ({
-  fetchPerson: vi.fn().mockResolvedValue({
-    data: {
-      results: [
-        { uuid: '42ae5ce0-d64b-11ea-9064-5adc43bbdd24', display: 'Person 1' },
-        { uuid: '691eed12-c0f1-11e2-94be-8c13b969e334', display: 'Person 2' },
-      ],
-    },
-  }),
+  fetchPerson: vi.fn().mockResolvedValue([
+    { uuid: '42ae5ce0-d64b-11ea-9064-5adc43bbdd24', display: 'Person 1' },
+    { uuid: '691eed12-c0f1-11e2-94be-8c13b969e334', display: 'Person 2' },
+  ]),
 }));
 
 const mockRelationshipTypes = {
@@ -92,6 +88,18 @@ function renderRelationshipsSectionWithFormik(
 }
 
 describe('RelationshipsSection', () => {
+  let consoleErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error');
+  });
+
+  afterEach(() => {
+    const keyWarnings = consoleErrorSpy.mock.calls.filter((call) => String(call[0]).includes('unique "key" prop'));
+    consoleErrorSpy.mockRestore();
+    expect(keyWarnings).toHaveLength(0);
+  });
+
   describe('Loading state', () => {
     it('renders a loader when relationshipTypes are not available', () => {
       const mockResourcesContextValue = {
@@ -148,6 +156,7 @@ describe('RelationshipsSection', () => {
         {
           relationships: [
             {
+              clientId: 'new-relationship-1',
               action: 'ADD',
               relatedPersonUuid: '11524ae7-3ef6-4ab6-aff6-804ffc58704a',
               relatedPersonName: 'John Doe',
@@ -178,7 +187,9 @@ describe('RelationshipsSection', () => {
 
       renderRelationshipsSectionWithFormik(
         {
-          relationships: [{ action: 'ADD', relatedPersonUuid: '', relationshipType: '' }],
+          relationships: [
+            { clientId: 'new-relationship-1', action: 'ADD', relatedPersonUuid: '', relationshipType: '' },
+          ],
         },
         mockResourcesContextValue,
       );
@@ -240,7 +251,13 @@ describe('RelationshipsSection', () => {
       const { getFormValues } = renderRelationshipsSectionWithFormik(
         {
           relationships: [
-            { action: 'ADD', relatedPersonUuid: 'test-uuid', relatedPersonName: 'Test Person', relationshipType: '' },
+            {
+              clientId: 'new-relationship-1',
+              action: 'ADD',
+              relatedPersonUuid: 'test-uuid',
+              relatedPersonName: 'Test Person',
+              relationshipType: '',
+            },
           ],
         },
         mockResourcesContextValue,
@@ -302,6 +319,63 @@ describe('RelationshipsSection', () => {
       await waitFor(() => {
         expect(screen.getByText(/relationship removed/i)).toBeInTheDocument();
       });
+    });
+
+    it('keeps the remaining new relationship row associated with its own values when another row is removed', async () => {
+      const user = userEvent.setup();
+      const person1Uuid = '42ae5ce0-d64b-11ea-9064-5adc43bbdd24';
+      const person2Uuid = '691eed12-c0f1-11e2-94be-8c13b969e334';
+      const motherValue = '42ae5ce0-d64b-11ea-9064-5adc43bbdd34/aIsToB';
+      const fatherValue = '52ae5ce0-d64b-11ea-9064-5adc43bbdd24/aIsToB';
+      const mockResourcesContextValue = {
+        addressTemplate: null,
+        currentSession: {
+          authenticated: true,
+          sessionId: 'JSESSION',
+          currentProvider: { uuid: '45ce6c2e-dd5a-11e6-9d9c-0242ac150002', identifier: 'PRO-123' },
+        },
+        identifierTypes: [],
+        relationshipTypes: mockRelationshipTypes,
+      } as Resources;
+
+      const { getFormValues } = renderRelationshipsSectionWithFormik({}, mockResourcesContextValue);
+
+      const addButton = screen.getByRole('button', { name: /add relationship/i });
+      await user.click(addButton);
+      await user.click(addButton);
+
+      const searchboxes = screen.getAllByRole('searchbox', { name: /full name/i });
+      const selects = screen.getAllByRole('combobox', { name: /relationship/i });
+      expect(searchboxes).toHaveLength(2);
+      expect(selects).toHaveLength(2);
+
+      await user.type(searchboxes[0], 'Person');
+      await user.click(await screen.findByText('Person 1'));
+      await user.selectOptions(selects[0], motherValue);
+
+      await user.type(searchboxes[1], 'Person');
+      await user.click(await screen.findByText('Person 2'));
+      await user.selectOptions(selects[1], fatherValue);
+
+      await waitFor(() => {
+        const { relationships } = getFormValues();
+        expect(relationships[0]).toMatchObject({ relatedPersonUuid: person1Uuid, relationshipType: motherValue });
+        expect(relationships[1]).toMatchObject({ relatedPersonUuid: person2Uuid, relationshipType: fatherValue });
+      });
+
+      await user.click(screen.getAllByRole('button', { name: /delete/i })[0]);
+
+      await waitFor(() => {
+        const { relationships } = getFormValues();
+        expect(relationships).toHaveLength(1);
+        expect(relationships[0]).toMatchObject({
+          action: 'ADD',
+          relatedPersonUuid: person2Uuid,
+          relationshipType: fatherValue,
+        });
+      });
+      expect(screen.getByRole('searchbox', { name: /full name/i })).toHaveValue('Person 2');
+      expect(screen.getByRole('combobox', { name: /relationship/i })).toHaveValue(fatherValue);
     });
   });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

New relationship rows don't have a server uuid, so after #2383 switched the row keys from the index to the uuid, every new row shared the same undefined key and React reconciled them by position. The relationship type select was also uncontrolled, so removing one of two new rows left the surviving row showing the removed row's person and type while Formik held the other row's values.

This gives each new relationship a client-side id when it's pushed, keys the rows on the server uuid or that id, and makes the select controlled by its Formik value. The id never reaches the server since `saveRelationships` only picks the fields it needs.

The section test's `fetchPerson` mock returned a response object where the real function returns an array, so nothing could exercise the person search. Fixed that, added an interaction test that fills two rows, removes the first and checks the second, and made the file fail if any test logs a React key warning.

## Screenshots

Both runs enter Joshua Johnson / Doctor in row 1 and Richard Jones / Patient (Doctor) in row 2, then delete row 1.

### Before: the surviving row still shows Joshua Johnson / Doctor.

<img width="1280" height="900" alt="before1tworows" src="https://github.com/user-attachments/assets/e14b9977-2d45-4635-adc9-4137b6be73d1" />

<img width="1280" height="900" alt="before2afterremovingfirstrow" src="https://github.com/user-attachments/assets/b6d218d8-5ecd-48e9-b30f-298ac101504a" />

### After: it shows Richard Jones / Patient (Doctor).

<img width="1280" height="900" alt="after1tworows" src="https://github.com/user-attachments/assets/d31763ee-55a2-4c08-a009-4f5ed523c3dd" />

<img width="1280" height="900" alt="after2afterremovingfirstrow" src="https://github.com/user-attachments/assets/a43036d0-3dd5-42d4-a9ff-f5d870de3e2a" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-5917

## Other

Registrations queued offline by a build before this change would still rehydrate their new rows without a client id. That's a narrow upgrade edge, so I've left it out here.

Not touched here either: the related person's name for a new row lives only in the Autosuggest DOM, since `relatedPersonName` is never written to Formik. That's pre-existing.
