### PR TITLE
(fix) Make patient search a little more light-weight

### DIFF
--- a/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-banner/banner/patient-banner.component.tsx
@@ -23,6 +23,9 @@ import { mapToFhirPatient } from '../../../utils/fhir-mapper';
 import { searchResultSwrConfig } from '../../../utils/swr-config';
 import styles from './patient-banner.scss';
 
+/** Lighter-weight view that's what we actually need for checking for active visits */
+const activeVisitRepresentation = 'custom:(uuid,startDatetime,stopDatetime,patient:(uuid))';
+
 interface ClickablePatientContainerProps {
   children: React.ReactNode;
   patient: fhir.Patient;
@@ -40,7 +43,7 @@ const PatientBanner = React.memo(
   ({ patient, patientUuid, hideActionsOverflow: hideActionsOverflowProp }: PatientBannerProps) => {
     const layout = useLayoutType();
     const isTablet = layout === 'tablet';
-    const { activeVisit } = useVisit(patientUuid);
+    const { activeVisit } = useVisit(patientUuid, activeVisitRepresentation);
     const { nonNavigationSelectPatientAction, hidePatientSearch, handleReturnToSearchList } =
       usePatientSearchContext() ?? {};
     // if context2 is present, we use the new workspace v2 APIs,

--- a/packages/esm-patient-search-app/src/patient-search-page/patient-search-views.component.tsx
+++ b/packages/esm-patient-search-app/src/patient-search-page/patient-search-views.component.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { SWRConfig } from 'swr';
 import { Layer, Tile } from '@carbon/react';
 import { EmptyCardIllustration } from '@openmrs/esm-framework';
 import { type SearchedPatient } from '../types';
 import PatientBanner, { PatientBannerSkeleton } from './patient-banner/banner/patient-banner.component';
+import { activeVisitSwrConfig } from '../utils/swr-config';
 import styles from './patient-search-lg.scss';
 
 interface PatientSearchResultsProps {
@@ -69,11 +71,15 @@ export const ErrorState: React.FC = () => {
 };
 
 export const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({ searchResults }) => {
+  // A row calls `useVisit` from its own body, so the config has to sit above the rows to reach it.
+  // The photo keeps its stricter config nested inside the banner.
   return (
-    <div data-openmrs-role="Search Results">
-      {searchResults.map((patient) => (
-        <PatientBanner key={patient.uuid} patientUuid={patient.uuid} patient={patient} />
-      ))}
-    </div>
+    <SWRConfig value={activeVisitSwrConfig}>
+      <div data-openmrs-role="Search Results">
+        {searchResults.map((patient) => (
+          <PatientBanner key={patient.uuid} patientUuid={patient.uuid} patient={patient} />
+        ))}
+      </div>
+    </SWRConfig>
   );
 };

--- a/packages/esm-patient-search-app/src/patient-search.resource.tsx
+++ b/packages/esm-patient-search-app/src/patient-search.resource.tsx
@@ -22,7 +22,8 @@ function fetcher<T>(url: string) {
 type InfinitePatientSearchResponse = FetchResponse<{
   results: Array<SearchedPatient>;
   links: Array<{ rel: 'prev' | 'next' }>;
-  totalCount: number;
+  /** Only requested for the first page; see `buildUrl` in `useInfinitePatientSearch`. */
+  totalCount?: number;
 }>;
 
 const patientProperties = [

--- a/packages/esm-patient-search-app/src/utils/swr-config.ts
+++ b/packages/esm-patient-search-app/src/utils/swr-config.ts
@@ -12,3 +12,14 @@ export const searchResultSwrConfig: SWRConfiguration = {
   revalidateOnReconnect: false,
   dedupingInterval: 180_000, // 3 minutes
 };
+
+/**
+ * SWR settings for the active visit lookup each search result makes. A visit can start while a
+ * result set is on screen, so unlike {@link searchResultSwrConfig} every revalidation trigger stays
+ * on and `dedupingInterval` acts as a TTL instead: mount, focus and reconnect all fire, but SWR
+ * serves them from the cached entry until the interval lapses. An explicit `mutate()` — what the
+ * visit store fans out when a visit starts — is never deduped and always fetches.
+ */
+export const activeVisitSwrConfig: SWRConfiguration = {
+  dedupingInterval: 180_000, // 3 minutes
+};


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Basically this does two things:

1. Fetch a smaller representation for a visit that includes the minimum we need.
2. Makes the SWR cache hold visits returned for 3 minutes. The idea being that paging through a single search shouldn't need to refetch the visit status unless the user genuinely switches their attention to elsewhere.

This should lightly improve the search experience.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
