### PR TITLE
(fix) Stop the header search icon opening a second overlay on the tablet search page

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -66,9 +66,10 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
   }, [setShowSearchInput, setCanClickOutside]);
 
   useEffect(() => {
-    // Search input should always be open when we direct to the search page.
-    setShowSearchInput(isSearchPage);
-  }, [isSearchPage]);
+    // On desktop the search page relies on this header input. On tablet the page renders its own
+    // overlay, so opening one here would stack a second copy on top of it.
+    setShowSearchInput(isSearchPage && isDesktop(layout));
+  }, [isSearchPage, layout]);
 
   useEffect(() => {
     if (showSearchInput) {
@@ -81,6 +82,11 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
       setCanClickOutside(false);
     }
   }, [showSearchInput, isSearchPage]);
+
+  if (isSearchPage && !isDesktop(layout)) {
+    // The page's overlay already carries the search input and its own back button.
+    return null;
+  }
 
   return (
     <div className={styles.patientSearchIconWrapper} ref={ref}>

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.component.tsx
@@ -65,11 +65,14 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
     setCanClickOutside(false);
   }, [setShowSearchInput, setCanClickOutside]);
 
+  // The search page renders its own overlay in the tablet layout (see patient-search-page), so the
+  // icon must not open a second one there. Desktop keeps the header input and phone keeps this
+  // overlay, since the page renders neither.
+  const pageRendersOverlay = isSearchPage && layout === 'tablet';
+
   useEffect(() => {
-    // On desktop the search page relies on this header input. On tablet the page renders its own
-    // overlay, so opening one here would stack a second copy on top of it.
-    setShowSearchInput(isSearchPage && isDesktop(layout));
-  }, [isSearchPage, layout]);
+    setShowSearchInput(isSearchPage && !pageRendersOverlay);
+  }, [isSearchPage, pageRendersOverlay]);
 
   useEffect(() => {
     if (showSearchInput) {
@@ -83,7 +86,7 @@ const PatientSearchLaunch: React.FC<PatientSearchLaunchProps> = () => {
     }
   }, [showSearchInput, isSearchPage]);
 
-  if (isSearchPage && !isDesktop(layout)) {
+  if (pageRendersOverlay) {
     // The page's overlay already carries the search input and its own back button.
     return null;
   }

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
@@ -24,6 +24,7 @@ vi.mock('react-router-dom', async () => ({
 
 describe('PatientSearchLaunch', () => {
   beforeEach(() => {
+    mockIsDesktop.mockReturnValue(true);
     mockUseParams.mockReturnValue({});
     mockUseLayoutType.mockReturnValue('desktop');
     mockUseConfig.mockReturnValue({
@@ -43,6 +44,8 @@ describe('PatientSearchLaunch', () => {
 
   it('toggles search input when search button is clicked', async () => {
     const user = userEvent.setup();
+    mockIsDesktop.mockReturnValue(false);
+    mockUseLayoutType.mockReturnValue('phone');
     render(<PatientSearchLaunch />);
 
     const searchButton = screen.getByTestId('searchPatientIcon');
@@ -73,7 +76,6 @@ describe('PatientSearchLaunch', () => {
     const { container } = render(<PatientSearchLaunch />);
 
     expect(container).toBeEmptyDOMElement();
-    expect(screen.queryByText('Search results')).not.toBeInTheDocument();
   });
 
   it('keeps its overlay open on the search page in phone layout, where the page renders none', () => {
@@ -89,6 +91,7 @@ describe('PatientSearchLaunch', () => {
   it('displays search input in overlay on mobile', async () => {
     const user = userEvent.setup();
     mockIsDesktop.mockReturnValue(false);
+    mockUseLayoutType.mockReturnValue('phone');
 
     render(<PatientSearchLaunch />);
 

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
@@ -3,13 +3,14 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { useParams } from 'react-router-dom';
-import { getDefaultsFromConfigSchema, isDesktop, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, isDesktop, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import { type PatientSearchConfig, configSchema } from '../config-schema';
 import PatientSearchLaunch from './patient-search-icon.component';
 
 const mockIsDesktop = vi.mocked(isDesktop);
 const mockUseConfig = vi.mocked(useConfig<PatientSearchConfig>);
 const mockUseParams = vi.mocked(useParams);
+const mockUseLayoutType = vi.mocked(useLayoutType);
 
 vi.mock('react-router-dom', async () => ({
   ...((await vi.importActual('react-router-dom')) as object),
@@ -24,9 +25,11 @@ vi.mock('react-router-dom', async () => ({
 describe('PatientSearchLaunch', () => {
   beforeEach(() => {
     mockUseParams.mockReturnValue({});
+    mockUseLayoutType.mockReturnValue('desktop');
     mockUseConfig.mockReturnValue({
       ...getDefaultsFromConfigSchema(configSchema),
       search: {
+        ...getDefaultsFromConfigSchema(configSchema).search,
         disableTabletSearchOnKeyUp: false,
         showRecentlySearchedPatients: false,
       } as PatientSearchConfig['search'],
@@ -64,12 +67,23 @@ describe('PatientSearchLaunch', () => {
 
   it('renders nothing on the search page in tablet layout, where the page owns the overlay', () => {
     mockIsDesktop.mockReturnValue(false);
+    mockUseLayoutType.mockReturnValue('tablet');
     mockUseParams.mockReturnValue({ page: 'search' });
 
     const { container } = render(<PatientSearchLaunch />);
 
     expect(container).toBeEmptyDOMElement();
     expect(screen.queryByText('Search results')).not.toBeInTheDocument();
+  });
+
+  it('keeps its overlay open on the search page in phone layout, where the page renders none', () => {
+    mockIsDesktop.mockReturnValue(false);
+    mockUseLayoutType.mockReturnValue('phone');
+    mockUseParams.mockReturnValue({ page: 'search' });
+
+    render(<PatientSearchLaunch />);
+
+    expect(screen.getByText('Search results')).toBeInTheDocument();
   });
 
   it('displays search input in overlay on mobile', async () => {

--- a/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-icon/patient-search-icon.test.tsx
@@ -2,15 +2,18 @@ import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
+import { useParams } from 'react-router-dom';
 import { getDefaultsFromConfigSchema, isDesktop, useConfig } from '@openmrs/esm-framework';
 import { type PatientSearchConfig, configSchema } from '../config-schema';
 import PatientSearchLaunch from './patient-search-icon.component';
 
 const mockIsDesktop = vi.mocked(isDesktop);
 const mockUseConfig = vi.mocked(useConfig<PatientSearchConfig>);
+const mockUseParams = vi.mocked(useParams);
 
 vi.mock('react-router-dom', async () => ({
   ...((await vi.importActual('react-router-dom')) as object),
+  useParams: vi.fn(() => ({})),
   useSearchParams: vi.fn(() => [
     {
       get: vi.fn(() => 'John'),
@@ -20,6 +23,7 @@ vi.mock('react-router-dom', async () => ({
 
 describe('PatientSearchLaunch', () => {
   beforeEach(() => {
+    mockUseParams.mockReturnValue({});
     mockUseConfig.mockReturnValue({
       ...getDefaultsFromConfigSchema(configSchema),
       search: {
@@ -47,6 +51,25 @@ describe('PatientSearchLaunch', () => {
     const closeButton = screen.getByTestId('closeSearchIcon');
     await user.click(closeButton);
     expect(searchInput).not.toBeInTheDocument();
+  });
+
+  it('keeps the search input open on the search page on desktop', () => {
+    mockIsDesktop.mockReturnValue(true);
+    mockUseParams.mockReturnValue({ page: 'search' });
+
+    render(<PatientSearchLaunch />);
+
+    expect(screen.getByRole('searchbox')).toHaveValue('John');
+  });
+
+  it('renders nothing on the search page in tablet layout, where the page owns the overlay', () => {
+    mockIsDesktop.mockReturnValue(false);
+    mockUseParams.mockReturnValue({ page: 'search' });
+
+    const { container } = render(<PatientSearchLaunch />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Search results')).not.toBeInTheDocument();
   });
 
   it('displays search input in overlay on mobile', async () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

On tablet, `/search?query=...` mounts two complete patient search overlays stacked at the same position. The search page renders one for the route, and the header search icon forces its own open whenever the route is the search page. That gives two result lists, two search inputs and two refine forms, each with its own state, and every page of results fetched and rendered twice. The one on top is the page's, so the icon's copy is invisible and does nothing but duplicate the work. This has been the case since the global search landed in #265 and #322.

The icon now only opens its input on the search page in desktop layouts, and renders nothing at all on that page in tablet layouts, where the page's overlay already carries the search input and its own back button. What users see is unchanged: the overlay they were already interacting with is the one that stays. Phone layouts are unaffected: the page renders no overlay there, so the icon's stays.

I went this way rather than the reverse (page yields to the icon) because the page shouldn't depend on a nav extension implementers are free to remove, and PIH's config does remove `patient-search-icon`.

Repro on main: at a width under 1024px, open `/search?query=a` and count the "search results" headings or the search inputs in the DOM. There are two of each.

Tests cover the desktop search page keeping its header input and the tablet search page rendering nothing from the icon.

## Screenshots

## Related Issue

## Other
