### PR TITLE
(fix) Keep patient search results when clearing attribute filters

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.test.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/advanced-patient-search.test.tsx
@@ -14,7 +14,12 @@ import { type PatientSearchResponse } from '../types';
 import { mockAdvancedSearchResults } from '__mocks__';
 import { PatientSearchContext } from '../patient-search-context';
 import { useInfinitePatientSearch } from '../patient-search.resource';
-import { usePersonAttributeType } from './refine-search/person-attributes.resource';
+import {
+  useAttributeConceptAnswers,
+  useConfiguredAnswerConcepts,
+  useLocations,
+  usePersonAttributeType,
+} from './refine-search/person-attributes.resource';
 import AdvancedPatientSearchComponent from './advanced-patient-search.component';
 
 const mockUseConfig = vi.mocked(useConfig<PatientSearchConfig>);
@@ -26,6 +31,9 @@ vi.mock('../patient-search.resource', () => ({
 }));
 
 vi.mock('./refine-search/person-attributes.resource', () => ({
+  useAttributeConceptAnswers: vi.fn(),
+  useConfiguredAnswerConcepts: vi.fn(),
+  useLocations: vi.fn(),
   usePersonAttributeType: vi.fn(),
 }));
 
@@ -269,6 +277,70 @@ describe('AdvancedPatientSearchComponent', () => {
       renderComponent({ inTabletOrOverlay: true });
       const container = screen.getByText(/Refine search/i);
       expect(container).toBeInTheDocument();
+    });
+  });
+
+  describe.each(['org.openmrs.Concept', 'org.openmrs.Location'])('Clearing %s attributes', (format) => {
+    const attributeTypeUuid = '8d87236c-c2cc-11de-8d13-0010c6dffd0f';
+    const answer = { uuid: '1ce1b7d4-c865-4178-82b0-5932e51503d6', display: 'Community Outreach' };
+
+    beforeEach(() => {
+      const config: PatientSearchConfig = getDefaultsFromConfigSchema(configSchema);
+      config.search.searchFilterFields.personAttributes = [{ attributeTypeUuid }];
+      mockUseConfig.mockReturnValue(config);
+      mockUsePersonAttributeType.mockReturnValue({
+        data: { uuid: attributeTypeUuid, display: 'Health Center', format },
+        isLoading: false,
+        error: null,
+      });
+      vi.mocked(useConfiguredAnswerConcepts).mockReturnValue({
+        configuredConceptAnswers: [],
+        isLoadingConfiguredAnswers: false,
+      });
+      vi.mocked(useAttributeConceptAnswers).mockReturnValue({
+        conceptAnswers: [answer],
+        isLoadingConceptAnswers: false,
+        errorFetchingConceptAnswers: null,
+      });
+      vi.mocked(useLocations).mockReturnValue({
+        locations: [
+          { resource: { id: answer.uuid, name: answer.display, resourceType: 'Location', status: 'active' } },
+        ],
+        isLoading: false,
+        loadingNewData: false,
+        error: null,
+      });
+    });
+
+    it('restores results when an applied attribute selection is cleared', async () => {
+      renderComponent();
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText(answer.display));
+      await user.click(screen.getByRole('button', { name: /^apply/i }));
+      expect(screen.getByRole('heading', { name: '1 search result' })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /clear selected item/i }));
+      await user.click(screen.getByRole('button', { name: /^apply/i }));
+
+      expect(screen.getByRole('heading', { name: '2 search result' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Apply', exact: true })).toBeInTheDocument();
+    });
+
+    it('keeps patients without the attribute when a cleared selection is applied', async () => {
+      mockUseInfinitePatientSearch.mockReturnValue({
+        ...mockSearchResults,
+        data: mockSearchResults.data.map((patient) => ({ ...patient, attributes: [] })),
+      });
+      renderComponent();
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText(answer.display));
+      await user.click(screen.getByRole('button', { name: /clear selected item/i }));
+      await user.click(screen.getByRole('button', { name: /^apply/i }));
+
+      expect(screen.getByRole('heading', { name: '2 search result' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Apply', exact: true })).toBeInTheDocument();
     });
   });
 });

--- a/packages/esm-patient-search-app/src/patient-search-page/refine-search/person-attribute-field.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/refine-search/person-attribute-field.component.tsx
@@ -149,7 +149,7 @@ const ConceptAttributeField: React.FC<ConceptAttributeFieldProps> = ({
           items={items}
           itemToString={(item: OpenmrsResource) => item?.display}
           selectedItem={items.sort((a, b) => a.display.localeCompare(b.display)).find((item) => item.uuid === value)}
-          onChange={({ selectedItem }) => onChange(selectedItem?.uuid)}
+          onChange={({ selectedItem }) => onChange(selectedItem?.uuid ?? '')}
           placeholder={t('selectOption', 'Select an option')}
           size={isTablet ? 'lg' : 'md'}
         />
@@ -210,7 +210,7 @@ const LocationAttributeField: React.FC<LocationAttributeFieldProps> = ({
             titleText={t(attributeDisplay)}
             items={locationOptions}
             selectedItem={locationOptions.find((option) => option.value === value)}
-            onChange={({ selectedItem }) => onChange(selectedItem?.value)}
+            onChange={({ selectedItem }) => onChange(selectedItem?.value ?? '')}
             onInputChange={(inputValue) => {
               if (inputValue && !locationOptions.find(({ label }) => label === inputValue)) {
                 setSearchQuery(inputValue);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
Clearing a concept or location attribute in Refine search and clicking Apply can crash patient search or incorrectly show no results. The cleared value is passed through as `undefined`, which is still treated as an active filter.

Normalize cleared selections to an empty string so applying the cleared field restores the results. Add regression tests for both field types, including patients without the configured attribute.

## Screenshots

### Before

#### Select Health Center, click Apply, clear the selection, then click Apply again. 

<img width="1655" height="1324" alt="cleared-filter-applied-zero-results" src="https://github.com/user-attachments/assets/e851e166-6246-4342-a600-a86fb62c574a" />

### After

<img width="1655" height="1324" alt="filter-cleared-result-returns" src="https://github.com/user-attachments/assets/dade9952-213f-4d7f-9a33-32532a40584a" />

## Related Issue

## Other

